### PR TITLE
Prevents the map reader from resetting when another map is read

### DIFF
--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -43,7 +43,7 @@ var/global/dmm_suite/preloader/_preloader = new
 
 	var/regex_index = 1
 	while(dmmRegex.Find(tfile, regex_index))
-
+		regex_index = dmmRegex.next
 		// "aa" = (/type{vars=blah})
 		if(dmmRegex.group[1]) // Model
 			var/key = dmmRegex.group[1]

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -41,8 +41,8 @@ var/global/dmm_suite/preloader/_preloader = new
 	var/list/grid_models = list()
 	var/key_len = 0
 
-	dmmRegex.next = 1
-	while(dmmRegex.Find(tfile, dmmRegex.next))
+	var/regex_index = 1
+	while(dmmRegex.Find(tfile, regex_index))
 
 		// "aa" = (/type{vars=blah})
 		if(dmmRegex.group[1]) // Model


### PR DESCRIPTION
:cl: Crazylemon
fix: The map loader no longer resets when it reads another map mid-load
/:cl:

