### PR TITLE
Fixes bugs regarding BO naming + fixes munitions window shattering after repeated MAC shell ejection

### DIFF
--- a/_maps/map_files/SpaceSHIP/SpaceSHIP.dmm
+++ b/_maps/map_files/SpaceSHIP/SpaceSHIP.dmm
@@ -13393,11 +13393,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"BK" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/thermomachine/heater,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "BL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	tag = "icon-manifold (EAST)";
@@ -13762,17 +13757,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"Cz" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 25
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "CA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14091,15 +14075,6 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/heater,
 /obj/structure/window/reinforced{
 	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"Dh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
@@ -20400,24 +20375,6 @@
 	dir = 4
 	},
 /area/shuttle/ftl/munitions)
-"Qw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/machinery/light_switch{
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/obj/machinery/camera{
-	c_tag = "Munitions West";
-	dir = 1;
-	pixel_x = 15
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel/bot,
-/area/shuttle/ftl/munitions)
 "Qy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22188,6 +22145,24 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
+"WC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/machinery/light_switch{
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/machinery/camera{
+	c_tag = "Munitions West";
+	dir = 1;
+	pixel_x = 15
+	},
+/obj/structure/window/reinforced/crosswired{
+	dir = 8
+	},
+/turf/open/floor/plasteel/bot,
+/area/shuttle/ftl/munitions)
 "WF" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal{
@@ -23232,26 +23207,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"Zx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/iv_drip,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/whiteblue/side{
-	tag = "icon-whiteblue (NORTH)";
-	icon_state = "whiteblue";
-	dir = 1
-	},
-/area/shuttle/ftl/medical/medbay)
 "Zy" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/computer/cloning{
@@ -23280,10 +23235,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
-"Zz" = (
-/obj/machinery/iv_drip,
-/turf/open/space,
-/area/shuttle/ftl/space)
 "ZA" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
@@ -52918,7 +52869,7 @@ pe
 Xs
 rn
 Qo
-Qw
+WC
 rT
 rT
 tI

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -14,6 +14,7 @@
 	var/reinf = 0
 	var/wtype = "glass"
 	var/fulltile = 0
+	var/immortal = 0 //!!!!!!!!!!!
 //	var/silicate = 0 // number of units of silicate
 //	var/icon/silicateIcon = null // the silicated icon
 	var/image/crack_overlay
@@ -31,6 +32,8 @@
 		reinf = re
 	if(reinf)
 		state = 2*anchored
+	if(immortal)
+		desc += " This window has been crosswired. It is nearly impossible to break it."
 
 	ini_dir = dir
 	air_update_turf(1)
@@ -54,7 +57,8 @@
 
 /obj/structure/window/bullet_act(obj/item/projectile/P)
 	. = ..()
-	take_damage(P.damage, P.damage_type, 0)
+	if(!immortal)
+		take_damage(P.damage, P.damage_type, 0)
 
 /obj/structure/window/ex_act(severity, target)
 	switch(severity)
@@ -150,8 +154,14 @@
 		return
 	user.do_attack_animation(src)
 	user.changeNext_move(CLICK_CD_MELEE)
-	user.visible_message("<span class='danger'>[user] smashes into [src]!</span>")
-	take_damage(damage, damage_type)
+	if(!immortal)
+		user.visible_message("<span class='danger'>[user] smashes into [src]!</span>")
+		take_damage(damage, damage_type)
+	else
+		user.visible_message("<span class='danger'>[user] smashes into [src], but the window is stronger than they are!</span>")
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			H.apply_damage(10, BRUTE, "chest")
 
 /obj/structure/window/attack_alien(mob/living/user)
 	attack_generic(user, 15)
@@ -253,7 +263,10 @@
 
 /obj/structure/window/attacked_by(obj/item/I, mob/living/user)
 	..()
-	take_damage(I.force, I.damtype)
+	if(!immortal)
+		take_damage(I.force, I.damtype)
+	else
+		user.visible_message("<span class=danger>[I] bounces off the [src], doing no damage at all!</span>")
 
 /obj/structure/window/mech_melee_attack(obj/mecha/M)
 	if(..())
@@ -440,6 +453,9 @@
 	name = "frosted window"
 	icon_state = "fwindow"
 
+/obj/structure/window/reinforced/crosswired
+	name = "hardened window"
+	immortal = 1
 
 /* Full Tile Windows (more health) */
 

--- a/code/modules/jobs/job_types/bridge.dm
+++ b/code/modules/jobs/job_types/bridge.dm
@@ -24,7 +24,7 @@ var/list/posts = list("weapons", "helms")
 /datum/outfit/job/bofficer //utilizes HoP headset for now
 	name = "Bridge Officer"
 
-	belt = /obj/item/device/pda
+	belt = /obj/item/device/pda //if you ever change this, remove the part that references it below
 	glasses = /obj/item/clothing/glasses/sunglasses
 	ears = /obj/item/device/radio/headset/heads/hop
 	uniform =  /obj/item/clothing/under/rank/bofficer
@@ -67,13 +67,16 @@ var/list/posts = list("weapons", "helms")
 
 	if(access_weapons_console in W.access) //I'm sorry
 		H.job = "Weapons Officer"
-		W.update_label(newjob = H.job) //actually don't
+		W.assignment = H.job
+		W.update_label(newjob=W.assignment)
 	if(access_helms_console in W.access)
 		H.job = "Helms Officer"
-		W.update_label(newjob = H.job)
+		W.assignment = H.job
+		W.update_label(newjob=W.assignment)
 
 	var/obj/item/device/pda/P = H.belt
-	if(P)
+	if(istype(P))
+		P.ownjob = W.assignment
 		P.update_label() //grrr
 
 	var/turf/T


### PR DESCRIPTION
:cl: CrAzYPiLoT
fix: Fixed bugs regarding BO naming.
fix: Fixed munitions window shattering after repeated MAC shell ejection.
/:cl: