### PR TITLE
Various fixes

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -366,7 +366,7 @@ var/datum/subsystem/ticker/ticker
 			if(Player.stat != DEAD && !isbrain(Player))
 				num_survivors++
 				if(station_evacuated) //If the shuttle has already left the station
-					if(Player.z == SSstarmap.current_planet.z_level)
+					if(Player.z == ZLEVEL_STATION)
 						Player << "<font color='blue'><b>You managed to survive, but were marooned on [station_name()]...</b></FONT>"
 					else
 						num_escapees++

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -183,7 +183,7 @@ var/datum/subsystem/ticker/ticker
 	data_core.manifest()
 
 	Master.RoundStart()
-	
+
 	spawn_empty_ai()
 
 	world << "<FONT color='blue'><B>Welcome to [station_name()], enjoy your stay!</B></FONT>"
@@ -366,7 +366,7 @@ var/datum/subsystem/ticker/ticker
 			if(Player.stat != DEAD && !isbrain(Player))
 				num_survivors++
 				if(station_evacuated) //If the shuttle has already left the station
-					if(!Player.onCentcom() && !Player.onSyndieBase())
+					if(Player.z == SSstarmap.current_planet.z_level)
 						Player << "<font color='blue'><b>You managed to survive, but were marooned on [station_name()]...</b></FONT>"
 					else
 						num_escapees++

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -421,7 +421,6 @@ var/time_last_changed_position = 0
 					var/newName = reject_bad_name(href_list["reg"])
 					if(newName)
 						modify.registered_name = newName
-						modify.update_label(newName) //how the fuck did it work without this
 					else
 						usr << "<span class='error'>Invalid name entered.</span>"
 						return
@@ -473,7 +472,7 @@ var/time_last_changed_position = 0
 				P.name = "paper- 'Crew Manifest'"
 				printing = null
 	if (modify)
-		modify.update_label()
+		modify.update_label(modify.registered_name, modify.assignment)
 	updateUsrDialog()
 	return
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -50,7 +50,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 /obj/machinery/computer/communications/Topic(href, href_list)
 	if(..())
 		return
-	if (z != ZLEVEL_CENTCOM && (!SSstarmap.current_planet || z != SSstarmap.current_planet.z_level)) //Can only use on centcom and SS13
+	if (z != ZLEVEL_CENTCOM && z != ZLEVEL_STATION) //Can only use on centcom and SS13
 		usr << "<span class='boldannounce'>Unable to establish a connection</span>: \black You're too far away from the ship!"
 		return
 	usr.set_machine(src)
@@ -350,7 +350,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 /obj/machinery/computer/communications/attack_hand(mob/user)
 	if(..())
 		return
-	if(z != ZLEVEL_CENTCOM && (!SSstarmap.current_planet || z != SSstarmap.current_planet.z_level))
+	if(z != ZLEVEL_CENTCOM && z != ZLEVEL_STATION)
 		user << "<span class='boldannounce'>Unable to establish a connection</span>: \black You're too far away from the ship!"
 		return
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -350,8 +350,8 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 /obj/machinery/computer/communications/attack_hand(mob/user)
 	if(..())
 		return
-	if (src.z > 6)
-		user << "<span class='boldannounce'>Unable to establish a connection</span>: \black You're too far away from the station!"
+	if(z != ZLEVEL_CENTCOM && (!SSstarmap.current_planet || z != SSstarmap.current_planet.z_level))
+		user << "<span class='boldannounce'>Unable to establish a connection</span>: \black You're too far away from the ship!"
 		return
 
 	user.set_machine(src)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -41,7 +41,7 @@
 /obj/machinery/computer/secure_data/attack_hand(mob/user)
 	if(..())
 		return
-	if(z != ZLEVEL_CENTCOM && (!SSstarmap.current_planet || z != SSstarmap.current_planet.z_level))
+	if(z != ZLEVEL_CENTCOM && z != ZLEVEL_STATION)
 		user << "<span class='boldannounce'>Unable to establish a connection</span>: \black You're too far away from the station!"
 		return
 	var/dat

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -41,7 +41,7 @@
 /obj/machinery/computer/secure_data/attack_hand(mob/user)
 	if(..())
 		return
-	if(src.z > 6)
+	if(z != ZLEVEL_CENTCOM && (!SSstarmap.current_planet || z != SSstarmap.current_planet.z_level))
 		user << "<span class='boldannounce'>Unable to establish a connection</span>: \black You're too far away from the station!"
 		return
 	var/dat

--- a/code/modules/jobs/job_types/bridge.dm
+++ b/code/modules/jobs/job_types/bridge.dm
@@ -67,12 +67,12 @@ var/list/posts = list("weapons", "helms")
 
 	if(access_weapons_console in W.access) //I'm sorry
 		H.job = "Weapons Officer"
-		W.assignment = H.job
-		W.update_label(newjob=W.assignment)
 	if(access_helms_console in W.access)
 		H.job = "Helms Officer"
-		W.assignment = H.job
-		W.update_label(newjob=W.assignment)
+
+	W.assignment = H.job
+	W.update_label(newjob=W.assignment)
+	data_core.manifest_modify(W.registered_name, W.assignment)
 
 	var/obj/item/device/pda/P = H.belt
 	if(istype(P))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -934,7 +934,7 @@ Sorry Giacom. Please don't be mad :(
 	var/turf/T = get_turf(src)
 	if(!T)
 		return 0
-	if(!SSstarmap.in_transit && (!SSstarmap.current_planet || T.z != SSstarmap.current_planet.z_level)) //astraeus yes
+	if(!SSstarmap.in_transit && T.z != ZLEVEL_STATION) //astraeus yes
 		return 0
 	if(user != null && src == user)
 		return 0

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -934,9 +934,7 @@ Sorry Giacom. Please don't be mad :(
 	var/turf/T = get_turf(src)
 	if(!T)
 		return 0
-	if(T.z == ZLEVEL_CENTCOM) //dont detect mobs on centcomm
-		return 0
-	if(T.z >= ZLEVEL_SPACEMAX)
+	if(!SSstarmap.in_transit && (!SSstarmap.current_planet || T.z != SSstarmap.current_planet.z_level)) //astraeus yes
 		return 0
 	if(user != null && src == user)
 		return 0

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -308,23 +308,25 @@
 					continue
 
 	character.loc = D
-	
+
 	// AI's don't need a spawnpoint, they must spawn at an empty core
 	if(character.mind.assigned_role == "AI")
 		character = character.AIize(move = 0) // AIize the character, but don't move them yet
-		
+
 		// IsJobAvailable for AI checks that there is an empty core available in this list
 		var/obj/structure/AIcore/deactivated/C = empty_playable_ai_cores[1]
 		empty_playable_ai_cores -= C
-		
+
 		character.loc = C.loc
-		
+		var/mob/living/silicon/ai/A = character
+		A.view_core()
+
 		AnnounceArrival(character, rank)
-		
+
 		qdel(C)
 		qdel(src)
 		return
-	
+
 	if(character.mind.assigned_role != "Cyborg")
 		data_core.manifest_inject(character)
 		ticker.minds += character.mind//Cyborgs and AIs handle this in the transform proc.	//TODO!!!!! ~Carn


### PR DESCRIPTION
Fixes #153.
Fixes #135.
Fixes #133.
Fixes #129.
Fixes #81.
Fixes latejoin AIs' camera view starting at latejoin landmark and not at core, still need to figure out how to do it for roundstart AIs.

:cl: CrAzYPiLoT
fix: Fixed multiple console issues.
fix: Fixed an issue when assigning a new job to ID.
fix: Fixed endround greentext stating 'Marooned' when not marooned.
fix: Fixed AIs unable to track mobs in transit.
fix: Fixed latejoin AIs' camera view starting at latejoin landmark and not at core.
/:cl:

