### PR TITLE
Major Map Edit

### DIFF
--- a/_maps/map_files/SpaceSHIP/SpaceSHIP.dmm
+++ b/_maps/map_files/SpaceSHIP/SpaceSHIP.dmm
@@ -35,6 +35,26 @@
 "aj" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/cargo/office)
+"ak" = (
+/obj/machinery/door/airlock/external{
+	name = "Supply Dock Airlock";
+	req_access_txt = "0"
+	},
+/obj/docking_port/mobile/ftl{
+	dir = 2
+	},
+/obj/docking_port/stationary{
+	dheight = 8;
+	dir = 2;
+	dwidth = 49;
+	height = 73;
+	id = "ftl_start";
+	name = "Starting Area";
+	width = 97
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/office)
 "al" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -52,6 +72,7 @@
 	name = "Supply Dock Airlock";
 	req_access_txt = "0"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/office)
 "an" = (
@@ -515,6 +536,11 @@
 /turf/closed/wall,
 /area/shuttle/ftl/medical/medbay)
 "aS" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/cargo)
 "aT" = (
@@ -574,11 +600,23 @@
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/storage)
 "aY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 1
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/metal{
+	amount = 50
 	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/weapon/electronics/airlock,
+/obj/item/weapon/stock_parts/cell/high/plus,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 30
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/storage)
 "aZ" = (
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/storage)
@@ -606,6 +644,24 @@
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plating,
+/area/shuttle/ftl/cargo/office)
+"bc" = (
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (EAST)";
+	icon_state = "pipe-c";
+	dir = 4
+	},
+/obj/machinery/computer/cargo,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"bd" = (
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	icon_state = "pipe-j2s";
+	sortType = "0"
+	},
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
 "be" = (
 /obj/structure/grille,
@@ -646,6 +702,12 @@
 "bi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
@@ -715,6 +777,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"bo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Hatch";
@@ -722,7 +790,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/detectives_office)
-"bo" = (
+"bp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -734,7 +802,7 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/shuttle/ftl/security/detectives_office)
-"bp" = (
+"bq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -745,7 +813,7 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/shuttle/ftl/security/detectives_office)
-"bq" = (
+"br" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
@@ -764,7 +832,7 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/shuttle/ftl/security/detectives_office)
-"br" = (
+"bs" = (
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -777,7 +845,7 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/shuttle/ftl/security/detectives_office)
-"bs" = (
+"bt" = (
 /obj/structure/filingcabinet,
 /obj/item/device/radio/intercom{
 	pixel_x = 0;
@@ -785,7 +853,7 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/shuttle/ftl/security/detectives_office)
-"bt" = (
+"bu" = (
 /obj/structure/toilet{
 	pixel_y = 8
 	},
@@ -799,10 +867,10 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"bu" = (
+"bv" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"bv" = (
+"bw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station,
 /obj/structure/cable{
 	d1 = 1;
@@ -811,7 +879,7 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"bw" = (
+"bx" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet,
 /obj/machinery/camera{
@@ -821,17 +889,17 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"bx" = (
+"by" = (
 /turf/closed/wall/shuttle{
 	icon_state = "swall3";
 	dir = 2
 	},
 /area/shuttle/ftl/subshuttle/pod_3)
-"by" = (
+"bz" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/shuttle/red,
 /area/shuttle/ftl/subshuttle/pod_3)
-"bz" = (
+"bA" = (
 /obj/structure/window/reinforced{
 	dir = 4;
 	pixel_x = 0
@@ -839,7 +907,7 @@
 /obj/structure/chair,
 /turf/open/floor/plasteel/shuttle/red,
 /area/shuttle/ftl/subshuttle/pod_3)
-"bA" = (
+"bB" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -850,14 +918,14 @@
 	},
 /turf/open/floor/plasteel/shuttle/yellow,
 /area/shuttle/ftl/subshuttle/pod_3)
-"bB" = (
+"bC" = (
 /obj/machinery/computer/emergency_shuttle,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/shuttle/yellow,
 /area/shuttle/ftl/subshuttle/pod_3)
-"bC" = (
+"bD" = (
 /obj/structure/window/reinforced{
 	dir = 4;
 	pixel_x = 0
@@ -866,14 +934,14 @@
 /obj/item/weapon/crowbar,
 /turf/open/floor/plasteel/shuttle/yellow,
 /area/shuttle/ftl/subshuttle/pod_3)
-"bD" = (
+"bE" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/chair,
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"bE" = (
+"bF" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/fire,
 /obj/item/weapon/storage/firstaid/regular{
@@ -883,12 +951,12 @@
 /obj/item/weapon/crowbar,
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"bF" = (
+"bG" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/surgery)
-"bG" = (
+"bH" = (
 /obj/structure/table,
 /obj/item/clothing/suit/apron/surgical,
 /obj/item/weapon/razor,
@@ -897,7 +965,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/surgery)
-"bH" = (
+"bI" = (
 /obj/effect/landmark/start{
 	name = "Medical Doctor";
 	shuttle_abstract_movable = 1
@@ -909,7 +977,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/surgery)
-"bI" = (
+"bJ" = (
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 4
@@ -922,13 +990,13 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/surgery)
-"bJ" = (
+"bK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/medical/surgery)
-"bK" = (
+"bL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -944,7 +1012,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay)
-"bL" = (
+"bM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -952,31 +1020,31 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/whiteblue/corner,
 /area/shuttle/ftl/medical/medbay)
-"bM" = (
+"bN" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/medbay)
-"bN" = (
+"bO" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/medbay)
-"bO" = (
+"bP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/medbay)
-"bP" = (
+"bQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/medbay)
-"bQ" = (
+"bR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -986,14 +1054,14 @@
 	},
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/medbay)
-"bR" = (
+"bS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/medbay)
-"bS" = (
+"bT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -1005,7 +1073,7 @@
 	},
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/medbay)
-"bT" = (
+"bU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -1016,7 +1084,7 @@
 	},
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/medbay)
-"bU" = (
+"bV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -1028,7 +1096,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/medbay)
-"bV" = (
+"bW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -1042,19 +1110,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/medbay)
-"bW" = (
+"bX" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"bX" = (
+"bY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/medbay)
-"bY" = (
+"bZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -1064,7 +1132,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay)
-"bZ" = (
+"ca" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -1074,7 +1142,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"ca" = (
+"cb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
@@ -1093,7 +1161,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"cb" = (
+"cc" = (
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{
 	pixel_x = 7;
@@ -1110,11 +1178,11 @@
 /obj/item/weapon/wrench,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/medical/medbay)
-"cc" = (
+"cd" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/medical/medbay)
-"cd" = (
+"ce" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
@@ -1125,13 +1193,13 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/cargo)
-"ce" = (
+"cf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/storage)
-"cf" = (
+"cg" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -1153,7 +1221,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/storage)
-"cg" = (
+"ch" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -1164,7 +1232,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/storage)
-"ch" = (
+"ci" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -1176,13 +1244,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/storage)
-"ci" = (
+"cj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/storage)
-"cj" = (
+"ck" = (
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
@@ -1198,7 +1266,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/office)
-"ck" = (
+"cl" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "mailSort"
 	},
@@ -1212,6 +1280,26 @@
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
 "cm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light_switch{
+	pixel_x = 40;
+	pixel_y = 8
+	},
+/obj/effect/landmark/start{
+	name = "Quartermaster"
+	},
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"cn" = (
 /obj/item/weapon/stamp{
 	pixel_x = -3;
 	pixel_y = 3
@@ -1230,10 +1318,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"cn" = (
+"co" = (
+/obj/machinery/door/airlock/external{
+	name = "Supply Dock Airlock";
+	req_access_txt = "0"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/office)
+"cp" = (
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/office)
-"co" = (
+"cq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -1243,24 +1338,24 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"cp" = (
+"cr" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"cq" = (
+"cs" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/armory)
-"cr" = (
+"ct" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/hos)
-"cs" = (
+"cu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/hos)
-"ct" = (
+"cv" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -1274,7 +1369,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"cu" = (
+"cw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -1288,12 +1383,12 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/shuttle/ftl/security/detectives_office)
-"cv" = (
+"cx" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
-"cw" = (
+"cy" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
@@ -1303,24 +1398,24 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
-"cx" = (
+"cz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
 /area/shuttle/ftl/security/detectives_office)
-"cy" = (
+"cA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
 /area/shuttle/ftl/security/detectives_office)
-"cz" = (
+"cB" = (
 /obj/structure/closet/secure_closet/detective,
 /obj/item/device/camera/detective,
 /turf/open/floor/plasteel/grimy,
 /area/shuttle/ftl/security/detectives_office)
-"cA" = (
+"cC" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -1330,7 +1425,7 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"cB" = (
+"cD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -1339,7 +1434,7 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"cC" = (
+"cE" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -1351,46 +1446,46 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"cD" = (
+"cF" = (
 /turf/open/floor/plasteel/shuttle/red,
 /area/shuttle/ftl/subshuttle/pod_3)
-"cE" = (
+"cG" = (
 /obj/structure/window/reinforced{
 	dir = 4;
 	pixel_x = 0
 	},
 /turf/open/floor/plasteel/shuttle/red,
 /area/shuttle/ftl/subshuttle/pod_3)
-"cF" = (
+"cH" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/open/floor/plasteel/shuttle/yellow,
 /area/shuttle/ftl/subshuttle/pod_3)
-"cG" = (
+"cI" = (
 /turf/open/floor/plasteel/shuttle/yellow,
 /area/shuttle/ftl/subshuttle/pod_3)
-"cH" = (
+"cJ" = (
 /obj/structure/window/reinforced{
 	dir = 4;
 	pixel_x = 0
 	},
 /turf/open/floor/plasteel/shuttle/yellow,
 /area/shuttle/ftl/subshuttle/pod_3)
-"cI" = (
+"cK" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"cJ" = (
+"cL" = (
 /obj/machinery/sleeper{
 	icon_state = "sleeper-open";
 	dir = 8
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"cK" = (
+"cM" = (
 /obj/structure/table,
 /obj/item/weapon/retractor,
 /obj/item/weapon/surgicaldrill,
@@ -1399,18 +1494,18 @@
 	dir = 2
 	},
 /area/shuttle/ftl/medical/surgery)
-"cL" = (
+"cN" = (
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/surgery)
-"cM" = (
+"cO" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/surgery)
-"cN" = (
+"cP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 4
@@ -1427,7 +1522,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay)
-"cO" = (
+"cQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
@@ -1444,27 +1539,27 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/medbay)
-"cP" = (
+"cR" = (
 /turf/closed/wall,
 /area/shuttle/ftl/medical/genetics)
-"cQ" = (
+"cS" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/genetics)
-"cR" = (
+"cT" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/genetics)
-"cS" = (
+"cU" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/genetics)
-"cT" = (
+"cV" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "5"
@@ -1477,7 +1572,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/medbay)
-"cU" = (
+"cW" = (
 /obj/machinery/disposal/bin,
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -1492,7 +1587,7 @@
 	dir = 9
 	},
 /area/shuttle/ftl/medical/medbay)
-"cV" = (
+"cX" = (
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
@@ -1511,7 +1606,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/medical/medbay)
-"cW" = (
+"cY" = (
 /obj/machinery/door/window{
 	dir = 1;
 	name = "Medical Storage";
@@ -1522,7 +1617,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"cX" = (
+"cZ" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/o2{
 	pixel_x = 3;
@@ -1547,7 +1642,7 @@
 	dir = 5
 	},
 /area/shuttle/ftl/medical/medbay)
-"cY" = (
+"da" = (
 /obj/machinery/sleeper{
 	dir = 4;
 	icon_state = "sleeper-open"
@@ -1567,14 +1662,14 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay)
-"cZ" = (
+"db" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"da" = (
+"dc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -1585,13 +1680,13 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"db" = (
+"dd" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/medical/medbay)
-"dc" = (
+"de" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4;
 	initialize_directions = 11
@@ -1602,7 +1697,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/medical/medbay)
-"dd" = (
+"df" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light/small{
 	dir = 4
@@ -1614,7 +1709,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/cargo)
-"de" = (
+"dg" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/item/device/radio/intercom{
 	pixel_x = -32;
@@ -1624,13 +1719,13 @@
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/cargo/storage)
-"df" = (
+"dh" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel{
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/cargo/storage)
-"dg" = (
+"di" = (
 /obj/machinery/airalarm{
 	dir = 1;
 	icon_state = "alarm0";
@@ -1639,7 +1734,7 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/storage)
-"dh" = (
+"dj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 4
 	},
@@ -1652,7 +1747,7 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/storage)
-"di" = (
+"dk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -1662,13 +1757,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/storage)
-"dj" = (
+"dl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/storage)
-"dk" = (
+"dm" = (
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -1687,7 +1782,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/office)
-"dl" = (
+"dn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -1702,7 +1797,7 @@
 /obj/structure/ore_box,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"dm" = (
+"do" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -1714,21 +1809,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"dn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Room";
-	req_access_txt = "34"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"dp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/break_room)
-"dp" = (
+/area/shuttle/ftl/cargo/office)
+"dq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/weapon/folder,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westleft{
+	name = "Cargo Desk";
+	req_access_txt = "20"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/office)
+"dr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -1738,7 +1839,7 @@
 	dir = 9
 	},
 /area/shuttle/ftl/cargo/office)
-"dq" = (
+"ds" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
@@ -1748,7 +1849,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/cargo/office)
-"dr" = (
+"dt" = (
 /obj/machinery/power/apc{
 	auto_name = 1;
 	dir = 4;
@@ -1765,7 +1866,7 @@
 	dir = 5
 	},
 /area/shuttle/ftl/cargo/office)
-"ds" = (
+"du" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -1773,7 +1874,14 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"du" = (
+"dv" = (
+/obj/structure/rack,
+/obj/item/weapon/gun/energy/ionrifle,
+/obj/item/clothing/suit/armor/laserproof,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/darkwarning,
+/area/shuttle/ftl/security/armory)
+"dw" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -1781,9 +1889,10 @@
 	name = "Armory";
 	req_access_txt = "3"
 	},
+/mob/living/simple_animal/bot/ed209,
 /turf/open/floor/plasteel/darkwarning,
 /area/shuttle/ftl/security/armory)
-"dv" = (
+"dx" = (
 /obj/structure/rack,
 /obj/item/ammo_box/magazine/sniper_rounds/haemorrhage,
 /obj/item/ammo_box/magazine/sniper_rounds/penetrator,
@@ -1792,34 +1901,42 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/darkwarning,
 /area/shuttle/ftl/security/armory)
-"dw" = (
+"dy" = (
 /obj/machinery/computer/secure_data,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"dx" = (
+"dz" = (
 /obj/machinery/computer/security,
 /obj/item/device/radio/intercom{
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/hos)
-"dz" = (
-/obj/machinery/suit_storage_unit/hos,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
 "dA" = (
+/obj/machinery/computer/card/minor/hos,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/requests_console{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"dB" = (
+/obj/machinery/suit_storage_unit/hos,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"dC" = (
 /obj/machinery/computer/security,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"dB" = (
+"dD" = (
 /obj/item/device/radio/intercom{
 	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"dC" = (
+"dE" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -1828,13 +1945,13 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"dD" = (
+"dF" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"dE" = (
+"dG" = (
 /obj/machinery/door/window/westleft{
 	name = "Brig Infirmary";
 	req_access_txt = "1"
@@ -1843,7 +1960,7 @@
 	dir = 9
 	},
 /area/shuttle/ftl/security/main)
-"dF" = (
+"dH" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -1851,7 +1968,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/security/main)
-"dG" = (
+"dI" = (
 /obj/machinery/sleeper{
 	icon_state = "sleeper-open";
 	dir = 8
@@ -1860,7 +1977,7 @@
 	dir = 5
 	},
 /area/shuttle/ftl/security/main)
-"dH" = (
+"dJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -1873,7 +1990,7 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/shuttle/ftl/security/detectives_office)
-"dI" = (
+"dK" = (
 /obj/structure/table/wood,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey{
 	pixel_x = 3
@@ -1881,19 +1998,19 @@
 /obj/item/weapon/lighter,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
-"dJ" = (
+"dL" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp/green,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
-"dK" = (
+"dM" = (
 /obj/structure/table/wood,
 /obj/item/weapon/storage/fancy/cigarettes,
 /obj/item/clothing/glasses/sunglasses,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
-"dL" = (
+"dN" = (
 /obj/structure/table/wood,
 /obj/item/weapon/storage/box/evidence,
 /obj/item/weapon/hand_labeler{
@@ -1901,20 +2018,20 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
-"dM" = (
+"dO" = (
 /obj/structure/table/wood,
 /obj/item/weapon/storage/briefcase,
 /obj/item/device/taperecorder,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
-"dN" = (
+"dP" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 3";
 	name = "Cell 3 Locker"
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"dO" = (
+"dQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -1923,7 +2040,7 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"dP" = (
+"dR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
 /obj/structure/cable{
 	d1 = 2;
@@ -1932,14 +2049,14 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"dQ" = (
+"dS" = (
 /obj/machinery/door/window/southright{
 	name = "Shuttle Brig";
 	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/shuttle/red,
 /area/shuttle/ftl/subshuttle/pod_3)
-"dR" = (
+"dT" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -1947,27 +2064,9 @@
 	},
 /turf/open/floor/plasteel/shuttle/red,
 /area/shuttle/ftl/subshuttle/pod_3)
-"dS" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle/yellow,
-/area/shuttle/ftl/subshuttle/pod_3)
-"dT" = (
-/obj/machinery/door/window/southleft{
-	name = "Cockpit";
-	req_access_txt = "42"
-	},
-/turf/open/floor/plasteel/shuttle/yellow,
-/area/shuttle/ftl/subshuttle/pod_3)
 "dU" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 8
 	},
 /obj/structure/window/reinforced,
 /obj/structure/chair{
@@ -1976,20 +2075,38 @@
 /turf/open/floor/plasteel/shuttle/yellow,
 /area/shuttle/ftl/subshuttle/pod_3)
 "dV" = (
+/obj/machinery/door/window/southleft{
+	name = "Cockpit";
+	req_access_txt = "42"
+	},
+/turf/open/floor/plasteel/shuttle/yellow,
+/area/shuttle/ftl/subshuttle/pod_3)
+"dW" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/window/reinforced,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle/yellow,
+/area/shuttle/ftl/subshuttle/pod_3)
+"dX" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"dW" = (
+"dY" = (
 /obj/machinery/door/window/southleft{
 	name = "Medbay";
 	req_access_txt = "5"
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"dX" = (
+"dZ" = (
 /obj/structure/table,
 /obj/item/weapon/cautery{
 	pixel_x = 4
@@ -2003,7 +2120,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/surgery)
-"dY" = (
+"ea" = (
 /obj/structure/table,
 /obj/item/weapon/scalpel{
 	pixel_y = 12
@@ -2013,13 +2130,13 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/surgery)
-"dZ" = (
+"eb" = (
 /obj/machinery/computer/operating,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/surgery)
-"ea" = (
+"ec" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -2033,7 +2150,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay)
-"eb" = (
+"ed" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/whiteblue/side{
@@ -2042,7 +2159,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/medbay)
-"ec" = (
+"ee" = (
 /obj/machinery/computer/scan_consolenew,
 /turf/open/floor/plasteel/whiteblue/side{
 	tag = "icon-whiteblue (NORTHWEST)";
@@ -2050,7 +2167,7 @@
 	dir = 9
 	},
 /area/shuttle/ftl/medical/genetics)
-"ed" = (
+"ef" = (
 /obj/structure/chair/office/light{
 	dir = 8
 	},
@@ -2065,7 +2182,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/medical/genetics)
-"ee" = (
+"eg" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -2073,7 +2190,7 @@
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/medical/genetics)
-"ef" = (
+"eh" = (
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
@@ -2082,7 +2199,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/medical/genetics)
-"eg" = (
+"ei" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -2091,7 +2208,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/medbay)
-"eh" = (
+"ej" = (
 /obj/structure/closet/secure_closet/medical3,
 /turf/open/floor/plasteel/whiteblue/side{
 	tag = "icon-whiteblue (WEST)";
@@ -2099,7 +2216,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay)
-"ei" = (
+"ek" = (
 /obj/effect/landmark/start{
 	name = "Medical Doctor";
 	shuttle_abstract_movable = 1
@@ -2116,7 +2233,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"ej" = (
+"el" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
 	},
@@ -2124,7 +2241,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"ek" = (
+"em" = (
 /obj/structure/table,
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -2150,7 +2267,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/medbay)
-"el" = (
+"en" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/masks{
 	pixel_x = 0;
@@ -2166,7 +2283,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay)
-"em" = (
+"eo" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
@@ -2181,7 +2298,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"en" = (
+"ep" = (
 /obj/effect/landmark/start{
 	name = "Medical Doctor";
 	shuttle_abstract_movable = 1
@@ -2199,7 +2316,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"eo" = (
+"eq" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -2212,18 +2329,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/medical/medbay)
-"ep" = (
+"er" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/medical/medbay)
-"eq" = (
+"es" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/cargo)
-"er" = (
+"et" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -2232,7 +2354,7 @@
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/storage)
-"es" = (
+"eu" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "qm_warehouse";
 	name = "warehouse shutters"
@@ -2240,7 +2362,7 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/storage)
-"et" = (
+"ev" = (
 /obj/structure/window/reinforced{
 	dir = 4;
 	pixel_x = 0
@@ -2254,7 +2376,7 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/office)
-"eu" = (
+"ew" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 2;
@@ -2265,7 +2387,7 @@
 /obj/structure/ore_box,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"ev" = (
+"ex" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
@@ -2276,7 +2398,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"ew" = (
+"ey" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -2287,7 +2409,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"ex" = (
+"ez" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -2304,7 +2426,7 @@
 	},
 /turf/open/floor/plasteel/delivery,
 /area/shuttle/ftl/cargo/office)
-"ey" = (
+"eA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -2319,7 +2441,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/cargo/office)
-"ez" = (
+"eB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2331,7 +2453,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"eA" = (
+"eC" = (
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 4
@@ -2361,13 +2483,13 @@
 	dir = 4
 	},
 /area/shuttle/ftl/cargo/office)
-"eB" = (
+"eD" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/item/weapon/storage/belt/utility,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"eC" = (
+"eE" = (
 /obj/structure/rack,
 /obj/item/weapon/storage/box/rubbershot,
 /obj/item/weapon/storage/box/rubbershot,
@@ -2383,12 +2505,12 @@
 	dir = 1
 	},
 /area/shuttle/ftl/security/armory)
-"eD" = (
+"eF" = (
 /turf/open/floor/plasteel/darkwarning{
 	dir = 1
 	},
 /area/shuttle/ftl/security/armory)
-"eE" = (
+"eG" = (
 /obj/item/weapon/grenade/barrier{
 	pixel_x = 4
 	},
@@ -2413,7 +2535,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/security/armory)
-"eF" = (
+"eH" = (
 /obj/item/weapon/book/manual/wiki/security_space_law,
 /obj/structure/table/wood,
 /obj/machinery/firealarm{
@@ -2422,18 +2544,18 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"eG" = (
+"eI" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/landmark/start{
 	name = "Head of Security"
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"eH" = (
+"eJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"eI" = (
+"eK" = (
 /obj/machinery/airalarm{
 	dir = 8;
 	icon_state = "alarm0";
@@ -2441,11 +2563,11 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"eJ" = (
+"eL" = (
 /obj/machinery/computer/prisoner,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"eK" = (
+"eM" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
@@ -2455,11 +2577,11 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"eL" = (
+"eN" = (
 /obj/machinery/vending/security,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"eM" = (
+"eO" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop,
 /obj/structure/window/reinforced{
@@ -2469,16 +2591,16 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/main)
-"eN" = (
+"eP" = (
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/security/main)
-"eO" = (
+"eQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
 /turf/open/floor/plasteel/whitered/side{
 	dir = 4
 	},
 /area/shuttle/ftl/security/main)
-"eP" = (
+"eR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -2493,11 +2615,11 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/shuttle/ftl/security/detectives_office)
-"eQ" = (
+"eS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/detectives_office)
-"eR" = (
+"eT" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 1;
 	icon_state = "rightsecure";
@@ -2509,17 +2631,26 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"eS" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+"eU" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/central)
-"eT" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/brig)
+"eV" = (
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/ftl/subshuttle/pod_3)
-"eU" = (
+"eW" = (
 /obj/structure/chair{
 	dir = 8
 	},
@@ -2529,7 +2660,7 @@
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"eV" = (
+"eX" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -2542,7 +2673,7 @@
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"eW" = (
+"eY" = (
 /obj/structure/window/reinforced{
 	dir = 4;
 	pixel_x = 0
@@ -2556,7 +2687,7 @@
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"eX" = (
+"eZ" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -2569,18 +2700,18 @@
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"eY" = (
+"fa" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/medical/cmo)
-"eZ" = (
+"fb" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/cmo)
-"fa" = (
+"fc" = (
 /turf/closed/wall,
 /area/shuttle/ftl/medical/cmo)
-"fb" = (
+"fd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -2598,7 +2729,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay)
-"fc" = (
+"fe" = (
 /obj/machinery/dna_scannernew,
 /turf/open/floor/plasteel/whiteblue/side{
 	tag = "icon-whiteblue (WEST)";
@@ -2606,7 +2737,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/genetics)
-"fd" = (
+"ff" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
 	},
@@ -2614,7 +2745,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/genetics)
-"fe" = (
+"fg" = (
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/westleft{
 	name = "Monkey Pen";
@@ -2623,12 +2754,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/medical/genetics)
-"ff" = (
+"fh" = (
 /obj/structure/window/reinforced,
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/medical/genetics)
-"fg" = (
+"fi" = (
 /obj/structure/closet/l3closet,
 /obj/machinery/light{
 	dir = 8
@@ -2639,7 +2770,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay)
-"fh" = (
+"fj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 1
 	},
@@ -2654,12 +2785,13 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"fi" = (
+"fk" = (
+/mob/living/simple_animal/bot/medbot,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"fj" = (
+"fl" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/fire{
 	pixel_x = 3;
@@ -2676,7 +2808,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/medbay)
-"fk" = (
+"fm" = (
 /obj/machinery/sleeper{
 	dir = 4;
 	icon_state = "sleeper-open"
@@ -2691,7 +2823,7 @@
 	dir = 10
 	},
 /area/shuttle/ftl/medical/medbay)
-"fl" = (
+"fn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -2701,7 +2833,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"fm" = (
+"fo" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
@@ -2718,7 +2850,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"fn" = (
+"fp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
 	},
@@ -2741,7 +2873,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"fo" = (
+"fq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -2755,7 +2887,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"fp" = (
+"fr" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "8"
@@ -2771,7 +2903,7 @@
 	},
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/ftl/medical/medbay)
-"fq" = (
+"fs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2783,28 +2915,53 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/cargo)
-"fr" = (
+"ft" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/mining)
-"fs" = (
+"fu" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"ft" = (
-/obj/machinery/meter,
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plasteel/blue/side{
-	dir = 6
-	},
-/area/shuttle/ftl/atmos)
 "fv" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/item/device/multitool,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"fw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/miner,
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/device/multitool,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"fx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -2825,7 +2982,7 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"fw" = (
+"fy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -2841,7 +2998,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"fx" = (
+"fz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -2868,7 +3025,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"fy" = (
+"fA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -2882,7 +3039,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"fz" = (
+"fB" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -2896,20 +3053,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"fA" = (
+"fC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"fB" = (
+"fD" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"fC" = (
+"fE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 4
 	},
@@ -2922,7 +3079,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/cargo/office)
-"fD" = (
+"fF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
@@ -2931,7 +3088,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"fE" = (
+"fG" = (
 /obj/machinery/airalarm{
 	dir = 8;
 	icon_state = "alarm0";
@@ -2955,7 +3112,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/cargo/office)
-"fF" = (
+"fH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
@@ -2969,10 +3126,10 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"fG" = (
+"fI" = (
 /turf/closed/wall,
 /area/shuttle/ftl/maintenance/security)
-"fH" = (
+"fJ" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/projectile/shotgun/riot{
 	pixel_x = -3;
@@ -2987,12 +3144,12 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
-"fI" = (
+"fK" = (
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
-"fJ" = (
+"fL" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/chemimp{
 	pixel_x = 6
@@ -3005,7 +3162,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
-"fK" = (
+"fM" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp/green{
 	on = 0;
@@ -3018,13 +3175,13 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"fL" = (
+"fN" = (
 /obj/structure/table/wood,
 /obj/item/weapon/folder/red,
 /obj/item/weapon/stamp/hos,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"fM" = (
+"fO" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger{
 	pixel_y = 4
@@ -3032,14 +3189,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"fN" = (
+"fP" = (
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"fO" = (
+"fQ" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/firealarm{
 	dir = 8;
@@ -3047,15 +3204,15 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"fP" = (
+"fR" = (
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"fQ" = (
+"fS" = (
 /obj/machinery/recharger,
 /obj/structure/table,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"fR" = (
+"fT" = (
 /obj/item/weapon/storage/box/bodybags,
 /obj/item/weapon/reagent_containers/syringe{
 	name = "steel point"
@@ -3071,7 +3228,7 @@
 	dir = 10
 	},
 /area/shuttle/ftl/security/main)
-"fS" = (
+"fU" = (
 /obj/item/weapon/storage/firstaid/regular{
 	pixel_x = 3;
 	pixel_y = 3
@@ -3081,7 +3238,7 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/whitered/side,
 /area/shuttle/ftl/security/main)
-"fT" = (
+"fV" = (
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/mask/surgical,
 /obj/item/weapon/reagent_containers/spray/cleaner,
@@ -3092,13 +3249,13 @@
 	},
 /turf/open/floor/plasteel/whitered/side,
 /area/shuttle/ftl/security/main)
-"fU" = (
+"fW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/brig)
-"fV" = (
+"fX" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -3114,13 +3271,13 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"fW" = (
+"fY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"fX" = (
+"fZ" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig";
 	req_access = null;
@@ -3131,7 +3288,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"fY" = (
+"ga" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -3141,13 +3298,13 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"fZ" = (
+"gb" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"ga" = (
+"gc" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -3161,7 +3318,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"gb" = (
+"gd" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -3177,7 +3334,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"gc" = (
+"ge" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -3188,14 +3345,14 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"gd" = (
+"gf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"ge" = (
+"gg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
@@ -3206,7 +3363,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"gf" = (
+"gh" = (
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 8
@@ -3217,7 +3374,7 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/ftl/subshuttle/pod_3)
-"gg" = (
+"gi" = (
 /obj/structure/window/reinforced{
 	dir = 4;
 	pixel_x = 0
@@ -3227,7 +3384,7 @@
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"gh" = (
+"gj" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -3236,7 +3393,7 @@
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"gi" = (
+"gk" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -3247,7 +3404,7 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/ftl/subshuttle/pod_3)
-"gj" = (
+"gl" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper_bin{
 	pixel_x = -2;
@@ -3255,7 +3412,7 @@
 	},
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/ftl/medical/cmo)
-"gk" = (
+"gm" = (
 /obj/structure/table/glass,
 /obj/item/weapon/folder/white{
 	pixel_x = 3;
@@ -3265,7 +3422,7 @@
 /obj/item/clothing/glasses/hud/health,
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/ftl/medical/cmo)
-"gl" = (
+"gn" = (
 /obj/machinery/suit_storage_unit/cmo,
 /obj/item/device/radio/intercom{
 	pixel_x = 32;
@@ -3273,7 +3430,7 @@
 	},
 /turf/open/floor/plasteel/barber,
 /area/shuttle/ftl/medical/cmo)
-"gm" = (
+"go" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -3286,7 +3443,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/medbay)
-"gn" = (
+"gp" = (
 /obj/structure/table/glass,
 /obj/item/weapon/folder/white{
 	pixel_x = 3;
@@ -3315,18 +3472,18 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/genetics)
-"go" = (
+"gq" = (
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/genetics)
-"gp" = (
+"gr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/genetics)
-"gq" = (
+"gs" = (
 /obj/machinery/clonepod{
 	connected = null;
 	tag = ""
@@ -3341,7 +3498,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/genetics)
-"gr" = (
+"gt" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /obj/item/clothing/glasses/hud/health,
@@ -3361,7 +3518,7 @@
 	dir = 10
 	},
 /area/shuttle/ftl/medical/medbay)
-"gs" = (
+"gu" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -3373,7 +3530,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"gt" = (
+"gv" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/glass/bottle/epinephrine{
 	pixel_x = 7;
@@ -3383,7 +3540,7 @@
 /obj/item/weapon/reagent_containers/syringe,
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/medbay)
-"gu" = (
+"gw" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/beakers{
 	pixel_x = 2;
@@ -3400,7 +3557,7 @@
 	dir = 6
 	},
 /area/shuttle/ftl/medical/medbay)
-"gv" = (
+"gx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_medical{
@@ -3412,7 +3569,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"gw" = (
+"gy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_medical{
@@ -3425,7 +3582,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"gx" = (
+"gz" = (
 /obj/machinery/door/airlock/medical{
 	name = "Medbay Reception";
 	req_access_txt = "5"
@@ -3434,19 +3591,19 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"gy" = (
+"gA" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/cargo)
-"gz" = (
+"gB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/mining)
-"gA" = (
+"gC" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -3465,7 +3622,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"gB" = (
+"gD" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -3476,7 +3633,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"gC" = (
+"gE" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -3484,7 +3641,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"gD" = (
+"gF" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -3499,23 +3656,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"gE" = (
+"gG" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"gF" = (
+"gH" = (
 /obj/structure/sign/securearea{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"gG" = (
+"gI" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "cargo"
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"gH" = (
+"gJ" = (
 /obj/machinery/light,
 /obj/machinery/status_display{
 	pixel_y = -32
@@ -3525,7 +3682,7 @@
 	icon_state = "loadingarea"
 	},
 /area/shuttle/ftl/cargo/office)
-"gI" = (
+"gK" = (
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "cargo";
@@ -3537,7 +3694,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"gJ" = (
+"gL" = (
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "cargo";
@@ -3549,7 +3706,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"gK" = (
+"gM" = (
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "cargo";
@@ -3558,7 +3715,7 @@
 /obj/structure/plasticflaps,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"gL" = (
+"gN" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -3575,11 +3732,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"gM" = (
+"gO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/computer/cargo/request,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"gN" = (
+"gP" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -3601,7 +3759,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/cargo/office)
-"gO" = (
+"gQ" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/energy/gun{
 	pixel_x = -3;
@@ -3619,7 +3777,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
-"gP" = (
+"gR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 4
 	},
@@ -3627,7 +3785,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
-"gQ" = (
+"gS" = (
 /obj/machinery/suit_storage_unit/security,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -3636,13 +3794,13 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
-"gR" = (
+"gT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/armory)
-"gS" = (
+"gU" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -3652,7 +3810,7 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"gT" = (
+"gV" = (
 /obj/structure/chair{
 	dir = 1
 	},
@@ -3664,7 +3822,7 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"gU" = (
+"gW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -3674,7 +3832,7 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"gV" = (
+"gX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -3689,13 +3847,30 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"gW" = (
+"gY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/hos)
-"gY" = (
+"gZ" = (
+/obj/structure/table,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/pen,
+/obj/item/weapon/hand_labeler,
+/obj/item/weapon/book/manual/wiki/security_space_law,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"ha" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -3706,7 +3881,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"gZ" = (
+"hb" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -3722,7 +3897,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"ha" = (
+"hc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -3733,7 +3908,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"hb" = (
+"hd" = (
 /obj/effect/landmark/start{
 	name = "Security Officer";
 	shuttle_abstract_movable = 1
@@ -3753,7 +3928,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"hc" = (
+"he" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -3770,23 +3945,46 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"hd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+"hf" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (EAST)";
+	icon_state = "pipe-c";
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"hg" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"he" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/office)
-"hf" = (
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"hh" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable{
@@ -3796,7 +3994,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/brig)
-"hg" = (
+"hi" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
@@ -3807,7 +4005,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"hh" = (
+"hj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -3825,7 +4023,22 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"hj" = (
+"hk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door_timer{
+	id = "Cell 1";
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"hl" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable{
 	d1 = 4;
@@ -3834,7 +4047,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"hk" = (
+"hm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -3857,7 +4070,25 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"hm" = (
+"hn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door_timer{
+	id = "Cell 2";
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"ho" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -3868,11 +4099,31 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"ho" = (
+"hp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/door_timer{
+	id = "Cell 3";
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"hq" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/ftl/medical/cmo)
-"hp" = (
+"hr" = (
 /obj/structure/chair/office/light{
 	dir = 8
 	},
@@ -3882,13 +4133,13 @@
 	},
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/ftl/medical/cmo)
-"hq" = (
+"hs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/ftl/medical/cmo)
-"hr" = (
+"ht" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -3901,7 +4152,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/cmo)
-"hs" = (
+"hu" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
@@ -3920,7 +4171,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"ht" = (
+"hv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	d1 = 4;
@@ -3935,7 +4186,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"hu" = (
+"hw" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -3954,7 +4205,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/genetics)
-"hv" = (
+"hx" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -3968,7 +4219,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/genetics)
-"hw" = (
+"hy" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -3984,7 +4235,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/genetics)
-"hx" = (
+"hz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 1
 	},
@@ -3992,7 +4243,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/genetics)
-"hy" = (
+"hA" = (
 /obj/machinery/computer/cloning{
 	pod1 = null;
 	scanner = null
@@ -4007,15 +4258,15 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/genetics)
-"hz" = (
+"hB" = (
 /turf/closed/wall,
 /area/shuttle/ftl/medical/chemistry)
-"hA" = (
+"hC" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/chemistry)
-"hB" = (
+"hD" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -4033,7 +4284,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/chemistry)
-"hC" = (
+"hE" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -4049,7 +4300,7 @@
 	dir = 9
 	},
 /area/shuttle/ftl/medical/medbay)
-"hD" = (
+"hF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4058,7 +4309,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"hE" = (
+"hG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	tag = "icon-pipe-c (WEST)";
@@ -4069,7 +4320,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"hF" = (
+"hH" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/folder/white{
 	pixel_x = 3;
@@ -4082,7 +4333,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/medical/medbay)
-"hG" = (
+"hI" = (
 /obj/structure/chair/office/light{
 	dir = 8
 	},
@@ -4106,10 +4357,14 @@
 	dir = 5
 	},
 /area/shuttle/ftl/medical/medbay)
-"hH" = (
+"hJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/cargo)
+"hK" = (
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/mining)
-"hI" = (
+"hL" = (
 /obj/machinery/camera{
 	c_tag = "Mining Equipment";
 	dir = 4
@@ -4121,24 +4376,24 @@
 /obj/structure/closet/wardrobe/miner,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"hJ" = (
+"hM" = (
 /obj/effect/landmark/start{
 	name = "Shaft Miner"
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"hK" = (
+"hN" = (
 /obj/machinery/suit_storage_unit/mining/eva,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"hL" = (
+"hO" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/cargo/plasmastorage)
-"hM" = (
+"hP" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/cargo/plasmastorage)
-"hN" = (
+"hQ" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "plasma_storage";
 	name = "Plasma Storage"
@@ -4146,67 +4401,91 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/plasmastorage)
-"hP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/obj/machinery/airalarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
+"hR" = (
+/obj/machinery/conveyor{
+	id = "cargo";
+	tag = "munitions south"
 	},
-/obj/machinery/camera{
-	c_tag = "Vault";
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 1
-	},
-/area/shuttle/ftl/security/nuke_storage)
-"hR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 8
-	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"hS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"hT" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/open/floor/plasteel/warning{
 	dir = 4
 	},
 /area/shuttle/ftl/cargo/office)
-"hS" = (
+"hU" = (
+/obj/structure/rack,
+/obj/item/weapon/gun/energy/gun/advtaser{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/gun/energy/gun/advtaser,
+/obj/item/weapon/gun/energy/gun/advtaser{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
+"hV" = (
 /obj/machinery/suit_storage_unit/security,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
-"hT" = (
+"hW" = (
 /obj/structure/closet/secure_closet/hos,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"hU" = (
+"hX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"hV" = (
+"hY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"hX" = (
+"hZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = -10
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/hos)
+"ia" = (
 /obj/structure/table,
 /obj/item/weapon/folder/red{
 	pixel_x = 3
@@ -4219,7 +4498,7 @@
 /obj/item/weapon/reagent_containers/spray/pepper,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/main)
-"hY" = (
+"ib" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -4233,7 +4512,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"hZ" = (
+"ic" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
 	},
@@ -4242,17 +4521,33 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"ia" = (
+"id" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"ib" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/munitions)
-"ic" = (
+"ie" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Security Office East";
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_x = 8;
+	pixel_y = -24
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/main)
+"if" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Brig";
@@ -4264,7 +4559,32 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"if" = (
+"ig" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	sortType = 7
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"ih" = (
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
+"ii" = (
 /obj/machinery/door/window/brigdoor{
 	id = "Cell 1";
 	name = "Cell 1";
@@ -4273,7 +4593,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"ig" = (
+"ij" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -4286,7 +4606,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/brig)
-"ih" = (
+"ik" = (
 /obj/machinery/door/window/brigdoor{
 	id = "Cell 2";
 	name = "Cell 2";
@@ -4295,7 +4615,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"ii" = (
+"il" = (
 /obj/machinery/door/window/brigdoor{
 	id = "Cell 3";
 	name = "Cell 3";
@@ -4304,7 +4624,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"ij" = (
+"im" = (
 /obj/machinery/computer/med_data,
 /obj/machinery/camera{
 	c_tag = "Chief Medical Officer's Office";
@@ -4316,7 +4636,29 @@
 	},
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/ftl/medical/cmo)
-"il" = (
+"in" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = -24;
+	pixel_z = 0
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/mob/living/simple_animal/pet/cat/Runtime,
+/turf/open/floor/plasteel/cmo,
+/area/shuttle/ftl/medical/cmo)
+"io" = (
 /obj/structure/closet/secure_closet/CMO,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -4333,7 +4675,7 @@
 	},
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/ftl/medical/cmo)
-"im" = (
+"ip" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -4346,7 +4688,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/cmo)
-"in" = (
+"iq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -4368,7 +4710,7 @@
 	dir = 10
 	},
 /area/shuttle/ftl/medical/medbay)
-"io" = (
+"ir" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
@@ -4378,7 +4720,7 @@
 	dir = 6
 	},
 /area/shuttle/ftl/medical/medbay)
-"ip" = (
+"is" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -4392,7 +4734,7 @@
 	dir = 10
 	},
 /area/shuttle/ftl/medical/genetics)
-"iq" = (
+"it" = (
 /obj/structure/table/glass,
 /obj/item/weapon/book/manual/medical_cloning{
 	pixel_y = 6
@@ -4410,7 +4752,7 @@
 /obj/item/weapon/storage/firstaid/toxin,
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/genetics)
-"ir" = (
+"iu" = (
 /obj/structure/chair{
 	dir = 4
 	},
@@ -4424,7 +4766,7 @@
 	},
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/genetics)
-"is" = (
+"iv" = (
 /obj/machinery/dna_scannernew{
 	tag = ""
 	},
@@ -4438,7 +4780,7 @@
 	dir = 6
 	},
 /area/shuttle/ftl/medical/genetics)
-"it" = (
+"iw" = (
 /obj/structure/table/glass,
 /obj/item/weapon/grenade/chem_grenade,
 /obj/item/weapon/grenade/chem_grenade,
@@ -4465,7 +4807,7 @@
 	dir = 9
 	},
 /area/shuttle/ftl/medical/chemistry)
-"iu" = (
+"ix" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -4477,7 +4819,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/chemistry)
-"iv" = (
+"iy" = (
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/whiteblue/side{
 	tag = "icon-whiteblue (NORTH)";
@@ -4485,7 +4827,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/medical/chemistry)
-"iw" = (
+"iz" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/beakers{
 	pixel_x = 2;
@@ -4505,18 +4847,18 @@
 	dir = 5
 	},
 /area/shuttle/ftl/medical/chemistry)
-"ix" = (
+"iA" = (
 /obj/machinery/smartfridge/chemistry,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/chemistry)
-"iy" = (
+"iB" = (
 /turf/open/floor/plasteel/whiteblue/side{
 	tag = "icon-whiteblue (WEST)";
 	icon_state = "whiteblue";
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay)
-"iz" = (
+"iC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 4
 	},
@@ -4525,7 +4867,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"iA" = (
+"iD" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
@@ -4533,7 +4875,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"iB" = (
+"iE" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/reagent_containers/food/drinks/britcup{
 	desc = "Kingston's personal cup."
@@ -4542,7 +4884,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"iC" = (
+"iF" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor/plasteel/whiteblue/side{
 	tag = "icon-whiteblue (EAST)";
@@ -4550,11 +4892,11 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/medbay)
-"iD" = (
+"iG" = (
 /obj/machinery/telecomms/relay/portable/preset,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"iE" = (
+"iH" = (
 /obj/machinery/airalarm{
 	dir = 1;
 	icon_state = "alarm0";
@@ -4562,7 +4904,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"iF" = (
+"iI" = (
 /obj/machinery/light_switch{
 	pixel_x = 28;
 	pixel_y = 6
@@ -4570,7 +4912,7 @@
 /obj/machinery/suit_storage_unit/mining/eva,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"iG" = (
+"iJ" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/item/device/radio/intercom{
 	pixel_x = -32;
@@ -4578,16 +4920,16 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/cargo/plasmastorage)
-"iH" = (
+"iK" = (
 /turf/open/floor/engine,
 /area/shuttle/ftl/cargo/plasmastorage)
-"iI" = (
+"iL" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/cargo/plasmastorage)
-"iJ" = (
+"iM" = (
 /obj/machinery/power/apc{
 	auto_name = 1;
 	dir = 1;
@@ -4600,7 +4942,7 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/cargo/plasmastorage)
-"iK" = (
+"iN" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -4615,7 +4957,15 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/cargo/plasmastorage)
-"iM" = (
+"iO" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/cargo/plasmastorage)
+"iP" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -4623,9 +4973,48 @@
 	id = "cargo";
 	tag = "munitions south"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"iP" = (
+"iQ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"iR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 4
+	},
+/area/shuttle/ftl/cargo/office)
+"iS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
@@ -4640,7 +5029,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"iQ" = (
+"iT" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
@@ -4656,13 +5045,35 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"iR" = (
+"iU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/armory)
-"iT" = (
+"iV" = (
+/obj/structure/rack,
+/obj/item/ammo_box/magazine/wt550m9/wtap{
+	pixel_x = 8;
+	pixel_y = -8
+	},
+/obj/item/ammo_box/magazine/wt550m9/wtap,
+/obj/item/ammo_box/magazine/wt550m9/wtap,
+/obj/item/ammo_box/magazine/wt550m9/wtap{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/ammo_box/magazine/wt550m9/wtap,
+/obj/item/ammo_box/magazine/wt550m9/wtap{
+	pixel_x = 8;
+	pixel_y = -8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
+"iW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 8
 	},
@@ -4670,7 +5081,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
-"iU" = (
+"iX" = (
 /obj/machinery/flasher/portable,
 /obj/machinery/firealarm{
 	dir = 4;
@@ -4680,7 +5091,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
-"iV" = (
+"iY" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable{
@@ -4689,7 +5100,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/hos)
-"iW" = (
+"iZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable{
@@ -4703,7 +5114,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/hos)
-"iX" = (
+"ja" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -4718,7 +5129,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/hos)
-"iY" = (
+"jb" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Head of Security";
 	req_access_txt = "31"
@@ -4738,7 +5149,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/hos)
-"iZ" = (
+"jc" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas/sechailer{
 	pixel_x = -3;
@@ -4751,7 +5162,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"ja" = (
+"jd" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -4761,28 +5172,33 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"jb" = (
+"je" = (
 /obj/effect/landmark/start{
 	name = "Security Officer";
 	shuttle_abstract_movable = 1
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"jc" = (
+"jf" = (
 /obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"jd" = (
+"jg" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/main)
-"je" = (
+"jh" = (
 /obj/machinery/door/airlock/glass_security{
 	name = "Brig Desk";
 	req_access_txt = "1"
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/main)
-"jg" = (
+"ji" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/main)
+"jj" = (
 /obj/machinery/door/airlock/security{
 	id_tag = "innerbrig";
 	name = "Brig";
@@ -4798,7 +5214,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"jh" = (
+"jk" = (
 /obj/machinery/door/airlock/security{
 	id_tag = "innerbrig";
 	name = "Brig";
@@ -4808,7 +5224,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"ji" = (
+"jl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Brig Cell 1";
@@ -4817,7 +5233,53 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"jj" = (
+"jm" = (
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 1";
+	name = "Cell 1 Locker"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"jn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Brig Cell 2";
+	dir = 4;
+	network = list("SS13","Brig")
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"jo" = (
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 2";
+	name = "Cell 2 Locker"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"jp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Brig Cell 3";
+	dir = 4;
+	network = list("SS13","Brig")
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/brig)
+"jq" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 3";
 	name = "Cell 3 Locker"
@@ -4831,29 +5293,11 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"jk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Brig Cell 2";
-	dir = 4;
-	network = list("SS13","Brig")
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
-"jl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Brig Cell 3";
-	dir = 4;
-	network = list("SS13","Brig")
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
-"jm" = (
+"jr" = (
 /obj/structure/sign/biohazard,
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/medical/cmo)
-"jn" = (
+"js" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -4888,18 +5332,18 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"jo" = (
+"jt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/medical/virology)
-"jp" = (
+"ju" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/medical/virology)
-"jq" = (
+"jv" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/shuttle/ftl/medical/genetics)
-"js" = (
+"jw" = (
 /obj/structure/table/glass,
 /obj/item/stack/sheet/mineral/plasma{
 	layer = 2.9
@@ -4927,7 +5371,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/chemistry)
-"jt" = (
+"jx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 4
 	},
@@ -4941,7 +5385,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/chemistry)
-"ju" = (
+"jy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -4949,7 +5393,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/chemistry)
-"jv" = (
+"jz" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
@@ -4970,7 +5414,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/chemistry)
-"jw" = (
+"jA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
 	base_state = "left";
@@ -4984,7 +5428,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/chemistry)
-"jx" = (
+"jB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -4994,7 +5438,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay)
-"jy" = (
+"jC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -5003,13 +5447,13 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"jz" = (
+"jD" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"jA" = (
+"jE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -5021,7 +5465,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/medbay)
-"jB" = (
+"jF" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/firealarm{
 	dir = 8;
@@ -5029,16 +5473,42 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/cargo/plasmastorage)
-"jC" = (
+"jG" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine,
 /area/shuttle/ftl/cargo/plasmastorage)
-"jD" = (
+"jH" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/conveyor{
+	id = "cargo";
+	tag = "munitions south"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"jI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"jF" = (
+"jJ" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 4
+	},
+/area/shuttle/ftl/cargo/office)
+"jK" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/projectile/automatic/wt550{
 	pixel_x = -3;
@@ -5053,23 +5523,23 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
-"jG" = (
+"jL" = (
 /turf/open/floor/plasteel/darkwarning{
 	dir = 4
 	},
 /area/shuttle/ftl/security/armory)
-"jH" = (
+"jM" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Armory";
 	req_access_txt = "3"
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/armory)
-"jI" = (
+"jN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"jJ" = (
+"jO" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -5084,7 +5554,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"jK" = (
+"jP" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -5096,7 +5566,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"jL" = (
+"jQ" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -5104,7 +5574,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"jM" = (
+"jR" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -5113,7 +5583,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"jN" = (
+"jS" = (
 /obj/machinery/button/door{
 	id = "briggate";
 	name = "Desk Shutters";
@@ -5129,11 +5599,11 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/main)
-"jO" = (
+"jT" = (
 /obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/main)
-"jP" = (
+"jU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "briggate";
@@ -5150,7 +5620,7 @@
 /obj/item/weapon/pen,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/brig)
-"jQ" = (
+"jV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -5160,7 +5630,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"jR" = (
+"jW" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/flasher{
 	id = "brigentry";
@@ -5168,7 +5638,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"jS" = (
+"jX" = (
 /obj/machinery/flasher{
 	id = "Cell 1";
 	pixel_x = -28
@@ -5176,7 +5646,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"jT" = (
+"jY" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -5191,7 +5661,7 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"jU" = (
+"jZ" = (
 /obj/machinery/flasher{
 	id = "Cell 2";
 	pixel_x = -28
@@ -5199,7 +5669,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"jV" = (
+"ka" = (
 /obj/machinery/flasher{
 	id = "Cell 3";
 	pixel_x = -28
@@ -5207,29 +5677,29 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"jW" = (
+"kb" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/ftl/subshuttle/pod_3)
-"jX" = (
+"kc" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"jY" = (
+"kd" = (
 /obj/machinery/light,
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"jZ" = (
+"ke" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/virology)
-"ka" = (
+"kf" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -5237,14 +5707,14 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"kb" = (
+"kg" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"kc" = (
+"kh" = (
 /obj/machinery/shower{
 	dir = 4
 	},
@@ -5261,7 +5731,7 @@
 	dir = 9
 	},
 /area/shuttle/ftl/medical/virology)
-"kd" = (
+"ki" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
@@ -5275,7 +5745,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/medical/virology)
-"ke" = (
+"kj" = (
 /obj/machinery/airalarm{
 	dir = 8;
 	icon_state = "alarm0";
@@ -5293,7 +5763,7 @@
 	dir = 5
 	},
 /area/shuttle/ftl/medical/virology)
-"kf" = (
+"kk" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -5309,7 +5779,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/medbay)
-"kg" = (
+"kl" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -5322,7 +5792,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/medbay)
-"kh" = (
+"km" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -5330,7 +5800,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/medbay)
-"ki" = (
+"kn" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -5348,7 +5818,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/medbay)
-"kj" = (
+"ko" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
@@ -5364,7 +5834,7 @@
 	dir = 10
 	},
 /area/shuttle/ftl/medical/chemistry)
-"kk" = (
+"kp" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5375,14 +5845,14 @@
 	},
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/chemistry)
-"kl" = (
+"kq" = (
 /obj/machinery/chem_dispenser,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/chemistry)
-"km" = (
+"kr" = (
 /obj/machinery/chem_master,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -5397,13 +5867,13 @@
 	dir = 6
 	},
 /area/shuttle/ftl/medical/chemistry)
-"kn" = (
+"ks" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/medical/chemistry)
-"ko" = (
+"kt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -5417,25 +5887,25 @@
 	dir = 10
 	},
 /area/shuttle/ftl/medical/medbay)
-"kp" = (
+"ku" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/medbay)
-"kq" = (
+"kv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 8
 	},
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/medbay)
-"kr" = (
+"kw" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Reception";
 	dir = 1
 	},
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/medbay)
-"ks" = (
+"kx" = (
 /obj/structure/chair{
 	dir = 8
 	},
@@ -5453,7 +5923,32 @@
 	dir = 6
 	},
 /area/shuttle/ftl/medical/medbay)
-"kt" = (
+"ky" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/cargo)
+"kz" = (
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/cargo)
+"kA" = (
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/cargo)
+"kB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Hatch";
@@ -5463,14 +5958,36 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/plasmastorage)
-"ku" = (
+"kC" = (
 /obj/machinery/camera{
 	c_tag = "Plasma Storage";
 	dir = 1
 	},
+/mob/living/simple_animal/bot/mulebot,
 /turf/open/floor/engine,
 /area/shuttle/ftl/cargo/plasmastorage)
-"kw" = (
+"kD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/warning,
+/area/shuttle/ftl/cargo/office)
+"kE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 6
+	},
+/area/shuttle/ftl/cargo/office)
+"kF" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "8"
@@ -5483,7 +6000,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/office)
-"kx" = (
+"kG" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -5492,7 +6009,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"ky" = (
+"kH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -5505,13 +6022,13 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"kz" = (
+"kI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/armory)
-"kA" = (
+"kJ" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/vest{
 	pixel_x = -3;
@@ -5548,7 +6065,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
-"kB" = (
+"kK" = (
 /obj/machinery/light,
 /obj/machinery/power/apc{
 	auto_name = 1;
@@ -5566,7 +6083,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
-"kC" = (
+"kL" = (
 /obj/machinery/airalarm{
 	dir = 1;
 	icon_state = "alarm0";
@@ -5584,7 +6101,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/security/armory)
-"kD" = (
+"kM" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Armory";
 	req_access_txt = "3"
@@ -5599,7 +6116,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/armory)
-"kE" = (
+"kN" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -5610,7 +6127,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"kF" = (
+"kO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 1
 	},
@@ -5624,7 +6141,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"kG" = (
+"kP" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -5640,7 +6157,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"kH" = (
+"kQ" = (
 /obj/machinery/airalarm{
 	dir = 1;
 	icon_state = "alarm0";
@@ -5651,7 +6168,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"kI" = (
+"kR" = (
 /obj/machinery/light,
 /obj/effect/landmark/start{
 	name = "Security Officer";
@@ -5664,7 +6181,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
-"kJ" = (
+"kS" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -5688,7 +6205,7 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/main)
-"kK" = (
+"kT" = (
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
@@ -5698,7 +6215,7 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/main)
-"kL" = (
+"kU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "briggate";
@@ -5712,14 +6229,14 @@
 /obj/item/device/radio/off,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/brig)
-"kM" = (
+"kV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"kN" = (
+"kW" = (
 /obj/item/device/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
 	dir = 2;
@@ -5733,7 +6250,7 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"kO" = (
+"kX" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet,
 /obj/structure/cable{
@@ -5744,7 +6261,7 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"kP" = (
+"kY" = (
 /obj/structure/shuttle/engine/propulsion/burst/left,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -5754,7 +6271,7 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/subshuttle/pod_3)
-"kQ" = (
+"kZ" = (
 /obj/structure/shuttle/engine/propulsion/burst/right,
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -5765,7 +6282,7 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/subshuttle/pod_3)
-"kR" = (
+"la" = (
 /obj/machinery/door/airlock/shuttle{
 	name = "Emergency Shuttle Airlock";
 	req_access_txt = "0"
@@ -5780,32 +6297,32 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/ftl/subshuttle/pod_3)
-"kS" = (
+"lb" = (
 /obj/structure/shuttle/engine/propulsion/burst,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/open/space,
 /area/shuttle/ftl/subshuttle/pod_3)
-"kT" = (
+"lc" = (
 /obj/machinery/door/airlock/shuttle{
 	name = "Emergency Shuttle Airlock";
 	req_access_txt = "0"
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/ftl/subshuttle/pod_3)
-"kU" = (
+"ld" = (
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"kV" = (
+"le" = (
 /obj/structure/table,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"kW" = (
+"lf" = (
 /obj/structure/sink{
 	icon_state = "sink";
 	dir = 8;
@@ -5829,7 +6346,7 @@
 	dir = 10
 	},
 /area/shuttle/ftl/medical/virology)
-"kX" = (
+"lg" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -5847,7 +6364,7 @@
 	},
 /turf/open/floor/plasteel/warnwhite,
 /area/shuttle/ftl/medical/virology)
-"kY" = (
+"lh" = (
 /obj/structure/closet/l3closet,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -5862,7 +6379,7 @@
 	dir = 6
 	},
 /area/shuttle/ftl/medical/virology)
-"kZ" = (
+"li" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -5872,40 +6389,52 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/medbay)
-"la" = (
+"lj" = (
 /turf/closed/wall/r_wall,
-/area/shuttle/ftl/engine/engineering)
-"lb" = (
-/obj/machinery/door/airlock/external{
-	id_tag = null;
-	name = "Port Docking Bay 2";
-	req_access_txt = "0"
+/area/shuttle/ftl/engine/break_room)
+"lk" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "34"
 	},
-/obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/starboard)
-"lc" = (
+/area/shuttle/ftl/engine/break_room)
+"ll" = (
 /obj/structure/sign/bluecross_2,
 /turf/closed/wall,
 /area/shuttle/ftl/medical/medbay)
-"ld" = (
+"lm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"le" = (
+"ln" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"lg" = (
+"lo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/cargo)
+"lp" = (
 /turf/closed/wall,
 /area/shuttle/ftl/maintenance/cargo)
-"lh" = (
+"lq" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
 	id = "cargo";
@@ -5914,11 +6443,28 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"lj" = (
+"lr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"ls" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/office)
+"lt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/shuttle/ftl/maintenance/security)
-"lk" = (
+"lu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "briggate";
@@ -5930,7 +6476,7 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/main)
-"ll" = (
+"lv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "briggate";
@@ -5944,7 +6490,7 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/main)
-"lm" = (
+"lw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -5961,7 +6507,7 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"ln" = (
+"lx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	id_tag = "outerbrig";
@@ -5972,7 +6518,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
-"lo" = (
+"ly" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
@@ -5981,7 +6527,7 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/brig)
-"lp" = (
+"lz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable,
@@ -5992,7 +6538,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/brig)
-"lq" = (
+"lA" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
@@ -6000,11 +6546,27 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/brig)
-"ls" = (
+"lB" = (
+/obj/machinery/door/airlock/glass_external{
+	name = "Escape Shuttle"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"lC" = (
 /obj/structure/lattice,
 /turf/open/space,
 /area/shuttle/ftl/space)
-"lu" = (
+"lD" = (
+/obj/machinery/door/airlock/glass_virology{
+	name = "Isolation A";
+	req_access_txt = "23"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"lE" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -6031,39 +6593,103 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"lw" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/meter,
-/turf/open/floor/plasteel/warning{
+"lF" = (
+/obj/machinery/vending/tool{
+	req_access_txt = "34"
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 9
+	},
+/area/shuttle/ftl/engine/break_room)
+"lG" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/area/shuttle/ftl/engine/engine_smes)
-"lD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/area/shuttle/ftl/engine/break_room)
+"lH" = (
+/obj/structure/noticeboard{
+	pixel_y = 32
 	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/engine/engineering)
-"lE" = (
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/break_room)
+"lI" = (
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/break_room)
+"lJ" = (
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 1;
+	pixel_y = 23
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/break_room)
+"lK" = (
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/break_room)
+"lL" = (
+/obj/machinery/camera{
+	c_tag = "Engineering Equipment"
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/break_room)
+"lM" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/break_room)
+"lN" = (
+/obj/machinery/suit_storage_unit/engine,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 5
+	},
+/area/shuttle/ftl/engine/break_room)
+"lO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"lF" = (
+"lP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"lG" = (
-/obj/machinery/light,
+/area/shuttle/ftl/hallway/primary/central)
+"lQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/suit_storage_unit/engine,
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engineering)
-"lH" = (
+/area/shuttle/ftl/hallway/primary/central)
+"lR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -6071,7 +6697,7 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"lI" = (
+"lS" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -6080,19 +6706,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"lJ" = (
+"lT" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"lK" = (
+"lU" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"lV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"lL" = (
+"lW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -6102,7 +6737,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"lM" = (
+"lX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -6111,7 +6746,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"lN" = (
+"lY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -6129,31 +6764,30 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"lO" = (
-/obj/structure/rack,
-/obj/item/weapon/circuitboard/machine/telecomms/broadcaster{
-	pixel_x = -3;
-	pixel_y = 3
+"lZ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
-/obj/item/weapon/circuitboard/machine/telecomms/bus,
-/obj/item/weapon/circuitboard/machine/telecomms/server{
-	pixel_x = 3;
-	pixel_y = -3;
-	pixel_z = 0
+/turf/open/floor/plasteel/warning{
+	dir = 4
 	},
-/obj/item/weapon/circuitboard/machine/telecomms/receiver{
-	pixel_x = -3;
-	pixel_y = 3
+/area/shuttle/ftl/hallway/primary/port)
+"ma" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/item/weapon/circuitboard/machine/telecomms/processor,
-/obj/item/weapon/circuitboard/computer/message_monitor{
-	pixel_x = 3;
-	pixel_y = -3
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/hallway/primary/port)
+"mb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"lP" = (
+/turf/open/floor/plasteel/warning{
+	dir = 8
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"mc" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -6163,7 +6797,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"lQ" = (
+"md" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -6174,7 +6808,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"lR" = (
+"me" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"mf" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"mg" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -6187,7 +6834,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"lS" = (
+"mh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -6200,14 +6847,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"lT" = (
+"mi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"lU" = (
+"mj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -6216,7 +6863,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"lV" = (
+"mk" = (
 /obj/structure/sign/directions/evac{
 	dir = 4;
 	icon_state = "direction_evac";
@@ -6228,39 +6875,39 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"lW" = (
+"ml" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"lX" = (
+"mm" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"lY" = (
+"mn" = (
 /turf/open/floor/plasteel/escape/corner{
 	tag = "icon-escapecorner (EAST)";
 	icon_state = "escapecorner";
 	dir = 4
 	},
 /area/shuttle/ftl/hallway/primary/port)
-"lZ" = (
+"mo" = (
 /turf/open/floor/plasteel/escape{
 	tag = "icon-escape (NORTH)";
 	icon_state = "escape";
 	dir = 1
 	},
 /area/shuttle/ftl/hallway/primary/port)
-"ma" = (
+"mp" = (
 /turf/open/floor/plasteel/escape/corner{
 	tag = "icon-escapecorner (NORTH)";
 	icon_state = "escapecorner";
 	dir = 1
 	},
 /area/shuttle/ftl/hallway/primary/port)
-"mb" = (
+"mq" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -6271,7 +6918,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"mc" = (
+"mr" = (
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway 5";
 	dir = 2
@@ -6286,7 +6933,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/hallway/primary/port)
-"md" = (
+"ms" = (
 /obj/structure/grille,
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -6298,12 +6945,12 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
-"me" = (
+"mt" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
-"mf" = (
+"mu" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
@@ -6312,7 +6959,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/virology)
-"mg" = (
+"mv" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/disposalpipe/segment{
@@ -6320,7 +6967,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/virology)
-"mh" = (
+"mw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -6328,7 +6975,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"mi" = (
+"mx" = (
 /obj/structure/sink{
 	pixel_y = 28
 	},
@@ -6348,7 +6995,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"mj" = (
+"my" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 4
 	},
@@ -6367,7 +7014,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"mk" = (
+"mz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
@@ -6383,28 +7030,119 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"ml" = (
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/security/nuke_storage)
-"mm" = (
+"mA" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/medical/virology)
+"mB" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -6;
 	pixel_y = 0
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/medical/virology)
-"mq" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"mC" = (
+/obj/machinery/vending/engivend{
+	req_access_txt = "34"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
+/area/shuttle/ftl/engine/break_room)
+"mD" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"mE" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"mF" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/weapon/book/manual/ftl_wiki/supermatter,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"mG" = (
+/obj/item/weapon/storage/belt/utility,
+/obj/item/weapon/wrench,
+/obj/item/weapon/weldingtool,
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"mH" = (
+/obj/structure/table,
+/obj/item/weapon/book/manual/wiki/engineering_hacking{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/book/manual/wiki/engineering_construction,
+/obj/item/weapon/book/manual/wiki/engineering_guide{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"mI" = (
+/obj/effect/landmark/start{
+	name = "Station Engineer";
+	shuttle_abstract_movable = 1
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"mJ" = (
+/obj/machinery/suit_storage_unit/engine,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/shuttle/ftl/engine/break_room)
+"mK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"mL" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (EAST)";
+	icon_state = "pipe-c";
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=AS";
+	location = "AP"
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"mx" = (
+"mM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 4;
@@ -6416,7 +7154,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"my" = (
+"mN" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -6429,7 +7167,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"mz" = (
+"mO" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -6440,7 +7178,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"mA" = (
+"mP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 1
 	},
@@ -6454,14 +7192,129 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"mB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"mQ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	sortType = 22
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"mR" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/bridge)
-"mD" = (
+/turf/open/floor/plasteel{
+	icon_state = "L1"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"mS" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L3"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"mT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L5"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"mU" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L7"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"mV" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L9"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"mW" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L11"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"mX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	desc = "";
+	icon_state = "L13";
+	name = "floor"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"mY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
 /obj/structure/cable{
 	d1 = 4;
@@ -6473,7 +7326,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"mF" = (
+"mZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	d1 = 4;
@@ -6487,7 +7340,32 @@
 	dir = 4
 	},
 /area/shuttle/ftl/hallway/primary/port)
-"mG" = (
+"na" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/hallway/primary/port)
+"nb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 8
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"nc" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -6509,7 +7387,52 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"mI" = (
+"nd" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"ne" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"nf" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"ng" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
@@ -6523,22 +7446,62 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"mK" = (
+"nh" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (WEST)";
+	icon_state = "pipe-c";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"mL" = (
+"ni" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"nj" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"nk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"nl" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"nm" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=AP";
+	location = "FP"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"nn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"mM" = (
+"no" = (
 /obj/effect/landmark{
 	name = "Observer-Start"
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"mN" = (
+"np" = (
 /obj/machinery/door/airlock/external{
 	id_tag = null;
 	name = "Port Docking Bay 2";
@@ -6546,10 +7509,19 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
-"mO" = (
+"nq" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
-"mP" = (
+"nr" = (
+/obj/machinery/door/airlock/external{
+	id_tag = null;
+	name = "Port Docking Bay 2";
+	req_access_txt = "0"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
+"ns" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start{
 	name = "Virologist";
@@ -6559,7 +7531,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"mQ" = (
+"nt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 4
 	},
@@ -6567,7 +7539,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"mR" = (
+"nu" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start{
 	name = "Virologist";
@@ -6580,7 +7552,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"mS" = (
+"nv" = (
 /obj/machinery/computer/pandemic,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -6593,13 +7565,90 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"nc" = (
-/obj/machinery/light/small{
-	dir = 1
+"nw" = (
+/obj/structure/closet/secure_closet/engineering_welding,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"nd" = (
+/area/shuttle/ftl/engine/break_room)
+"nx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"ny" = (
+/obj/effect/landmark/start{
+	name = "Station Engineer";
+	shuttle_abstract_movable = 1
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"nz" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -4
+	},
+/obj/item/stack/cable_coil,
+/obj/item/weapon/electronics/airlock,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"nA" = (
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"nB" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/device/flashlight{
+	pixel_x = -2;
+	pixel_y = 9
+	},
+/obj/item/device/flashlight,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"nC" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
+"nD" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/shuttle/ftl/engine/break_room)
+"nE" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"nF" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"nG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -6607,13 +7656,13 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"ne" = (
+"nH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"nf" = (
+"nI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -6626,23 +7675,88 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"ni" = (
+"nJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Port Primary Hallway 1";
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L2"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"nK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L4"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"nL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L6"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"nM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L8"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"nN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	icon_state = "L10"
+	},
 /area/shuttle/ftl/hallway/primary/port)
-"nj" = (
+"nO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L12"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"nP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	desc = "";
+	icon_state = "L14"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"nQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"nk" = (
+"nR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -6651,7 +7765,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"nl" = (
+"nS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -6663,7 +7777,25 @@
 	dir = 4
 	},
 /area/shuttle/ftl/hallway/primary/port)
-"nm" = (
+"nT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/hallway/primary/port)
+"nU" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 8
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"nV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -6678,7 +7810,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"nn" = (
+"nW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"nX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -6693,26 +7834,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"no" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+"nY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	layer = 2.9;
-	name = "bridge blast door"
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"nZ" = (
+/obj/machinery/camera{
+	c_tag = "Port Primary Hallway 3";
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/bridge)
-"nq" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"oa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -6723,23 +7866,71 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"nr" = (
+"ob" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"oc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"nt" = (
+"od" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/pump,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"oe" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/pump,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"of" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"og" = (
+/obj/machinery/camera{
+	c_tag = "Port Primary Hallway 4";
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"oh" = (
 /turf/open/floor/plasteel/arrival/corner,
 /area/shuttle/ftl/hallway/primary/port)
-"nu" = (
+"oi" = (
 /obj/effect/landmark/latejoin,
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/plasteel/arrival,
 /area/shuttle/ftl/hallway/primary/port)
-"nv" = (
+"oj" = (
 /obj/effect/landmark/latejoin,
 /obj/structure/chair{
 	dir = 1
@@ -6747,16 +7938,16 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/arrival,
 /area/shuttle/ftl/hallway/primary/port)
-"nw" = (
+"ok" = (
 /turf/open/floor/plasteel/arrival,
 /area/shuttle/ftl/hallway/primary/port)
-"nx" = (
+"ol" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"ny" = (
+"om" = (
 /obj/machinery/smartfridge/chemistry/virology,
 /obj/machinery/camera{
 	c_tag = "Virology";
@@ -6766,7 +7957,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"nz" = (
+"on" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper_bin{
 	pixel_x = -2;
@@ -6783,7 +7974,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"nA" = (
+"oo" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/beakers{
 	pixel_x = 2;
@@ -6800,7 +7991,7 @@
 	icon_state = "whitegreen"
 	},
 /area/shuttle/ftl/medical/virology)
-"nB" = (
+"op" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/color/latex,
 /obj/item/device/healthanalyzer,
@@ -6816,7 +8007,7 @@
 	icon_state = "whitegreen"
 	},
 /area/shuttle/ftl/medical/virology)
-"nC" = (
+"oq" = (
 /obj/structure/table/glass,
 /obj/item/weapon/book/manual/wiki/infections{
 	pixel_y = 7
@@ -6833,19 +8024,97 @@
 	icon_state = "whitegreen"
 	},
 /area/shuttle/ftl/medical/virology)
-"nI" = (
+"or" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 10
+	},
+/area/shuttle/ftl/engine/break_room)
+"os" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/shuttle/ftl/engine/break_room)
+"ot" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/shuttle/ftl/engine/break_room)
+"ou" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/shuttle/ftl/engine/break_room)
+"ov" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/shuttle/ftl/engine/break_room)
+"ow" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/power/apc{
 	auto_name = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+	name = "south bump";
+	pixel_y = -24
 	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/disposal)
-"nK" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/shuttle/ftl/engine/break_room)
+"ox" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/shuttle/ftl/engine/break_room)
+"oy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/shuttle/ftl/engine/break_room)
+"oz" = (
+/obj/structure/tank_dispenser,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 6
+	},
+/area/shuttle/ftl/engine/break_room)
+"oA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26;
@@ -6853,10 +8122,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"nM" = (
+"oB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"oC" = (
 /turf/closed/wall,
 /area/shuttle/ftl/janitor)
-"nN" = (
+"oD" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -6871,10 +8144,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/janitor)
-"nO" = (
+"oE" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/munitions/loading)
-"nP" = (
+"oF" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -6883,15 +8156,15 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions/loading)
-"nQ" = (
+"oG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/munitions/loading)
-"nR" = (
+"oH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/munitions/loading)
-"nS" = (
+"oI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
 	name = "Munitions Access";
@@ -6901,7 +8174,7 @@
 	icon_state = "loadingarea"
 	},
 /area/shuttle/ftl/munitions/loading)
-"nT" = (
+"oJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -6916,23 +8189,61 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions)
-"nU" = (
+"oK" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/munitions)
-"nV" = (
+"oL" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/maintenance/disposal)
-"nW" = (
+"oM" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/maintenance/disposal)
-"nX" = (
-/obj/machinery/suit_storage_unit/engine,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 5
+"oN" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Disposal Access";
+	req_access_txt = "40"
 	},
-/area/shuttle/ftl/engine/break_room)
-"nY" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"oO" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/storage/tech)
+"oP" = (
+/turf/closed/wall,
+/area/shuttle/ftl/storage/tech)
+"oQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall,
+/area/shuttle/ftl/storage/tech)
+"oR" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Tech Storage";
+	req_one_access_txt = "7;19"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"oS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/shuttle/ftl/storage/tech)
+"oT" = (
+/obj/effect/landmark/ship_fire,
+/turf/open/space,
+/area/shuttle/ftl/space)
+"oU" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -6950,25 +8261,27 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/medbay)
-"ob" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/central)
-"oc" = (
+"oV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room";
+	req_access_txt = "34"
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/central)
-"od" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/central)
-"oe" = (
+/area/shuttle/ftl/engine/break_room)
+"oW" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/break_room)
+"oX" = (
 /obj/structure/table,
 /obj/item/weapon/grenade/chem_grenade/cleaner,
 /obj/item/weapon/grenade/chem_grenade/cleaner,
@@ -6976,7 +8289,7 @@
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/janitor)
-"of" = (
+"oY" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/lights/mixed{
 	pixel_x = 5;
@@ -6993,7 +8306,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/janitor)
-"og" = (
+"oZ" = (
 /obj/machinery/power/apc{
 	auto_name = 1;
 	dir = 4;
@@ -7004,7 +8317,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/janitor)
-"oh" = (
+"pa" = (
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "munitions_loading";
@@ -7012,22 +8325,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/loading)
-"oi" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"oj" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/break_room)
-"ok" = (
+"pb" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -7049,7 +8347,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/loading)
-"ol" = (
+"pc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/airalarm{
 	frequency = 1439;
@@ -7069,7 +8367,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/loading)
-"om" = (
+"pd" = (
 /obj/machinery/conveyor{
 	dir = 10;
 	id = "munitions_loading";
@@ -7083,7 +8381,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/loading)
-"on" = (
+"pe" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable{
@@ -7094,7 +8392,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions/loading)
-"oo" = (
+"pf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -7113,7 +8411,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/munitions)
-"op" = (
+"pg" = (
 /obj/structure/disposaloutlet{
 	dir = 4
 	},
@@ -7124,14 +8422,14 @@
 	dir = 4
 	},
 /area/shuttle/ftl/maintenance/disposal)
-"oq" = (
+"ph" = (
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "garbage"
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"or" = (
+"pi" = (
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "garbage"
@@ -7141,7 +8439,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"os" = (
+"pj" = (
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "garbage"
@@ -7153,7 +8451,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"ot" = (
+"pk" = (
 /obj/machinery/conveyor{
 	dir = 6;
 	id = "garbage";
@@ -7161,7 +8459,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"ou" = (
+"pl" = (
 /obj/machinery/camera{
 	c_tag = "Waste Disposals"
 	},
@@ -7174,32 +8472,185 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"ow" = (
-/obj/machinery/pdapainter,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/light_switch{
-	pixel_x = 28;
+"pm" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/machinery/requests_console{
-	pixel_x = 32
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = -8
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/heads)
-"ox" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"pn" = (
+/obj/machinery/mineral/stacking_unit_console{
+	dir = 2;
+	machinedir = 8;
+	pixel_y = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/storage/tech)
+"po" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/computer/aifixer{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/computer/teleporter,
+/obj/item/weapon/circuitboard/computer/rdconsole{
+	pixel_x = 3;
+	pixel_y = -3;
+	pixel_z = 0
+	},
+/obj/item/weapon/circuitboard/computer/pandemic{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/machine/circuit_imprinter,
+/obj/item/weapon/circuitboard/machine/destructive_analyzer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/weapon/circuitboard/machine/mechfab{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/machine/protolathe,
+/obj/item/weapon/circuitboard/machine/rdserver{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"pp" = (
+/obj/structure/rack,
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/clothing/gloves/color/yellow{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/device/multitool{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/device/multitool,
+/obj/item/clothing/glasses/meson{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/meson,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"pq" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"pr" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/computer/security,
+/obj/item/weapon/circuitboard/computer/secure_data{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/weapon/circuitboard/computer/arcade/battle{
+	permeability_coefficient = 1;
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/computer/mining,
+/obj/item/weapon/circuitboard/machine/autolathe{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"ps" = (
+/obj/item/weapon/stock_parts/subspace/amplifier,
+/obj/item/weapon/stock_parts/subspace/amplifier,
+/obj/item/weapon/stock_parts/subspace/amplifier,
+/obj/item/weapon/stock_parts/subspace/analyzer,
+/obj/item/weapon/stock_parts/subspace/analyzer,
+/obj/item/weapon/stock_parts/subspace/analyzer,
+/obj/item/weapon/stock_parts/subspace/ansible,
+/obj/item/weapon/stock_parts/subspace/ansible,
+/obj/item/weapon/stock_parts/subspace/ansible,
+/obj/item/weapon/stock_parts/subspace/crystal,
+/obj/item/weapon/stock_parts/subspace/crystal,
+/obj/item/weapon/stock_parts/subspace/crystal,
+/obj/item/weapon/stock_parts/subspace/filter,
+/obj/item/weapon/stock_parts/subspace/filter,
+/obj/item/weapon/stock_parts/subspace/filter,
+/obj/item/weapon/stock_parts/subspace/filter,
+/obj/item/weapon/stock_parts/subspace/filter,
+/obj/item/weapon/stock_parts/subspace/transmitter,
+/obj/item/weapon/stock_parts/subspace/transmitter,
+/obj/item/weapon/stock_parts/subspace/transmitter,
+/obj/item/weapon/stock_parts/subspace/treatment,
+/obj/item/weapon/stock_parts/subspace/treatment,
+/obj/item/weapon/stock_parts/subspace/treatment,
+/obj/structure/table,
+/obj/item/weapon/storage/belt/utility/full,
+/obj/item/weapon/storage/belt/utility/full,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"pt" = (
+/obj/item/device/aicard,
+/obj/item/weapon/aiModule/reset{
+	pixel_y = 2
+	},
+/obj/structure/table,
+/obj/item/device/flashlight,
+/obj/item/device/flashlight,
+/obj/machinery/cell_charger,
+/obj/item/weapon/stock_parts/cell/high/plus,
+/obj/item/weapon/stock_parts/cell/high/plus,
+/obj/item/device/assembly/flash{
+	pixel_x = 6
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"pu" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"pv" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/computer/borgupload{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/computer/aiupload,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"pw" = (
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion";
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/ftl/engine/engine_smes)
-"oy" = (
+"px" = (
 /obj/structure/shuttle/engine/heater{
 	icon_state = "heater";
 	dir = 8
@@ -7209,7 +8660,10 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/ftl/engine/engine_smes)
-"oz" = (
+"py" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/engine_smes)
+"pz" = (
 /obj/structure/window/reinforced{
 	dir = 8;
 	layer = 2.9
@@ -7221,7 +8675,7 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/engine/engine_smes)
-"oA" = (
+"pA" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	tag = "icon-intact (SOUTHWEST)";
 	icon_state = "intact";
@@ -7229,7 +8683,7 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/engine/engine_smes)
-"oB" = (
+"pB" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	tag = "icon-intact (SOUTHEAST)";
 	icon_state = "intact";
@@ -7237,7 +8691,7 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/engine/engine_smes)
-"oC" = (
+"pC" = (
 /obj/structure/window/reinforced{
 	dir = 4;
 	pixel_x = 0
@@ -7249,7 +8703,7 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/engine/engine_smes)
-"oD" = (
+"pD" = (
 /obj/structure/closet/radiation,
 /obj/item/clothing/glasses/meson,
 /obj/structure/window/reinforced{
@@ -7265,13 +8719,58 @@
 	dir = 2
 	},
 /area/shuttle/ftl/engine/chiefs_office)
-"oG" = (
+"pE" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 8;
+	pixel_y = 24
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"pF" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/button/door{
+	desc = "A remote control-switch for the engineering security doors.";
+	id = "Engineering";
+	name = "Engineering Lockdown";
+	pixel_x = 24;
+	pixel_y = 24;
+	req_access_txt = "29"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"pG" = (
 /obj/machinery/suit_storage_unit/ce,
 /turf/open/floor/plasteel/neutral{
 	dir = 2
 	},
 /area/shuttle/ftl/engine/chiefs_office)
-"oH" = (
+"pH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -7280,26 +8779,34 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/chiefs_office)
-"oI" = (
+"pI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"oK" = (
-/obj/machinery/computer/card/minor/ce,
+"pJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"pK" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
 /obj/machinery/camera{
-	c_tag = "Chief Engineer's Office";
-	dir = 1
+	c_tag = "Engineering Hallway North"
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
 	},
-/turf/open/floor/plasteel/neutral{
-	dir = 2
-	},
-/area/shuttle/ftl/engine/chiefs_office)
-"oL" = (
+/area/shuttle/ftl/engine/engineering)
+"pL" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
@@ -7309,7 +8816,7 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engineering)
-"oM" = (
+"pM" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
 	name = "engineering security door"
@@ -7319,7 +8826,7 @@
 	name = "floor"
 	},
 /area/shuttle/ftl/engine/engineering)
-"oN" = (
+"pN" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/camera{
 	c_tag = "Engineering Access"
@@ -7330,26 +8837,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"oO" = (
+"pO" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"oP" = (
+"pP" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engineering)
-"oQ" = (
+"pQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"oR" = (
+"pR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -7362,20 +8869,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"oS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/central)
-"oT" = (
+"pS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/janitor)
-"oU" = (
+"pT" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start{
 	name = "Janitor";
@@ -7390,13 +8890,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/janitor)
-"oV" = (
+"pU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/janitor)
-"oW" = (
+"pV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Janitor's Closet";
@@ -7408,34 +8908,43 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/janitor)
-"oX" = (
+"pW" = (
 /obj/machinery/ammo_rack/full,
 /turf/open/floor/plasteel/delivery,
 /area/shuttle/ftl/munitions/loading)
-"oY" = (
+"pX" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plasteel/neutral,
 /area/shuttle/ftl/munitions/loading)
-"oZ" = (
+"pY" = (
 /obj/machinery/ammo_rack/full/shield_piercing,
 /turf/open/floor/plasteel{
 	icon_state = "delivery"
 	},
 /area/shuttle/ftl/munitions/loading)
-"pa" = (
+"pZ" = (
+/obj/machinery/ammo_rack/full/smart_homing,
+/turf/open/floor/plasteel{
+	icon_state = "delivery"
+	},
+/area/shuttle/ftl/munitions/loading)
+"qa" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/loading)
+"qb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/loading)
-"pb" = (
+"qc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/loading)
-"pc" = (
+"qd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
 	},
@@ -7444,18 +8953,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/loading)
-"pd" = (
+"qe" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/loading)
-"pe" = (
+"qf" = (
+/obj/machinery/conveyor_switch{
+	id = "munitions_loading"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/loading)
+"qg" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions/loading)
-"pf" = (
+"qh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/power/apc{
 	auto_name = 1;
@@ -7471,21 +8986,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions)
-"pg" = (
+"qi" = (
 /obj/machinery/conveyor{
 	dir = 5;
 	id = "garbage"
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"ph" = (
+"qj" = (
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "garbage"
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"pi" = (
+"qk" = (
 /obj/machinery/conveyor{
 	dir = 10;
 	id = "garbage";
@@ -7493,7 +9008,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"pj" = (
+"ql" = (
 /obj/machinery/conveyor_switch/oneway{
 	convdir = -1;
 	id = "garbage";
@@ -7501,24 +9016,69 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"pk" = (
+"qm" = (
+/obj/machinery/button/door{
+	id = "Disposal Exit";
+	name = "Disposal Vent Control";
+	pixel_x = 25;
+	pixel_y = 4;
+	req_access_txt = "40"
+	},
+/obj/machinery/button/massdriver{
+	id = "trash";
+	pixel_x = 26;
+	pixel_y = -6
+	},
+/obj/structure/chair/stool,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/vault{
-	icon_state = "closed";
-	locked = 1;
-	req_access_txt = "13"
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"qn" = (
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"qo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"qp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
 	},
-/area/shuttle/ftl/security/nuke_storage)
-"pl" = (
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"qq" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Tech Storage";
+	req_one_access_txt = "19;29"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"qr" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"qs" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/computer/communications{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/computer/card,
+/obj/item/weapon/circuitboard/computer/crew{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"qt" = (
 /obj/structure/window/reinforced{
 	dir = 8;
 	layer = 2.9
@@ -7526,11 +9086,11 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
 /area/shuttle/ftl/engine/engine_smes)
-"pm" = (
+"qu" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
 /area/shuttle/ftl/engine/engine_smes)
-"pn" = (
+"qv" = (
 /obj/structure/window/reinforced{
 	dir = 4;
 	pixel_x = 0
@@ -7538,7 +9098,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
 /area/shuttle/ftl/engine/engine_smes)
-"po" = (
+"qw" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -7549,12 +9109,12 @@
 	dir = 2
 	},
 /area/shuttle/ftl/engine/chiefs_office)
-"pp" = (
+"qx" = (
 /turf/open/floor/plasteel/neutral{
 	dir = 2
 	},
 /area/shuttle/ftl/engine/chiefs_office)
-"pq" = (
+"qy" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -7569,7 +9129,7 @@
 	dir = 2
 	},
 /area/shuttle/ftl/engine/chiefs_office)
-"pr" = (
+"qz" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -7578,7 +9138,23 @@
 	dir = 2
 	},
 /area/shuttle/ftl/engine/chiefs_office)
-"pt" = (
+"qA" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"qB" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -7591,7 +9167,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"pu" = (
+"qC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 4;
@@ -7606,7 +9182,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/engine/engineering)
-"pv" = (
+"qD" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -7623,7 +9199,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"pw" = (
+"qE" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
 	name = "engineering security door"
@@ -7639,7 +9215,7 @@
 	name = "floor"
 	},
 /area/shuttle/ftl/engine/engineering)
-"px" = (
+"qF" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -7651,7 +9227,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"py" = (
+"qG" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -7664,7 +9240,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"pz" = (
+"qH" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 4;
@@ -7679,7 +9255,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engineering)
-"pA" = (
+"qI" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -7697,7 +9273,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"pB" = (
+"qJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -7709,7 +9285,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"pC" = (
+"qK" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Central Hallway 1";
@@ -7717,13 +9293,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"pD" = (
+"qL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/janitor)
-"pE" = (
+"qM" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -7733,7 +9309,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/janitor)
-"pF" = (
+"qN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
 	},
@@ -7742,7 +9318,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/janitor)
-"pG" = (
+"qO" = (
 /obj/item/weapon/mop,
 /obj/item/weapon/reagent_containers/glass/bucket,
 /obj/machinery/light{
@@ -7756,7 +9332,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/janitor)
-"pH" = (
+"qP" = (
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "munitions";
@@ -7764,7 +9340,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/loading)
-"pI" = (
+"qQ" = (
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "munitions";
@@ -7772,7 +9348,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/loading)
-"pJ" = (
+"qR" = (
 /obj/machinery/conveyor{
 	dir = 6;
 	id = "munitions";
@@ -7780,20 +9356,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/loading)
-"pK" = (
+"qS" = (
 /obj/machinery/door/airlock/command{
 	name = "Munitions Access";
 	req_access_txt = "35"
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/loading)
-"pL" = (
+"qT" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions/loading)
-"pM" = (
+"qU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Munitions East";
@@ -7810,17 +9386,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions)
-"pN" = (
+"qV" = (
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "garbage"
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"pO" = (
+"qW" = (
 /turf/closed/wall,
 /area/shuttle/ftl/maintenance/disposal)
-"pP" = (
+"qX" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 2
 	},
@@ -7844,28 +9420,166 @@
 	dir = 4
 	},
 /area/shuttle/ftl/maintenance/disposal)
-"pQ" = (
+"qY" = (
 /obj/machinery/mineral/stacking_machine{
 	input_dir = 1;
 	stack_amt = 10
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"pR" = (
+"qZ" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"pS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"ra" = (
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"rb" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/machine/mac_barrel{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"pT" = (
+/obj/item/weapon/circuitboard/machine/mac_breech,
+/obj/item/weapon/circuitboard/machine/phase_cannon{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"rc" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/machine/telecomms/broadcaster{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/machine/telecomms/bus,
+/obj/item/weapon/circuitboard/machine/telecomms/server{
+	pixel_x = 3;
+	pixel_y = -3;
+	pixel_z = 0
+	},
+/obj/item/weapon/circuitboard/machine/telecomms/receiver{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/machine/telecomms/processor,
+/obj/item/weapon/circuitboard/computer/message_monitor{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"rd" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/computer/cloning{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/weapon/circuitboard/computer/med_data{
+	pixel_x = 3;
+	pixel_y = -3;
+	pixel_z = 0
+	},
+/obj/item/weapon/circuitboard/machine/clonescanner{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/machine/clonepod,
+/obj/item/weapon/circuitboard/computer/scan_consolenew{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"re" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/computer/atmos_alert{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/computer/stationalert,
+/obj/item/weapon/circuitboard/computer/powermonitor{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/weapon/circuitboard/machine/thermomachine/freezer{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"rf" = (
+/obj/item/device/analyzer,
+/obj/item/device/healthanalyzer,
+/obj/item/device/plant_analyzer{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/stock_parts/micro_laser,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/micro_laser/high,
+/obj/item/weapon/stock_parts/micro_laser/high,
+/obj/item/weapon/stock_parts/micro_laser/high,
+/obj/item/weapon/stock_parts/micro_laser/high,
+/obj/structure/table,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"rg" = (
+/obj/item/weapon/electronics/airlock{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/electronics/apc,
+/obj/structure/table,
+/obj/item/stack/cable_coil{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/stack/cable_coil,
+/obj/item/device/multitool{
+	pixel_x = -4;
+	pixel_y = -1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"rh" = (
+/obj/machinery/camera{
+	c_tag = "Secure Tech Storage";
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"ri" = (
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/computer/mecha_control{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/computer/robotics,
+/turf/open/floor/plating,
+/area/shuttle/ftl/storage/tech)
+"rj" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/clipboard,
 /obj/item/weapon/lighter,
@@ -7879,7 +9593,7 @@
 	dir = 2
 	},
 /area/shuttle/ftl/engine/chiefs_office)
-"pU" = (
+"rk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 4
 	},
@@ -7887,7 +9601,7 @@
 	dir = 2
 	},
 /area/shuttle/ftl/engine/chiefs_office)
-"pV" = (
+"rl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -7904,7 +9618,7 @@
 	dir = 2
 	},
 /area/shuttle/ftl/engine/chiefs_office)
-"pW" = (
+"rm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -7921,7 +9635,7 @@
 	dir = 2
 	},
 /area/shuttle/ftl/engine/chiefs_office)
-"pX" = (
+"rn" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
 	name = "engineering security door"
@@ -7947,7 +9661,7 @@
 	name = "floor"
 	},
 /area/shuttle/ftl/engine/chiefs_office)
-"pY" = (
+"ro" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -7967,7 +9681,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"pZ" = (
+"rp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
@@ -7978,7 +9692,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"qa" = (
+"rq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -7987,14 +9701,14 @@
 	dir = 4
 	},
 /area/shuttle/ftl/engine/engineering)
-"qb" = (
+"rr" = (
 /obj/structure/sign/securearea,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engineering)
-"qc" = (
+"rs" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
 	name = "engineering security door"
@@ -8006,7 +9720,20 @@
 	name = "floor"
 	},
 /area/shuttle/ftl/engine/engineering)
-"qf" = (
+"rt" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/suit_storage_unit/engine,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"ru" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/suit_storage_unit/engine,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"rv" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -8015,35 +9742,44 @@
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engineering)
-"qg" = (
+"rw" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"rx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"qi" = (
+"ry" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"qj" = (
+"rz" = (
 /obj/structure/janitorialcart,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/janitor)
-"qk" = (
+"rA" = (
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/janitor)
-"ql" = (
+"rB" = (
 /obj/structure/closet/jcloset,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/janitor)
-"qm" = (
+"rC" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
 	id = "munitions";
@@ -8051,26 +9787,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/loading)
-"qn" = (
+"rD" = (
 /turf/open/floor/plasteel/warning{
 	tag = "icon-plasteel_warn (NORTHWEST)";
 	icon_state = "plasteel_warn";
 	dir = 9
 	},
 /area/shuttle/ftl/munitions)
-"qo" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+"rE" = (
+/obj/structure/table,
+/obj/item/weapon/crowbar,
+/obj/item/weapon/wrench,
+/obj/item/device/multitool,
+/obj/item/clothing/ears/earmuffs,
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTH)";
+	icon_state = "plasteel_warn";
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/sleep)
-"qp" = (
+/area/shuttle/ftl/munitions)
+"rF" = (
 /obj/structure/table,
 /obj/item/weapon/weldingtool,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -8080,7 +9816,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/munitions)
-"qq" = (
+"rG" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/mechanical{
 	pixel_x = -2;
@@ -8092,7 +9828,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/munitions)
-"qr" = (
+"rH" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/electrical{
 	pixel_x = 1;
@@ -8104,7 +9840,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/munitions)
-"qs" = (
+"rI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -8116,7 +9852,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions)
-"qt" = (
+"rJ" = (
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "garbage"
@@ -8126,12 +9862,12 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"qu" = (
+"rK" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"qv" = (
+"rL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -8140,7 +9876,7 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"qw" = (
+"rM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -8148,7 +9884,17 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"qx" = (
+"rN" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c (WEST)";
+	icon_state = "pipe-c";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"rO" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/folder/yellow,
 /obj/item/weapon/paper/monitorkey,
@@ -8159,7 +9905,7 @@
 	dir = 2
 	},
 /area/shuttle/ftl/engine/chiefs_office)
-"qy" = (
+"rP" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start{
 	name = "Chief Engineer"
@@ -8168,22 +9914,13 @@
 	dir = 2
 	},
 /area/shuttle/ftl/engine/chiefs_office)
-"qz" = (
+"rQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station,
 /turf/open/floor/plasteel/neutral{
 	dir = 2
 	},
 /area/shuttle/ftl/engine/chiefs_office)
-"qA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engineering)
-"qB" = (
+"rR" = (
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 4
@@ -8192,7 +9929,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"qC" = (
+"rS" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/engineering)
+"rT" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -8201,29 +9941,44 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel/escape{
+	dir = 4
+	},
 /area/shuttle/ftl/hallway/primary/central)
-"qD" = (
+"rU" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"qE" = (
+"rV" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/janitor)
-"qF" = (
+"rW" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/janitor)
+"rX" = (
 /obj/structure/closet/l3closet/janitor,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/janitor)
-"qG" = (
+"rY" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/munitions/office)
-"qH" = (
+"rZ" = (
 /obj/machinery/computer/munitions_console,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/office)
-"qI" = (
+"sa" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/device/multitool{
@@ -8239,7 +9994,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/office)
-"qJ" = (
+"sb" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -8251,7 +10006,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions/office)
-"qK" = (
+"sc" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -8266,7 +10021,7 @@
 	dir = 9
 	},
 /area/shuttle/ftl/munitions)
-"qL" = (
+"sd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -8282,7 +10037,21 @@
 	dir = 1
 	},
 /area/shuttle/ftl/munitions)
-"qM" = (
+"se" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 5
+	},
+/area/shuttle/ftl/munitions)
+"sf" = (
 /obj/machinery/conveyor{
 	id = "munitions";
 	tag = "munitions south"
@@ -8298,7 +10067,21 @@
 	},
 /turf/open/floor/plasteel/delivery,
 /area/shuttle/ftl/munitions)
-"qN" = (
+"sg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 9
+	},
+/area/shuttle/ftl/munitions)
+"sh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -8314,7 +10097,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/munitions)
-"qO" = (
+"si" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -8326,7 +10109,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions)
-"qP" = (
+"sj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -8339,7 +10122,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions)
-"qQ" = (
+"sk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
@@ -8356,7 +10139,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions)
-"qR" = (
+"sl" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Disposal Exit";
 	layer = 3;
@@ -8370,7 +10153,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"qS" = (
+"sm" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -8382,7 +10165,15 @@
 	dir = 8
 	},
 /area/shuttle/ftl/maintenance/disposal)
-"qU" = (
+"sn" = (
+/obj/machinery/door/poddoor{
+	id = "trash";
+	name = "disposal bay door"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/disposal)
+"so" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/paper_bin{
 	pixel_x = -3;
@@ -8397,7 +10188,22 @@
 	dir = 2
 	},
 /area/shuttle/ftl/engine/chiefs_office)
-"qW" = (
+"sp" = (
+/obj/machinery/computer/card/minor/ce,
+/obj/machinery/camera{
+	c_tag = "Chief Engineer's Office";
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/neutral{
+	dir = 2
+	},
+/area/shuttle/ftl/engine/chiefs_office)
+"sq" = (
 /obj/machinery/computer/station_alert,
 /obj/item/device/radio/intercom{
 	pixel_x = 0;
@@ -8407,7 +10213,7 @@
 	dir = 2
 	},
 /area/shuttle/ftl/engine/chiefs_office)
-"qX" = (
+"sr" = (
 /obj/machinery/computer/atmos_alert,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -8416,7 +10222,7 @@
 	dir = 2
 	},
 /area/shuttle/ftl/engine/chiefs_office)
-"qY" = (
+"ss" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8428,7 +10234,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/chiefs_office)
-"qZ" = (
+"st" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -8440,64 +10246,69 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"ra" = (
+"su" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"rb" = (
+"sv" = (
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel/darkwarning/corner,
 /area/shuttle/ftl/engine/engineering)
-"rc" = (
+"sw" = (
 /obj/machinery/camera{
 	c_tag = "Shield Generator"
 	},
 /turf/open/floor/plasteel/darkwarning,
 /area/shuttle/ftl/engine/engineering)
-"rd" = (
+"sx" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/darkwarning,
 /area/shuttle/ftl/engine/engineering)
-"re" = (
+"sy" = (
 /turf/open/floor/plasteel/darkwarning,
 /area/shuttle/ftl/engine/engineering)
-"rf" = (
+"sz" = (
 /turf/open/floor/plasteel/darkwarning/corner{
 	tag = "icon-black_warn_corner (NORTH)";
 	icon_state = "black_warn_corner";
 	dir = 1
 	},
 /area/shuttle/ftl/engine/engineering)
-"rg" = (
+"sA" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel/escape{
+	dir = 4
+	},
 /area/shuttle/ftl/hallway/primary/central)
-"rh" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Hatch";
+"sB" = (
+/obj/machinery/door/airlock{
+	name = "Custodial Closet";
 	req_access_txt = "39"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/shuttle/ftl/janitor)
-"ri" = (
+"sC" = (
 /obj/structure/chair{
 	dir = 1
 	},
@@ -8535,7 +10346,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/office)
-"rj" = (
+"sD" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -8552,7 +10363,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/office)
-"rk" = (
+"sE" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable{
@@ -8566,7 +10377,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions/office)
-"rl" = (
+"sF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
@@ -8587,13 +10398,13 @@
 	dir = 8
 	},
 /area/shuttle/ftl/munitions)
-"rm" = (
+"sG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions)
-"rn" = (
+"sH" = (
 /obj/machinery/conveyor_switch{
 	id = "munitions"
 	},
@@ -8604,7 +10415,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/munitions)
-"ro" = (
+"sI" = (
 /obj/machinery/conveyor{
 	id = "munitions";
 	tag = "munitions south"
@@ -8614,7 +10425,7 @@
 	},
 /turf/open/floor/plasteel/delivery,
 /area/shuttle/ftl/munitions)
-"rp" = (
+"sJ" = (
 /obj/machinery/conveyor_switch{
 	id = "munitions"
 	},
@@ -8625,7 +10436,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/munitions)
-"rq" = (
+"sK" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
@@ -8639,7 +10450,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions)
-"rr" = (
+"sL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -8650,25 +10461,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions)
-"rs" = (
+"sM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions)
-"rt" = (
+"sN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions)
-"ru" = (
+"sO" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions)
-"rv" = (
+"sP" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions)
-"rw" = (
+"sQ" = (
 /obj/structure/window/reinforced{
 	dir = 8;
 	layer = 2.9
@@ -8681,7 +10492,7 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/engine/engine_smes)
-"rx" = (
+"sR" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	tag = "icon-intact (NORTHEAST)";
@@ -8690,7 +10501,7 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/engine/engine_smes)
-"ry" = (
+"sS" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	tag = "icon-intact (NORTHWEST)";
@@ -8699,7 +10510,7 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/engine/engine_smes)
-"rz" = (
+"sT" = (
 /obj/structure/window/reinforced{
 	dir = 4;
 	pixel_x = 0
@@ -8712,10 +10523,10 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/engine/engine_smes)
-"rA" = (
+"sU" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/chiefs_office)
-"rB" = (
+"sV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
@@ -8726,7 +10537,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"rC" = (
+"sW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -8734,7 +10545,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"rD" = (
+"sX" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -8746,7 +10557,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engineering)
-"rE" = (
+"sY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
 	},
@@ -8754,58 +10565,71 @@
 	dir = 4
 	},
 /area/shuttle/ftl/engine/engineering)
-"rF" = (
+"sZ" = (
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engineering)
-"rG" = (
+"ta" = (
 /turf/open/floor/plasteel/darkwarning{
 	tag = "icon-black_warn (WEST)";
 	icon_state = "black_warn";
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engineering)
-"rH" = (
+"tb" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel/arrival{
+	dir = 4
+	},
+/area/shuttle/ftl/hallway/primary/central)
+"tc" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"rI" = (
+"td" = (
 /turf/closed/wall,
-/area/shuttle/ftl/maintenance/bridge)
-"rJ" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/weapon/storage/belt/utility,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/bridge)
-"rK" = (
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/bridge)
-"rL" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "43"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/munitions/office)
-"rM" = (
+/area/storage/emergency2)
+"te" = (
+/obj/structure/closet/toolcloset,
+/turf/open/floor/plasteel/delivery,
+/area/storage/emergency2)
+"tf" = (
+/turf/open/floor/plasteel/neutral,
+/area/storage/emergency2)
+"tg" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/office)
-"rN" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
+"th" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions/office)
+"ti" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "munitions";
 	name = "munitions blast door"
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/command{
+	name = "Munitions Officer";
+	req_access_txt = "43"
+	},
+/turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/office)
-"rO" = (
+"tj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -8815,21 +10639,36 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions)
-"rQ" = (
-/obj/structure/tank_dispenser,
-/turf/open/floor/plasteel/yellow/side{
+"tk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"tl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/warning{
 	dir = 6
 	},
-/area/shuttle/ftl/engine/break_room)
-"rS" = (
+/area/shuttle/ftl/munitions)
+"tm" = (
+/obj/machinery/conveyor{
+	id = "munitions";
+	tag = "munitions south"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/munitions)
+"tn" = (
+/obj/structure/chair/stool,
+/turf/open/floor/engine,
+/area/shuttle/ftl/munitions)
+"to" = (
+/turf/closed/wall,
+/area/shuttle/ftl/munitions)
+"tp" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions)
-"rT" = (
-/turf/closed/wall,
-/area/shuttle/ftl/munitions)
-"rU" = (
+"tq" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
@@ -8837,18 +10676,18 @@
 	pixel_y = 0
 	},
 /turf/open/space,
-/area/shuttle/ftl/munitions/cannon)
-"rV" = (
+/area/shuttle/ftl/munitions)
+"tr" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/shuttle/ftl/munitions/cannon)
-"rW" = (
+/area/shuttle/ftl/munitions)
+"ts" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel{
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"rX" = (
+"tt" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -8858,7 +10697,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"rY" = (
+"tu" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -8867,7 +10706,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"rZ" = (
+"tv" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -8877,7 +10716,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"sb" = (
+"tw" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	tag = "icon-pump_map (EAST)";
+	icon_state = "pump_map";
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Engine North";
+	network = list("SS13","Supermatter")
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"tx" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -8893,7 +10747,7 @@
 /obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"sc" = (
+"ty" = (
 /obj/machinery/power/terminal{
 	dir = 4
 	},
@@ -8908,7 +10762,7 @@
 	dir = 9
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"sd" = (
+"tz" = (
 /obj/machinery/power/smes/engineering{
 	color = ""
 	},
@@ -8931,7 +10785,7 @@
 	dir = 5
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"se" = (
+"tA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -8944,12 +10798,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"sf" = (
+"tB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"sg" = (
+"tC" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
 	name = "engineering security door"
@@ -8961,12 +10815,12 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
-"sh" = (
+"tD" = (
 /turf/open/floor/plasteel/darkwarning{
 	dir = 4
 	},
 /area/shuttle/ftl/engine/engineering)
-"si" = (
+"tE" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plasteel/darkwarning{
@@ -8975,23 +10829,41 @@
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engineering)
-"sj" = (
-/obj/structure/rack,
+"tF" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel/arrival{
+	dir = 4
+	},
+/area/shuttle/ftl/hallway/primary/central)
+"tG" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/bridge)
-"sk" = (
+/obj/structure/closet/emcloset,
+/obj/item/weapon/tank/internals/emergency_oxygen,
+/obj/item/weapon/tank/internals/emergency_oxygen/double,
+/obj/item/weapon/tank/internals/emergency_oxygen,
+/turf/open/floor/plasteel/delivery,
+/area/storage/emergency2)
+"tH" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/bridge)
-"sl" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/bridge)
-"sm" = (
+/turf/open/floor/plasteel/neutral,
+/area/storage/emergency2)
+"tI" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel/delivery,
+/area/storage/emergency2)
+"tJ" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/airalarm{
 	dir = 4;
@@ -9000,13 +10872,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/office)
-"sn" = (
+"tK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/office)
-"so" = (
+"tL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -9018,7 +10890,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions/office)
-"sp" = (
+"tM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -9031,42 +10903,56 @@
 	},
 /turf/open/floor/plasteel/delivery,
 /area/shuttle/ftl/munitions)
-"sq" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
+"tN" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/munitions)
+"tO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+	dir = 9
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"ss" = (
+/obj/machinery/light_switch{
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/machinery/camera{
+	c_tag = "Munitions West";
+	dir = 1;
+	pixel_x = 15
+	},
+/obj/structure/window/reinforced/crosswired{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/munitions)
+"tP" = (
+/turf/open/floor/engine,
+/area/shuttle/ftl/munitions)
+"tQ" = (
 /obj/machinery/mac_breech{
 	dir = 4
 	},
-/turf/open/floor/plating/warnplate/end{
-	dir = 8
-	},
+/turf/open/floor/engine,
 /area/shuttle/ftl/munitions)
-"st" = (
+"tR" = (
+/obj/machinery/mac_barrel{
+	dir = 4;
+	id = "weapon_k_1"
+	},
 /turf/open/floor/plating/warnplate/side{
 	tag = "icon-plating_warn_side (EAST)";
 	icon_state = "plating_warn_side";
 	dir = 4
 	},
 /area/shuttle/ftl/munitions)
-"su" = (
+"tS" = (
+/turf/open/floor/plating/warnplate/side{
+	tag = "icon-plating_warn_side (EAST)";
+	icon_state = "plating_warn_side";
+	dir = 4
+	},
+/area/shuttle/ftl/munitions)
+"tT" = (
 /obj/structure/plasticflaps/mining,
 /turf/open/floor/plating/warnplate/side{
 	tag = "icon-plating_warn_side (EAST)";
@@ -9074,30 +10960,41 @@
 	dir = 4
 	},
 /area/shuttle/ftl/munitions)
-"sw" = (
+"tU" = (
+/obj/machinery/door/poddoor{
+	id = "weapon_k_1";
+	name = "munitions launcher bay door"
+	},
+/turf/open/floor/plating/warnplate/side{
+	tag = "icon-plating_warn_side (EAST)";
+	icon_state = "plating_warn_side";
+	dir = 4
+	},
+/area/shuttle/ftl/munitions)
+"tV" = (
 /obj/structure/lattice,
 /turf/open/space,
-/area/shuttle/ftl/munitions/cannon)
-"sx" = (
+/area/shuttle/ftl/munitions)
+"tW" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel{
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"sy" = (
+"tX" = (
 /obj/effect/landmark/start{
 	name = "Station Engineer";
 	shuttle_abstract_movable = 1
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"sz" = (
+"tY" = (
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	name = "Coolant valve"
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"sA" = (
+"tZ" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	icon_state = "intact";
@@ -9105,20 +11002,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"sB" = (
+"ua" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"sC" = (
+"ub" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"sD" = (
+"uc" = (
 /obj/structure/window/reinforced{
 	dir = 4;
 	pixel_x = 0
@@ -9128,7 +11025,7 @@
 /obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"sE" = (
+"ud" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -9139,7 +11036,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"sF" = (
+"ue" = (
 /obj/machinery/computer/monitor{
 	name = "primary power monitoring console"
 	},
@@ -9155,7 +11052,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"sG" = (
+"uf" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -9164,11 +11061,11 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engineering)
-"sH" = (
+"ug" = (
 /obj/machinery/ftl_shieldgen,
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engineering)
-"sI" = (
+"uh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 4
 	},
@@ -9183,13 +11080,32 @@
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engineering)
-"sJ" = (
+"ui" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engineering)
-"sK" = (
+"uj" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"uk" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"ul" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/airalarm{
 	dir = 8;
@@ -9198,18 +11114,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"sL" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/bridge)
-"sM" = (
+"um" = (
+/obj/structure/closet/crate/internals,
+/obj/item/weapon/tank/internals/emergency_oxygen,
+/obj/item/weapon/tank/internals/emergency_oxygen,
+/turf/open/floor/plasteel/delivery,
+/area/storage/emergency2)
+"un" = (
 /obj/structure/closet/emcloset,
+/obj/item/weapon/tank/internals/emergency_oxygen,
+/obj/item/weapon/tank/internals/emergency_oxygen/double,
+/obj/item/weapon/tank/internals/emergency_oxygen,
+/turf/open/floor/plasteel/delivery,
+/area/storage/emergency2)
+"uo" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
 /turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/bridge)
-"sN" = (
+/area/shuttle/ftl/munitions/office)
+"up" = (
 /turf/closed/wall,
 /area/shuttle/ftl/munitions/office)
-"sO" = (
+"uq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -9222,26 +11152,24 @@
 	name = "munitions blast door"
 	},
 /obj/machinery/door/airlock/command{
+	emergency = 1;
 	name = "Munitions Access";
 	req_access_txt = "35"
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions)
-"sP" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "munitions";
-	name = "munitions blast door"
-	},
+"ur" = (
 /obj/machinery/door/airlock/command{
+	emergency = 1;
 	name = "Munitions Access";
 	req_access_txt = "35"
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions)
-"sQ" = (
+"us" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/bridge)
-"sR" = (
+"ut" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -9251,7 +11179,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/bridge)
-"sS" = (
+"uu" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
 	name = "KEEP CLEAR: DOCKING AREA";
@@ -9259,31 +11187,41 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/shuttle/ftl/munitions/cannon)
-"sT" = (
+/area/shuttle/ftl/munitions)
+"uv" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/warning,
 /area/shuttle/ftl/engine/engine_smes)
-"sU" = (
+"uw" = (
 /turf/open/floor/plasteel/warning,
 /area/shuttle/ftl/engine/engine_smes)
-"sV" = (
+"ux" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 8
 	},
 /turf/open/floor/plasteel/warning,
 /area/shuttle/ftl/engine/engine_smes)
-"sW" = (
+"uy" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/warning,
 /area/shuttle/ftl/engine/engine_smes)
-"sY" = (
+"uz" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	icon_state = "intact";
+	dir = 10
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel/warning/corner{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"uA" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"sZ" = (
+"uB" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -9297,7 +11235,7 @@
 	dir = 10
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"ta" = (
+"uC" = (
 /obj/machinery/computer/atmos_control/tank{
 	frequency = 1438;
 	input_tag = "cooling_in";
@@ -9314,7 +11252,7 @@
 	dir = 6
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"tb" = (
+"uD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -9326,9 +11264,14 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"tc" = (
+"uE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet{
@@ -9342,7 +11285,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"td" = (
+"uF" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -9350,7 +11293,7 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engineering)
-"te" = (
+"uG" = (
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -9362,7 +11305,7 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engineering)
-"tf" = (
+"uH" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	tag = "icon-intact (EAST)";
 	icon_state = "intact";
@@ -9370,7 +11313,7 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engineering)
-"tg" = (
+"uI" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	tag = "icon-intact (NORTHWEST)";
 	icon_state = "intact";
@@ -9378,7 +11321,7 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engineering)
-"th" = (
+"uJ" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -9389,14 +11332,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"ti" = (
+"uK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"tj" = (
+"uL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/power/apc{
 	auto_name = 1;
@@ -9411,7 +11354,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"tk" = (
+"uM" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/neutral,
+/area/storage/emergency2)
+"uN" = (
+/obj/structure/closet/firecloset/full,
+/obj/item/weapon/tank/internals/emergency_oxygen,
+/turf/open/floor/plasteel/delivery,
+/area/storage/emergency2)
+"uO" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -9428,7 +11380,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/munitions)
-"tl" = (
+"uP" = (
 /obj/machinery/camera{
 	c_tag = "Munitions Access";
 	dir = 8
@@ -9439,7 +11391,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/munitions)
-"tm" = (
+"uQ" = (
 /obj/machinery/computer/monitor,
 /obj/structure/cable{
 	d2 = 2;
@@ -9452,36 +11404,36 @@
 	},
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge)
-"tn" = (
+"uR" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/toolbox/emergency,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge)
-"to" = (
+"uS" = (
 /obj/structure/table/reinforced,
 /obj/item/device/multitool,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge)
-"tp" = (
+"uT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge)
-"tq" = (
+"uU" = (
 /obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge)
-"tr" = (
+"uV" = (
 /obj/machinery/computer/security,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge)
-"ts" = (
+"uW" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge)
-"tt" = (
+"uX" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor{
@@ -9489,7 +11441,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"tu" = (
+"uY" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor{
@@ -9498,7 +11450,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
-"tv" = (
+"uZ" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/button/door{
 	name = "Shutters Control";
@@ -9511,14 +11463,14 @@
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"tw" = (
+"va" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"tx" = (
+"vb" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -9530,7 +11482,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"ty" = (
+"vc" = (
 /obj/machinery/power/port_gen/pacman{
 	pixel_y = 4
 	},
@@ -9552,7 +11504,21 @@
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"tz" = (
+"vd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"ve" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/power/apc{
 	auto_name = 1;
@@ -9567,16 +11533,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"tA" = (
+"vf" = (
 /turf/open/floor/plasteel/darkwarning/corner,
 /area/shuttle/ftl/engine/engineering)
-"tB" = (
+"vg" = (
 /obj/machinery/camera{
 	c_tag = "FTL Drive"
 	},
 /turf/open/floor/plasteel/darkwarning,
 /area/shuttle/ftl/engine/engineering)
-"tC" = (
+"vh" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -9587,13 +11553,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"tD" = (
+"vi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"tE" = (
+"vj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass,
@@ -9604,49 +11570,57 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"tF" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "8"
+"vk" = (
+/obj/machinery/door/airlock/glass{
+	name = "Emergency Storage"
 	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/bridge)
-"tG" = (
+/turf/open/floor/plasteel/neutral,
+/area/storage/emergency2)
+"vl" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	layer = 2.9;
+	name = "bridge blast door"
 	},
 /turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"tI" = (
+/area/shuttle/ftl/bridge)
+"vm" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	layer = 2.9;
+	name = "bridge blast door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge)
+"vn" = (
 /turf/closed/wall,
 /area/shuttle/ftl/bridge)
-"tJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/door/firedoor,
+"vo" = (
 /obj/machinery/door/airlock/command{
+	emergency = 1;
 	name = "Munitions Access";
 	req_access_txt = "35"
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge)
-"tK" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	name = "Munitions Access";
-	req_access_txt = "35"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/bridge)
-"tL" = (
+"vp" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -9669,12 +11643,12 @@
 	dir = 1
 	},
 /area/shuttle/ftl/bridge)
-"tM" = (
+"vq" = (
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 1
 	},
 /area/shuttle/ftl/bridge)
-"tN" = (
+"vr" = (
 /obj/structure/chair{
 	dir = 1
 	},
@@ -9682,12 +11656,12 @@
 	dir = 5
 	},
 /area/shuttle/ftl/bridge)
-"tO" = (
+"vs" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/toolbox/mechanical,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge)
-"tP" = (
+"vt" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -9700,7 +11674,10 @@
 	},
 /turf/open/floor/plasteel/darkwarning,
 /area/shuttle/ftl/engine/engine_smes)
-"tQ" = (
+"vu" = (
+/turf/open/floor/plasteel/darkwarning,
+/area/shuttle/ftl/engine/engine_smes)
+"vv" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1;
 	frequency = 1438;
@@ -9714,7 +11691,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"tR" = (
+"vw" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "8"
@@ -9724,7 +11701,7 @@
 	},
 /turf/open/floor/noslip,
 /area/shuttle/ftl/engine/engine_smes)
-"tS" = (
+"vx" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/button/door{
 	name = "Emitter Port";
@@ -9737,14 +11714,14 @@
 	dir = 10
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"tT" = (
+"vy" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel/warning,
 /area/shuttle/ftl/engine/engine_smes)
-"tU" = (
+"vz" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10;
 	initialize_directions = 10
@@ -9753,7 +11730,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"tV" = (
+"vA" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -9762,7 +11739,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"tW" = (
+"vB" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -9774,7 +11751,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"tX" = (
+"vC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
@@ -9790,7 +11767,7 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engine_smes)
-"tY" = (
+"vD" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -9802,7 +11779,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"tZ" = (
+"vE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -9812,7 +11789,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"ua" = (
+"vF" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"vG" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"vH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -9821,7 +11811,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"ub" = (
+"vI" = (
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
@@ -9829,16 +11819,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"uc" = (
+"vJ" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"ud" = (
+"vK" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"ue" = (
+"vL" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/securearea{
 	pixel_y = 32
@@ -9847,14 +11837,14 @@
 	name = "floor"
 	},
 /area/shuttle/ftl/hallway/primary/central)
-"uf" = (
+"vM" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Command Access";
 	req_one_access_txt = "12;35"
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge)
-"ug" = (
+"vN" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 1;
@@ -9865,16 +11855,36 @@
 	name = "floor"
 	},
 /area/shuttle/ftl/bridge)
-"uh" = (
+"vO" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge)
-"uk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"vP" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge)
-"ul" = (
+"vQ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge)
+"vR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge)
+"vS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -9884,7 +11894,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge)
-"um" = (
+"vT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -9895,7 +11905,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge)
-"un" = (
+"vU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge)
+"vV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -9906,7 +11922,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge)
-"uo" = (
+"vW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
 	},
@@ -9919,26 +11935,33 @@
 	dir = 1
 	},
 /area/shuttle/ftl/bridge)
-"up" = (
+"vX" = (
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge)
-"uq" = (
+"vY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/status_display,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge)
-"ur" = (
+"vZ" = (
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 4
 	},
 /area/shuttle/ftl/bridge)
-"us" = (
+"wa" = (
+/obj/item/weapon/melee/classic_baton/telescopic,
+/turf/open/space,
+/area/shuttle/ftl/space)
+"wb" = (
 /obj/machinery/door/poddoor{
 	id = "supermatter_eject"
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engine_smes)
-"ut" = (
+"wc" = (
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engine_smes)
+"wd" = (
 /obj/machinery/mass_driver{
 	dir = 8;
 	id = "supermatter_eject"
@@ -9946,7 +11969,7 @@
 /obj/machinery/power/supermatter_shard,
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engine_smes)
-"uu" = (
+"we" = (
 /obj/machinery/air_sensor{
 	frequency = 1438;
 	id_tag = "engine_sensor"
@@ -9957,7 +11980,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"uv" = (
+"wf" = (
 /obj/machinery/door/poddoor{
 	id = "Supermatter port"
 	},
@@ -9965,11 +11988,11 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating/airless,
 /area/shuttle/ftl/engine/engine_smes)
-"uw" = (
+"wg" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"ux" = (
+"wh" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
 	dir = 8;
@@ -9981,19 +12004,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"uy" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Equipment"
+"wi" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/device/radio/intercom{
-	pixel_x = 0;
-	pixel_y = 32
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 1
+/obj/item/weapon/book/manual/ftl_wiki/supermatter,
+/turf/open/floor/plasteel/warning{
+	dir = 8
 	},
-/area/shuttle/ftl/engine/break_room)
-"uz" = (
+/area/shuttle/ftl/engine/engine_smes)
+"wj" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -10008,7 +12036,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"uA" = (
+"wk" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -10024,7 +12052,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"uB" = (
+"wl" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -10044,7 +12072,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"uC" = (
+"wm" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -10059,7 +12087,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"uD" = (
+"wn" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
 	name = "engineering security door"
@@ -10071,11 +12099,11 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
-"uE" = (
+"wo" = (
 /obj/machinery/ftl_drive,
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engineering)
-"uF" = (
+"wp" = (
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 4
@@ -10089,7 +12117,13 @@
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engineering)
-"uG" = (
+"wq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/engineering)
+"wr" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -10108,7 +12142,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"uI" = (
+"ws" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start{
+	name = "Assistant"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=FP";
+	location = "AFT"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"wt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 4;
@@ -10126,7 +12177,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"uJ" = (
+"wu" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -10138,7 +12189,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"uK" = (
+"wv" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -10150,7 +12201,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"uL" = (
+"ww" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -10162,7 +12213,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"uM" = (
+"wx" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -10174,7 +12225,27 @@
 	name = "floor"
 	},
 /area/shuttle/ftl/hallway/primary/central)
-"uO" = (
+"wy" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	layer = 2.9;
+	name = "bridge blast door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge)
+"wz" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -10197,31 +12268,110 @@
 	name = "floor"
 	},
 /area/shuttle/ftl/bridge)
-"uP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+"wA" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-8";
+	pixel_y = 0
 	},
-/turf/open/floor/plasteel/yellow/side,
-/area/shuttle/ftl/engine/break_room)
-"uQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = -24
+/turf/open/floor/plasteel{
+	icon_state = "L1"
+	},
+/area/shuttle/ftl/bridge)
+"wB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L3"
+	},
+/area/shuttle/ftl/bridge)
+"wC" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
 	},
 /obj/structure/cable{
 	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
 	},
-/turf/open/floor/plasteel/yellow/side,
-/area/shuttle/ftl/engine/break_room)
-"uU" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel{
+	icon_state = "L5"
+	},
+/area/shuttle/ftl/bridge)
+"wD" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel{
+	icon_state = "L7"
+	},
+/area/shuttle/ftl/bridge)
+"wE" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L9"
+	},
+/area/shuttle/ftl/bridge)
+"wF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L11"
+	},
+/area/shuttle/ftl/bridge)
+"wG" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	desc = "";
+	icon_state = "L13";
+	name = "floor"
+	},
+/area/shuttle/ftl/bridge)
+"wH" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -10238,7 +12388,7 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
-"uV" = (
+"wI" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -10249,7 +12399,7 @@
 	},
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge)
-"uW" = (
+"wJ" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
@@ -10265,15 +12415,15 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
-"uX" = (
+"wK" = (
 /obj/machinery/computer/communications,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
-"uY" = (
+"wL" = (
 /obj/machinery/hologram/holopad,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
-"uZ" = (
+"wM" = (
 /obj/structure/chair{
 	dir = 4
 	},
@@ -10282,13 +12432,13 @@
 	dir = 4
 	},
 /area/shuttle/ftl/bridge)
-"va" = (
+"wN" = (
 /obj/machinery/computer/ftl_navigation{
 	req_access_txt = "46"
 	},
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge)
-"vb" = (
+"wO" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
@@ -10307,14 +12457,14 @@
 	dir = 1
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"vc" = (
+"wP" = (
 /turf/open/floor/plasteel/darkwarning{
 	tag = "icon-black_warn (NORTH)";
 	icon_state = "black_warn";
 	dir = 1
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"vd" = (
+"wQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	external_pressure_bound = 100;
 	frequency = 1438;
@@ -10328,7 +12478,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"ve" = (
+"wR" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel/warning{
 	tag = "icon-plasteel_warn (NORTHWEST)";
@@ -10336,7 +12486,7 @@
 	dir = 9
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"vf" = (
+"wS" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
@@ -10350,7 +12500,25 @@
 	dir = 1
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"vh" = (
+"wT" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/warning/corner{
+	dir = 4
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"wU" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
@@ -10360,7 +12528,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"vi" = (
+"wV" = (
 /obj/effect/landmark/start{
 	name = "Station Engineer";
 	shuttle_abstract_movable = 1
@@ -10370,7 +12538,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"vj" = (
+"wW" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
@@ -10383,14 +12551,14 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engine_smes)
-"vk" = (
+"wX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"vl" = (
+"wY" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
 	},
@@ -10398,7 +12566,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/engine/engineering)
-"vm" = (
+"wZ" = (
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	tag = "icon-dvalve_map (EAST)";
 	icon_state = "dvalve_map";
@@ -10406,7 +12574,7 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engineering)
-"vn" = (
+"xa" = (
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2";
@@ -10415,7 +12583,7 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engineering)
-"vo" = (
+"xb" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
 	},
@@ -10425,7 +12593,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engineering)
-"vp" = (
+"xc" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -10440,7 +12608,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"vq" = (
+"xd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -10449,7 +12617,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"vr" = (
+"xe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -10459,7 +12627,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"vs" = (
+"xf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -10468,7 +12636,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"vt" = (
+"xg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -10481,7 +12649,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"vu" = (
+"xh" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -10491,7 +12659,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"vv" = (
+"xi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -10506,7 +12674,7 @@
 	name = "floor"
 	},
 /area/shuttle/ftl/hallway/primary/central)
-"vw" = (
+"xj" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Command Access";
 	req_one_access_txt = "12;35"
@@ -10519,7 +12687,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge)
-"vx" = (
+"xk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -10536,23 +12704,93 @@
 	name = "floor"
 	},
 /area/shuttle/ftl/bridge)
-"vz" = (
-/obj/structure/table,
-/obj/item/weapon/crowbar,
-/obj/item/weapon/wrench,
-/obj/item/device/multitool,
-/obj/item/clothing/ears/earmuffs,
-/turf/open/floor/plasteel/warning{
-	tag = "icon-plasteel_warn (NORTH)";
-	icon_state = "plasteel_warn";
+"xl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L2"
+	},
+/area/shuttle/ftl/bridge)
+"xm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Bridge Access";
 	dir = 1
 	},
-/area/shuttle/ftl/munitions)
-"vA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/break_room)
-"vF" = (
+/turf/open/floor/plasteel{
+	icon_state = "L4"
+	},
+/area/shuttle/ftl/bridge)
+"xn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L6"
+	},
+/area/shuttle/ftl/bridge)
+"xo" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L8"
+	},
+/area/shuttle/ftl/bridge)
+"xp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel{
+	icon_state = "L10"
+	},
+/area/shuttle/ftl/bridge)
+"xq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L12"
+	},
+/area/shuttle/ftl/bridge)
+"xr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	desc = "";
+	icon_state = "L14"
+	},
+/area/shuttle/ftl/bridge)
+"xs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -10563,18 +12801,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge)
-"vG" = (
+"xt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 8
 	},
 /turf/open/floor/plasteel/darkblue/side,
 /area/shuttle/ftl/bridge)
-"vH" = (
+"xu" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"xv" = (
 /obj/structure/table/reinforced,
 /obj/item/device/radio/intercom,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge)
-"vI" = (
+"xw" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor{
@@ -10582,7 +12828,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
-"vJ" = (
+"xx" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -10591,13 +12837,22 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
-"vK" = (
-/obj/structure/window/reinforced,
+"xy" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 1;
+	filter_type = "plasma";
+	on = 1
+	},
+/obj/machinery/button/massdriver{
+	id = "supermatter_eject";
+	pixel_x = -24;
+	pixel_y = 8
+	},
 /turf/open/floor/plasteel/warning{
-	dir = 1
+	dir = 8
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"vL" = (
+"xz" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -10612,29 +12867,21 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"vM" = (
-/obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (WEST)";
-	icon_state = "pipe-c";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+"xA" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	tag = "icon-intact (WEST)";
+	icon_state = "intact";
+	dir = 8;
+	color = "#444444"
 	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/bar)
-"vN" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"xB" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	tag = "icon-intact (WEST)";
 	icon_state = "intact";
@@ -10644,7 +12891,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"vO" = (
+"xC" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	color = "#444444";
 	dir = 10;
@@ -10654,7 +12901,16 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"vP" = (
+"xD" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/engine_smes)
+"xE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -10663,7 +12919,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"vQ" = (
+"xF" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -10684,7 +12940,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"vR" = (
+"xG" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -10694,7 +12950,7 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engineering)
-"vS" = (
+"xH" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -10716,7 +12972,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engineering)
-"vT" = (
+"xI" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -10728,7 +12984,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/engine/engineering)
-"vU" = (
+"xJ" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -10738,12 +12994,12 @@
 	dir = 1
 	},
 /area/shuttle/ftl/engine/engineering)
-"vV" = (
+"xK" = (
 /turf/open/floor/plasteel/darkwarning{
 	dir = 1
 	},
 /area/shuttle/ftl/engine/engineering)
-"vW" = (
+"xL" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
@@ -10754,19 +13010,35 @@
 	dir = 4
 	},
 /area/shuttle/ftl/engine/engineering)
-"vX" = (
+"xM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"vY" = (
+"xN" = (
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/heads)
-"vZ" = (
+"xO" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/heads)
-"wb" = (
+"xP" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	layer = 2.9;
+	name = "bridge blast door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge)
+"xQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -10782,7 +13054,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge)
-"wc" = (
+"xR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -10793,7 +13065,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge)
-"wd" = (
+"xS" = (
 /obj/structure/chair,
 /obj/machinery/airalarm{
 	dir = 4;
@@ -10810,22 +13082,76 @@
 	},
 /turf/open/floor/plasteel/darkblue/side,
 /area/shuttle/ftl/bridge)
-"we" = (
+"xT" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/darkblue/side,
 /area/shuttle/ftl/bridge)
-"wf" = (
+"xU" = (
+/turf/open/floor/plasteel/darkblue/side,
+/area/shuttle/ftl/bridge)
+"xV" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/bo/weapons,
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 6
 	},
 /area/shuttle/ftl/bridge)
-"wg" = (
+"xW" = (
 /obj/structure/table/reinforced,
 /obj/item/device/aicard,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge)
-"wl" = (
+"xX" = (
+/obj/structure/window/reinforced,
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"xY" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/warning{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"xZ" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/meter,
+/turf/open/floor/plasteel/warning{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"ya" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 6
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel/warning{
+	dir = 1
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"yb" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/warning/corner{
+	dir = 4
+	},
+/area/shuttle/ftl/engine/engine_smes)
+"yc" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
@@ -10836,7 +13162,45 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"wn" = (
+"yd" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"ye" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"yf" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	color = "#444444"
+	},
+/obj/machinery/computer/pmanagement,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"yg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"yh" = (
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 4
@@ -10853,10 +13217,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"wo" = (
+"yi" = (
 /turf/closed/wall,
 /area/shuttle/ftl/bridge/meeting_room)
-"wp" = (
+"yj" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -10869,7 +13233,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"wq" = (
+"yk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
@@ -10878,14 +13242,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"wr" = (
+"yl" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/bridge/meeting_room)
-"ws" = (
+"ym" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge)
-"wt" = (
+"yn" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/firstaid/regular,
 /obj/structure/cable{
@@ -10895,19 +13259,19 @@
 	},
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge)
-"wu" = (
+"yo" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
 /obj/item/weapon/storage/fancy/donut_box,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge)
-"wv" = (
+"yp" = (
 /obj/machinery/computer/ftl_weapons{
 	req_access_txt = "45"
 	},
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge)
-"wx" = (
+"yq" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -10916,7 +13280,7 @@
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"wy" = (
+"yr" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -10926,13 +13290,13 @@
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"wz" = (
+"ys" = (
 /obj/machinery/atmospherics/components/binary/circulator{
 	dir = 2
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"wA" = (
+"yt" = (
 /obj/machinery/power/generator{
 	cold_dir = 4;
 	hot_dir = 8
@@ -10941,7 +13305,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"wB" = (
+"yu" = (
 /obj/machinery/atmospherics/components/binary/circulator{
 	dir = 2;
 	icon_state = "circ2-off";
@@ -10949,13 +13313,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"wD" = (
+"yv" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6;
+	initialize_directions = 6
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"yw" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"wE" = (
+"yx" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
@@ -10963,13 +13339,13 @@
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/engine/engine_smes)
-"wF" = (
+"yy" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"wG" = (
+"yz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -10982,11 +13358,39 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"wH" = (
+"yA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/delivery,
 /area/shuttle/ftl/hallway/primary/central)
-"wJ" = (
+"yB" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/northleft{
+	dir = 8;
+	icon_state = "left";
+	name = "Reception Window";
+	req_access_txt = "0"
+	},
+/obj/machinery/door/window/brigdoor{
+	base_state = "rightsecure";
+	dir = 4;
+	icon_state = "rightsecure";
+	name = "Head of Personnel's Desk";
+	req_access = null;
+	req_access_txt = "30"
+	},
+/obj/machinery/flasher{
+	id = "hopflash";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hop";
+	layer = 2.9;
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/heads)
+"yC" = (
 /obj/machinery/button/flasher{
 	id = "hopflash";
 	pixel_x = 6;
@@ -11013,7 +13417,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/heads)
-"wK" = (
+"yD" = (
 /obj/machinery/power/apc{
 	auto_name = 1;
 	dir = 1;
@@ -11026,12 +13430,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/heads)
-"wM" = (
+"yE" = (
+/obj/machinery/pdapainter,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/machinery/light_switch{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/machinery/requests_console{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/heads)
+"yF" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/bridge/meeting_room)
-"wN" = (
+"yG" = (
 /obj/machinery/door/airlock/command{
 	name = "Conference Room";
 	req_access = null;
@@ -11046,7 +13468,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"wO" = (
+"yH" = (
 /obj/machinery/door/airlock/command{
 	name = "Conference Room";
 	req_access = null;
@@ -11056,17 +13478,45 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"wP" = (
+"yI" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	layer = 2.9;
+	name = "bridge blast door"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge)
+"yJ" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
+	name = "KEEP CLEAR: DOCKING AREA";
+	pixel_y = 0
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/shuttle/ftl/munitions/cannon)
+"yK" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/shuttle/ftl/munitions/cannon)
+"yL" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"wQ" = (
+"yM" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"wR" = (
+"yN" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 4;
@@ -11076,12 +13526,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"wS" = (
+"yO" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"wU" = (
+"yP" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"yQ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	tag = "icon-pump_map (WEST)";
 	icon_state = "pump_map";
@@ -11089,14 +13548,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"wV" = (
+"yR" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	icon_state = "connector_map";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"wW" = (
+"yS" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -11106,7 +13565,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"wX" = (
+"yT" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
 	name = "engineering security door"
@@ -11118,7 +13577,7 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
-"wY" = (
+"yU" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -11131,11 +13590,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"wZ" = (
+"yV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/bot,
 /area/shuttle/ftl/hallway/primary/central)
-"xa" = (
+"yW" = (
 /obj/structure/grille,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hop";
@@ -11154,7 +13613,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/heads)
-"xb" = (
+"yX" = (
 /obj/machinery/computer/card,
 /obj/structure/cable{
 	d1 = 4;
@@ -11163,7 +13622,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/heads)
-"xc" = (
+"yY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 4
 	},
@@ -11179,7 +13638,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/heads)
-"xd" = (
+"yZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -11190,7 +13649,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/heads)
-"xe" = (
+"za" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
 	req_access = null;
@@ -11206,7 +13665,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/heads)
-"xf" = (
+"zb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -11217,7 +13676,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"xg" = (
+"zc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -11233,7 +13692,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"xh" = (
+"zd" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -11248,7 +13707,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"xi" = (
+"ze" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
 	},
@@ -11259,7 +13718,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"xj" = (
+"zf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -11273,7 +13732,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"xk" = (
+"zg" = (
 /obj/structure/disposalpipe/segment{
 	tag = "icon-pipe-c";
 	icon_state = "pipe-c";
@@ -11281,17 +13740,46 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"xl" = (
+"zh" = (
 /obj/structure/closet/emcloset,
 /obj/item/device/radio/intercom{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"xm" = (
+"zi" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/turret_protected/ai)
-"xn" = (
+"zj" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/space,
+/area/shuttle/ftl/munitions/cannon)
+"zk" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/shuttle/ftl/munitions/cannon)
+"zl" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/space,
+/area/shuttle/ftl/munitions/cannon)
+"zm" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	d1 = 2;
@@ -11306,7 +13794,7 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/munitions/cannon)
-"xp" = (
+"zn" = (
 /obj/machinery/power/shipweapon{
 	anchored = 1;
 	dir = 4;
@@ -11318,14 +13806,17 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/ftl/munitions/cannon)
-"xq" = (
+"zo" = (
 /turf/open/floor/plasteel/warning{
 	tag = "icon-plasteel_warn (EAST)";
 	icon_state = "plasteel_warn";
 	dir = 4
 	},
 /area/shuttle/ftl/munitions/cannon)
-"xr" = (
+"zp" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"zq" = (
 /obj/effect/landmark/start{
 	name = "Station Engineer";
 	shuttle_abstract_movable = 1
@@ -11333,7 +13824,7 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"xs" = (
+"zr" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 5
 	},
@@ -11343,7 +13834,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"xt" = (
+"zs" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
@@ -11358,7 +13849,39 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"xv" = (
+"zt" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"zu" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	tag = "icon-pump_map (WEST)";
+	icon_state = "pump_map";
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engine_smes)
+"zv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
@@ -11371,11 +13894,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"xw" = (
+"zw" = (
 /obj/machinery/gravity_generator/main/station,
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engineering)
-"xx" = (
+"zx" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"zy" = (
 /obj/structure/grille,
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -11392,20 +13928,20 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/heads)
-"xy" = (
+"zz" = (
 /obj/structure/table,
 /obj/machinery/recharger,
 /turf/open/floor/plasteel/blue/side{
 	dir = 9
 	},
 /area/shuttle/ftl/crew_quarters/heads)
-"xz" = (
+"zA" = (
 /mob/living/simple_animal/pet/dog/corgi/Ian{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/heads)
-"xA" = (
+"zB" = (
 /obj/machinery/airalarm{
 	dir = 8;
 	icon_state = "alarm0";
@@ -11417,20 +13953,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/heads)
-"xB" = (
+"zC" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"xC" = (
+"zD" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"xD" = (
+"zE" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/bridge/meeting_room)
-"xE" = (
+"zF" = (
 /obj/structure/table/wood,
 /obj/item/weapon/storage/fancy/donut_box,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11447,7 +13983,7 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/bridge/meeting_room)
-"xF" = (
+"zG" = (
 /obj/structure/table/wood,
 /obj/item/device/paicard,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -11458,7 +13994,7 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/bridge/meeting_room)
-"xG" = (
+"zH" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
@@ -11469,7 +14005,7 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/bridge/meeting_room)
-"xH" = (
+"zI" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -11478,7 +14014,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"xI" = (
+"zJ" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
 /obj/machinery/power/apc{
@@ -11493,10 +14029,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"xJ" = (
+"zK" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/munitions/cannon)
-"xK" = (
+"zL" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	d1 = 1;
@@ -11509,7 +14045,77 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/munitions/cannon)
-"xL" = (
+"zM" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
+	name = "KEEP CLEAR: DOCKING AREA";
+	pixel_y = 0
+	},
+/turf/open/space,
+/area/shuttle/ftl/munitions/cannon)
+"zN" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/space)
+"zO" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/space)
+"zP" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/space)
+"zQ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/space)
+"zR" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/space)
+"zS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
@@ -11523,20 +14129,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"xM" = (
+"zT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/atmos)
-"xN" = (
+"zU" = (
 /obj/structure/sign/securearea,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/atmos)
-"xO" = (
+"zV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -11556,10 +14162,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"xP" = (
+"zW" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/atmos)
-"xQ" = (
+"zX" = (
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -11570,7 +14176,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engineering)
-"xR" = (
+"zY" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator";
 	dir = 1
@@ -11579,13 +14185,13 @@
 	dir = 1
 	},
 /area/shuttle/ftl/engine/engineering)
-"xS" = (
+"zZ" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/darkwarning{
 	dir = 1
 	},
 /area/shuttle/ftl/engine/engineering)
-"xT" = (
+"Aa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 4
 	},
@@ -11595,27 +14201,38 @@
 	dir = 4
 	},
 /area/shuttle/ftl/engine/engineering)
-"xU" = (
+"Ab" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"Ac" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
 	sortType = 15
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"xV" = (
+"Ad" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/bot,
 /area/shuttle/ftl/hallway/primary/central)
-"xW" = (
+"Ae" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/heads)
-"xX" = (
+"Af" = (
 /obj/structure/table,
 /obj/item/weapon/book/manual/wiki/security_space_law,
 /obj/item/weapon/folder/blue,
@@ -11625,7 +14242,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/heads)
-"xY" = (
+"Ag" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -11635,7 +14252,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/heads)
-"xZ" = (
+"Ah" = (
 /obj/structure/closet/secure_closet/hop,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station,
 /obj/item/device/radio/intercom{
@@ -11643,14 +14260,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/heads)
-"ya" = (
+"Ai" = (
 /obj/machinery/vending/snack,
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"yb" = (
+"Aj" = (
 /obj/structure/table/wood,
 /obj/effect/holodeck_effect/cards,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11662,22 +14279,22 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/bridge/meeting_room)
-"yc" = (
+"Ak" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/bridge/meeting_room)
-"yd" = (
+"Al" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/bridge/meeting_room)
-"ye" = (
+"Am" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"yf" = (
+"An" = (
 /obj/structure/table/wood,
 /obj/item/weapon/book/manual/wiki/security_space_law,
 /obj/machinery/light{
@@ -11690,13 +14307,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"yg" = (
+"Ao" = (
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/shuttle/ftl/turret_protected/ai)
-"yh" = (
+"Ap" = (
 /obj/machinery/airalarm{
 	frequency = 1439;
 	locked = 1;
@@ -11704,13 +14321,39 @@
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
-"yk" = (
+"Aq" = (
+/obj/machinery/camera/motion{
+	c_tag = "AI Chamber North";
+	network = list("SS13","MiniSat");
+	pixel_x = 0
+	},
+/obj/structure/rack,
+/obj/item/weapon/aiModule/core/freeformcore,
+/obj/item/weapon/aiModule/core/full/asimov{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/circuit,
+/area/shuttle/ftl/turret_protected/ai)
+"Ar" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/weapon/aiModule/core/full/corp,
+/obj/item/weapon/aiModule/reset{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/circuit,
+/area/shuttle/ftl/turret_protected/ai)
+"As" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
-"yl" = (
+"At" = (
 /obj/machinery/porta_turret/ai{
 	dir = 8
 	},
@@ -11718,7 +14361,7 @@
 	icon_state = "dark"
 	},
 /area/shuttle/ftl/turret_protected/ai)
-"ym" = (
+"Au" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	d1 = 1;
@@ -11731,11 +14374,62 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/munitions/cannon)
-"yn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+"Av" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/shuttle/ftl/munitions/cannon)
+"Aw" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
 /turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"yo" = (
+/area/shuttle/ftl/space)
+"Ax" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/nuke_storage)
+"Ay" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/nuke_storage)
+"Az" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/space)
+"AA" = (
+/obj/structure/shuttle/engine/heater{
+	icon_state = "heater";
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/ftl/atmos)
+"AB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"AC" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/heater,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"AD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 2;
 	external_pressure_bound = 0;
@@ -11757,7 +14451,7 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/shuttle/ftl/atmos)
-"yp" = (
+"AE" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "n2o_sensor"
@@ -11770,7 +14464,7 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/engine/n2o,
 /area/shuttle/ftl/atmos)
-"yq" = (
+"AF" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 2;
 	frequency = 1441;
@@ -11787,7 +14481,7 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/shuttle/ftl/atmos)
-"yr" = (
+"AG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 2;
 	external_pressure_bound = 0;
@@ -11809,7 +14503,7 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/shuttle/ftl/atmos)
-"ys" = (
+"AH" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "tox_sensor"
@@ -11822,7 +14516,7 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/engine/plasma,
 /area/shuttle/ftl/atmos)
-"yt" = (
+"AI" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 2;
 	frequency = 1441;
@@ -11839,7 +14533,7 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/shuttle/ftl/atmos)
-"yu" = (
+"AJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 2;
 	external_pressure_bound = 0;
@@ -11861,7 +14555,7 @@
 	},
 /turf/open/floor/engine/co2,
 /area/shuttle/ftl/atmos)
-"yv" = (
+"AK" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "co2_sensor"
@@ -11874,7 +14568,7 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/engine/co2,
 /area/shuttle/ftl/atmos)
-"yw" = (
+"AL" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 2;
 	frequency = 1441;
@@ -11891,7 +14585,7 @@
 	},
 /turf/open/floor/engine/co2,
 /area/shuttle/ftl/atmos)
-"yx" = (
+"AM" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
 	name = "atmos blast door"
@@ -11908,24 +14602,24 @@
 	name = "floor"
 	},
 /area/shuttle/ftl/atmos)
-"yy" = (
+"AN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/loadingarea{
 	dir = 1
 	},
 /area/shuttle/ftl/hallway/primary/central)
-"yz" = (
+"AO" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/toilet)
-"yA" = (
+"AP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/toilet)
-"yB" = (
+"AQ" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"yC" = (
+"AR" = (
 /obj/machinery/airalarm{
 	dir = 1;
 	icon_state = "alarm0";
@@ -11933,14 +14627,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"yD" = (
+"AS" = (
 /obj/machinery/camera{
 	c_tag = "Conference Room";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"yE" = (
+"AT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -11950,19 +14644,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"yF" = (
+"AU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"yG" = (
+"AV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"yH" = (
+"AW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 8
 	},
@@ -11972,26 +14666,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"yI" = (
+"AX" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/meeting_room)
-"yJ" = (
+"AY" = (
 /obj/machinery/computer/upload/ai,
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
-"yK" = (
+"AZ" = (
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
-"yL" = (
+"Ba" = (
 /turf/open/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/shuttle/ftl/turret_protected/ai)
-"yM" = (
+"Bb" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	d1 = 1;
@@ -12000,20 +14694,167 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/munitions/cannon)
-"yN" = (
-/turf/open/floor/plasteel/bot,
-/area/shuttle/ftl/munitions)
-"yO" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1
+"Bc" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/structure/window/reinforced{
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/space)
+"Bd" = (
+/obj/structure/closet/secure_closet/freezer/money,
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
+/area/shuttle/ftl/security/nuke_storage)
+"Be" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/nuclearbomb/selfdestruct,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/nuke_storage)
+"Bf" = (
+/obj/structure/filingcabinet/security,
+/obj/item/weapon/folder/documents,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/nuke_storage)
+"Bg" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"yS" = (
+/area/shuttle/ftl/atmos)
+"Bh" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel/escape{
+	dir = 9
+	},
+/area/shuttle/ftl/atmos)
+"Bi" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/machinery/computer/atmos_control/tank{
+	frequency = 1441;
+	input_tag = "n2o_in";
+	name = "Nitrous Oxide Supply Control";
+	output_tag = "n2o_out";
+	sensors = list("n2o_sensor" = "Tank")
+	},
+/turf/open/floor/plasteel/escape{
+	dir = 1
+	},
+/area/shuttle/ftl/atmos)
+"Bj" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel/escape{
+	dir = 5
+	},
+/area/shuttle/ftl/atmos)
+"Bk" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel/warning{
+	dir = 9
+	},
+/area/shuttle/ftl/atmos)
+"Bl" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/machinery/computer/atmos_control/tank{
+	frequency = 1441;
+	input_tag = "tox_in";
+	name = "Plasma Supply Control";
+	output_tag = "tox_out";
+	sensors = list("tox_sensor" = "Tank")
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 1
+	},
+/area/shuttle/ftl/atmos)
+"Bm" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel/warning{
+	dir = 5
+	},
+/area/shuttle/ftl/atmos)
+"Bn" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 9
+	},
+/area/shuttle/ftl/atmos)
+"Bo" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/machinery/computer/atmos_control/tank{
+	frequency = 1441;
+	input_tag = "co2_in";
+	name = "Carbon Dioxide Supply Control";
+	output_tag = "co2_out";
+	sensors = list("co2_sensor" = "Tank")
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/shuttle/ftl/atmos)
+"Bp" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 5
+	},
+/area/shuttle/ftl/atmos)
+"Bq" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -12029,7 +14870,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"yT" = (
+"Br" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -12041,7 +14882,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"yV" = (
+"Bs" = (
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/item/device/pipe_painter,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"Bt" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/item/device/radio/intercom{
 	pixel_x = 0;
@@ -12050,21 +14896,33 @@
 /obj/item/device/pipe_painter,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"yW" = (
+"Bu" = (
 /obj/machinery/pipedispenser,
 /obj/machinery/camera{
 	c_tag = "Atmospherics Storage"
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"yX" = (
+"Bv" = (
 /obj/machinery/pipedispenser/disposal,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"yY" = (
+"Bw" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"Bx" = (
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/toilet)
-"yZ" = (
+"By" = (
 /obj/structure/toilet{
 	pixel_y = 8
 	},
@@ -12076,13 +14934,13 @@
 	icon_state = "freezerfloor"
 	},
 /area/shuttle/ftl/crew_quarters/toilet)
-"za" = (
+"Bz" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/captain)
-"zb" = (
+"BA" = (
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/captain)
-"zc" = (
+"BB" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
 	req_access = null;
@@ -12097,7 +14955,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/captain)
-"zd" = (
+"BC" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
 	req_access = null;
@@ -12105,35 +14963,52 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/captain)
-"ze" = (
+"BD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/captain)
-"zf" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+"BE" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
 /obj/structure/cable{
-	d1 = 1;
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "captains_shutters";
+	name = "Captains Office"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/captain)
+"BF" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
 	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"zg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	name = "south bump";
-	pixel_y = -24
+	icon_state = "0-2";
+	pixel_y = 0
 	},
 /obj/structure/cable{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/yellow/side,
-/area/shuttle/ftl/engine/break_room)
-"zi" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "captains_shutters";
+	name = "Captains Office"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/captain)
+"BG" = (
+/obj/structure/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio3";
+	name = "containment blast door"
+	},
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/engine,
+/area/shuttle/ftl/turret_protected/ai)
+"BH" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -12142,7 +15017,7 @@
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
-"zj" = (
+"BI" = (
 /obj/machinery/door/window{
 	dir = 1;
 	name = "AI Core Door";
@@ -12152,27 +15027,71 @@
 	icon_state = "dark"
 	},
 /area/shuttle/ftl/turret_protected/ai)
-"zk" = (
+"BJ" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
-"zl" = (
+"BK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/machinery/camera{
+	c_tag = "Vault";
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 1
+	},
+/area/shuttle/ftl/security/nuke_storage)
+"BL" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/turf/open/floor/plasteel/vault,
+/area/shuttle/ftl/security/nuke_storage)
+"BM" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 1
+	},
+/area/shuttle/ftl/security/nuke_storage)
+"BN" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"zm" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"BO" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	tag = "icon-pump_map (WEST)";
 	icon_state = "pump_map";
 	dir = 8
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"zn" = (
+"BP" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	tag = "icon-intact (EAST)";
 	icon_state = "intact";
@@ -12181,7 +15100,7 @@
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"zo" = (
+"BQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	tag = "icon-intact (EAST)";
 	icon_state = "intact";
@@ -12189,7 +15108,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"zp" = (
+"BR" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 8;
 	filter_type = "n2o";
@@ -12199,7 +15118,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"zq" = (
+"BS" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 8;
 	filter_type = "plasma";
@@ -12209,7 +15128,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"zr" = (
+"BT" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 8;
 	filter_type = "co2";
@@ -12219,7 +15138,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"zs" = (
+"BU" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	tag = "icon-intact (SOUTHWEST)";
 	icon_state = "intact";
@@ -12238,18 +15157,88 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"zw" = (
-/obj/structure/window/reinforced,
+"BV" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 28;
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"BW" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Equipment";
+	req_access_txt = "15"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"BX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -26;
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"BY" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"BZ" = (
 /obj/machinery/airalarm{
-	dir = 4;
+	dir = 8;
 	icon_state = "alarm0";
-	pixel_x = -22
+	pixel_x = 24
 	},
-/turf/open/floor/plasteel/warning{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
 	},
-/area/shuttle/ftl/engine/engine_smes)
-"zy" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"Ca" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -12261,20 +15250,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"zz" = (
+"Cb" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"zA" = (
+"Cc" = (
 /obj/structure/mirror{
 	pixel_y = 4
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/toilet)
-"zB" = (
+"Cd" = (
 /obj/machinery/door/airlock{
 	name = "Unit 1"
 	},
@@ -12283,14 +15272,14 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/crew_quarters/toilet)
-"zC" = (
+"Ce" = (
 /obj/structure/closet/secure_closet/captains,
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/captain)
-"zD" = (
+"Cf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 4
 	},
@@ -12302,7 +15291,7 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/captain)
-"zE" = (
+"Cg" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
 	req_access = null;
@@ -12313,7 +15302,7 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
-"zF" = (
+"Ch" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -12328,7 +15317,7 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
-"zG" = (
+"Ci" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -12340,7 +15329,7 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
-"zH" = (
+"Cj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -12361,7 +15350,7 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
-"zI" = (
+"Ck" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -12373,7 +15362,7 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
-"zJ" = (
+"Cl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -12399,7 +15388,7 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
-"zK" = (
+"Cm" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Core Access";
 	req_access_txt = "44"
@@ -12417,7 +15406,7 @@
 	icon_state = "dark"
 	},
 /area/shuttle/ftl/turret_protected/ai)
-"zL" = (
+"Cn" = (
 /obj/machinery/door/window{
 	base_state = "right";
 	dir = 4;
@@ -12438,7 +15427,7 @@
 	icon_state = "dark"
 	},
 /area/shuttle/ftl/turret_protected/ai)
-"zM" = (
+"Co" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
 	},
@@ -12452,7 +15441,7 @@
 	icon_state = "dark"
 	},
 /area/shuttle/ftl/turret_protected/ai)
-"zN" = (
+"Cp" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -12463,7 +15452,7 @@
 	icon_state = "dark"
 	},
 /area/shuttle/ftl/turret_protected/ai)
-"zO" = (
+"Cq" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -12480,7 +15469,7 @@
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
-"zP" = (
+"Cr" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -12489,7 +15478,7 @@
 	},
 /turf/open/floor/plasteel/darkwarning,
 /area/shuttle/ftl/turret_protected/ai)
-"zQ" = (
+"Cs" = (
 /obj/machinery/flasher{
 	id = "AI";
 	pixel_x = -11;
@@ -12511,33 +15500,149 @@
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
-"zR" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+"Ct" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/space)
+"Cu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/nuke_storage)
+"Cv" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/closet/crate,
+/obj/item/weapon/coin/silver{
+	pixel_x = -4;
+	pixel_y = -4;
+	pixel_z = 0
+	},
+/obj/item/weapon/coin/silver{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/weapon/coin/silver{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/coin/silver{
+	pixel_x = 4
+	},
+/obj/item/weapon/coin/silver,
+/obj/item/stack/sheet/mineral/gold{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/mineral/gold,
+/obj/item/stack/sheet/mineral/gold{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/weapon/storage/belt/champion,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/nuke_storage)
+"Cw" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/vault,
+/area/shuttle/ftl/security/nuke_storage)
+"Cx" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/safe,
+/obj/item/clothing/head/bearpelt,
+/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/weapon/gun/projectile/revolver/russian,
+/obj/item/ammo_box/a357,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka/badminka,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/nuke_storage)
+"Cy" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/space)
+"Cz" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"zS" = (
+"CA" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 1
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"zT" = (
+"CB" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"zU" = (
+"CC" = (
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"zV" = (
+"CD" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	tag = "icon-manifold (NORTH)";
 	icon_state = "manifold";
@@ -12545,11 +15650,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"zW" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"zX" = (
+"CE" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	tag = "icon-intact (SOUTHWEST)";
 	icon_state = "intact";
@@ -12557,7 +15658,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"zY" = (
+"CF" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -12567,15 +15668,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"zZ" = (
+"CG" = (
+/obj/structure/table,
+/obj/item/weapon/tank/internals/emergency_oxygen{
+	pixel_x = -8;
+	pixel_y = 0
+	},
+/obj/item/weapon/tank/internals/emergency_oxygen{
+	pixel_x = -8;
+	pixel_y = 0
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"Aa" = (
+"CH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/atmos)
-"Ab" = (
+"CI" = (
 /obj/structure/table,
 /obj/item/clothing/head/welding{
 	pixel_x = -3;
@@ -12591,7 +15710,7 @@
 /obj/item/device/multitool,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"Ac" = (
+"CJ" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass{
@@ -12612,7 +15731,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"Ad" = (
+"CK" = (
 /obj/structure/rack{
 	dir = 8;
 	layer = 2.9
@@ -12628,14 +15747,32 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"Af" = (
+"CL" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"CM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"Ag" = (
+"CN" = (
 /obj/structure/sink{
 	pixel_y = 20
 	},
@@ -12647,7 +15784,7 @@
 	icon_state = "freezerfloor"
 	},
 /area/shuttle/ftl/crew_quarters/toilet)
-"Ah" = (
+"CO" = (
 /obj/structure/urinal{
 	pixel_y = 32
 	},
@@ -12656,7 +15793,7 @@
 	icon_state = "freezerfloor"
 	},
 /area/shuttle/ftl/crew_quarters/toilet)
-"Ai" = (
+"CP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
@@ -12671,20 +15808,20 @@
 	icon_state = "freezerfloor"
 	},
 /area/shuttle/ftl/crew_quarters/toilet)
-"Aj" = (
+"CQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/captain)
-"Ak" = (
+"CR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
 /obj/machinery/suit_storage_unit/captain,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/captain)
-"Al" = (
+"CS" = (
 /obj/item/weapon/storage/secure/safe{
 	pixel_x = 35;
 	pixel_y = 5
@@ -12698,7 +15835,7 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/captain)
-"Am" = (
+"CT" = (
 /obj/structure/displaycase/captain,
 /obj/structure/cable{
 	d1 = 1;
@@ -12708,19 +15845,26 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
-"An" = (
+"CU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
-"Ao" = (
+"CV" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp/green,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
-"Aq" = (
+"CW" = (
+/obj/item/weapon/card/id/captains_spare,
+/obj/structure/table/wood,
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/stamp/captain,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/captain)
+"CX" = (
 /obj/structure/table/wood,
 /obj/item/weapon/storage/box/matches,
 /obj/item/clothing/mask/cigarette/cigar,
@@ -12736,7 +15880,7 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
-"Ar" = (
+"CY" = (
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	freerange = 1;
@@ -12778,7 +15922,22 @@
 	},
 /turf/open/floor/bluegrid,
 /area/shuttle/ftl/turret_protected/ai)
-"At" = (
+"CZ" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access = null;
+	req_access_txt = "7;9"
+	},
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/ftl/munitions/cannon)
+"Da" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
@@ -12788,37 +15947,62 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/munitions/cannon)
-"Au" = (
+"Db" = (
+/obj/structure/cable,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/space)
+"Dc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/shuttle/ftl/maintenance/engineering)
-"Av" = (
+/area/shuttle/ftl/security/nuke_storage)
+"Dd" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/vault{
+	icon_state = "closed";
+	locked = 1;
+	req_access_txt = "13"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/ftl/security/nuke_storage)
+"De" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"Aw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
 /obj/machinery/camera{
 	c_tag = "Atmospherics West";
 	dir = 4
 	},
-/obj/structure/fireaxecabinet{
-	pixel_x = -31
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+/obj/item/device/radio/intercom{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"Ax" = (
+"Df" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"Dg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"Dh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	icon_state = "intact";
 	dir = 10
@@ -12828,14 +16012,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"Ay" = (
+"Di" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 6;
 	initialize_directions = 6
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"Az" = (
+"Dj" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	icon_state = "intact";
 	dir = 8
@@ -12847,7 +16031,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"AA" = (
+"Dk" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 4;
 	icon_state = "mixer_off";
@@ -12858,14 +16042,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"AB" = (
+"Dl" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	icon_state = "intact";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"AC" = (
+"Dm" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	tag = "icon-intact (SOUTHEAST)";
 	icon_state = "intact";
@@ -12873,7 +16057,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"AD" = (
+"Dn" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	tag = "icon-intact (EAST)";
 	icon_state = "intact";
@@ -12886,7 +16070,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"AE" = (
+"Do" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	tag = "icon-intact (NORTHWEST)";
 	icon_state = "intact";
@@ -12900,31 +16084,48 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"AG" = (
+"Dp" = (
+/obj/machinery/camera{
+	c_tag = "Atmospherics East";
+	dir = 8
+	},
+/obj/structure/closet/firecloset/full,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"Dq" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"Dr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"AI" = (
+"Ds" = (
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"Dt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/atmos)
-"AJ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/central)
-"AK" = (
+"Du" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/toilet)
-"AL" = (
+"Dv" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
@@ -12943,7 +16144,7 @@
 	icon_state = "freezerfloor"
 	},
 /area/shuttle/ftl/crew_quarters/toilet)
-"AM" = (
+"Dw" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -12954,7 +16155,7 @@
 	icon_state = "freezerfloor"
 	},
 /area/shuttle/ftl/crew_quarters/toilet)
-"AN" = (
+"Dx" = (
 /obj/machinery/shower{
 	dir = 8
 	},
@@ -12969,14 +16170,14 @@
 	icon_state = "freezerfloor"
 	},
 /area/shuttle/ftl/crew_quarters/toilet)
-"AO" = (
+"Dy" = (
 /obj/structure/dresser,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/captain)
-"AP" = (
+"Dz" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/captain,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -12984,7 +16185,7 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/captain)
-"AQ" = (
+"DA" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
 /obj/item/weapon/melee/chainofcommand,
@@ -13000,13 +16201,13 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
-"AR" = (
+"DB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
-"AS" = (
+"DC" = (
 /obj/machinery/door/window{
 	dir = 8;
 	name = "Captains Chair Access";
@@ -13015,7 +16216,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
-"AT" = (
+"DD" = (
 /obj/effect/landmark/start{
 	name = "Captain"
 	},
@@ -13037,7 +16238,7 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
-"AU" = (
+"DE" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -13050,27 +16251,27 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/captain)
-"AV" = (
+"DF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/turret_protected/ai)
-"AW" = (
+"DG" = (
 /obj/machinery/computer/upload/borg,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
-"AX" = (
+"DH" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 8
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
-"AY" = (
+"DI" = (
 /obj/machinery/porta_turret/ai{
 	dir = 8
 	},
@@ -13084,11 +16285,11 @@
 	icon_state = "dark"
 	},
 /area/shuttle/ftl/turret_protected/ai)
-"AZ" = (
+"DJ" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions/cannon)
-"Ba" = (
+"DK" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -13096,7 +16297,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions/cannon)
-"Bb" = (
+"DL" = (
 /obj/structure/rack{
 	dir = 8;
 	layer = 2.9
@@ -13107,30 +16308,77 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions/cannon)
-"Bc" = (
+"DM" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions/cannon)
-"Bd" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
-	dir = 6
+"DN" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/device/radio/intercom{
-	pixel_x = -32
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
+"DO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"DP" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
+"DQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/fireaxecabinet{
+	pixel_x = -31
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"Be" = (
+"DR" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	filter_type = "n2";
 	on = 1
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"Bf" = (
+"DS" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8;
 	initialize_directions = 11
@@ -13138,21 +16386,21 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"Bg" = (
+"DT" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"Bh" = (
+"DU" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"Bi" = (
+"DV" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4;
 	initialize_directions = 11
@@ -13160,22 +16408,22 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"Bj" = (
+"DW" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"Bk" = (
+"DX" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"Bl" = (
+"DY" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8;
 	initialize_directions = 11
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"Bm" = (
+"DZ" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	tag = "icon-pump_map (EAST)";
 	icon_state = "pump_map";
@@ -13189,23 +16437,35 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"Bo" = (
+"Ea" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"Eb" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plasteel/bot,
 /area/shuttle/ftl/atmos)
-"Bp" = (
+"Ec" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/bot,
 /area/shuttle/ftl/atmos)
-"Bq" = (
+"Ed" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plasteel/bot,
 /area/shuttle/ftl/atmos)
-"Br" = (
+"Ee" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plasteel/bot,
 /area/shuttle/ftl/atmos)
-"Bv" = (
+"Ef" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms";
 	req_access_txt = "0"
@@ -13220,20 +16480,7 @@
 	icon_state = "freezerfloor"
 	},
 /area/shuttle/ftl/crew_quarters/toilet)
-"Bw" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "captains_shutters";
-	name = "Captains Office"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/crew_quarters/captain)
-"Bx" = (
+"Eg" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable{
@@ -13251,7 +16498,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/captain)
-"By" = (
+"Eh" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable{
@@ -13266,7 +16513,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/captain)
-"Bz" = (
+"Ei" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
 	req_access = null;
@@ -13279,25 +16526,53 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions/cannon)
-"BA" = (
+"Ej" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/hallway/primary/starboard)
-"BB" = (
+"Ek" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/starboard)
-"BC" = (
+"El" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
 /turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"BD" = (
+/area/shuttle/ftl/hallway/primary/starboard)
+"Em" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
+"En" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"Eo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /mob/living/simple_animal/mouse,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"BE" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"Ep" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"Eq" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	tag = "icon-intact (NORTHEAST)";
 	icon_state = "intact";
@@ -13305,7 +16580,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"BF" = (
+"Er" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	tag = "icon-intact (EAST)";
 	icon_state = "intact";
@@ -13318,7 +16593,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"BG" = (
+"Es" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 4;
 	filter_type = "o2";
@@ -13328,7 +16603,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"BH" = (
+"Et" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	tag = "icon-intact (EAST)";
@@ -13337,7 +16612,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"BI" = (
+"Eu" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	tag = "icon-intact (NORTHWEST)";
 	icon_state = "intact";
@@ -13345,7 +16620,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"BJ" = (
+"Ev" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	tag = "icon-pump_map (NORTH)";
 	icon_state = "pump_map";
@@ -13353,7 +16628,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"BL" = (
+"Ew" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start{
+	name = "Atmospheric Technician";
+	shuttle_abstract_movable = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"Ex" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	tag = "icon-manifold (EAST)";
 	icon_state = "manifold";
@@ -13366,7 +16653,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"BM" = (
+"Ey" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -13386,7 +16673,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"BN" = (
+"Ez" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -13399,7 +16686,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"BO" = (
+"EA" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -13412,7 +16699,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"BP" = (
+"EB" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -13426,7 +16713,7 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"BQ" = (
+"EC" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -13438,7 +16725,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"BR" = (
+"ED" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -13455,7 +16742,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"BS" = (
+"EE" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -13473,7 +16760,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"BT" = (
+"EF" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -13485,7 +16772,122 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"BV" = (
+"EG" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Starboard Primary Hallway 1"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L1"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"EH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L3"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"EI" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L5"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"EJ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L7"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"EK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L9"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"EL" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L11"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"EM" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	desc = "";
+	icon_state = "L13";
+	name = "floor"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"EN" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -13500,7 +16902,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"BW" = (
+"EO" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -13517,7 +16919,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"BX" = (
+"EP" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -13532,7 +16934,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"BY" = (
+"EQ" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -13549,7 +16951,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"BZ" = (
+"ER" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -13561,7 +16963,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Ca" = (
+"ES" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -13573,13 +16975,43 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Cb" = (
+"ET" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Ce" = (
+"EU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"EV" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"EW" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"EX" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"EY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -13588,7 +17020,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Cf" = (
+"EZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 1;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Fa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -13597,25 +17040,69 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Ch" = (
+"Fb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Ci" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
+"Fc" = (
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Cj" = (
+"Fd" = (
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Fe" = (
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Ff" = (
+/obj/machinery/camera{
+	c_tag = "Starboard Primary Hallway 4"
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Fg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Fh" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Fi" = (
 /turf/open/floor/plasteel/arrival/corner{
 	tag = "icon-arrivalcorner (EAST)";
 	icon_state = "arrivalcorner";
 	dir = 4
 	},
 /area/shuttle/ftl/hallway/primary/starboard)
-"Ck" = (
+"Fj" = (
 /obj/effect/landmark/latejoin,
 /obj/structure/chair,
 /turf/open/floor/plasteel/arrival{
@@ -13624,7 +17111,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/hallway/primary/starboard)
-"Cl" = (
+"Fk" = (
 /obj/effect/landmark/latejoin,
 /obj/structure/chair,
 /obj/machinery/light{
@@ -13636,7 +17123,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/hallway/primary/starboard)
-"Cm" = (
+"Fl" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -13646,7 +17133,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/hallway/primary/starboard)
-"Cn" = (
+"Fm" = (
 /obj/structure/grille,
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -13658,7 +17145,7 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Co" = (
+"Fn" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
@@ -13667,57 +17154,132 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"Cp" = (
+"Fo" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"Cq" = (
+/area/shuttle/ftl/atmos)
+"Fp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	tag = "icon-pipe-c";
 	icon_state = "pipe-c";
 	dir = 2
 	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"Cu" = (
-/obj/structure/rack,
-/obj/item/weapon/circuitboard/computer/communications{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/circuitboard/computer/card,
-/obj/item/weapon/circuitboard/computer/crew{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"Cx" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/central)
-"Cy" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start{
-	name = "Atmospheric Technician";
-	shuttle_abstract_movable = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 4
+/area/shuttle/ftl/atmos)
+"Fq" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"CA" = (
+"Fr" = (
+/obj/machinery/meter,
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/plasteel/red/side{
+	dir = 10
+	},
+/area/shuttle/ftl/atmos)
+"Fs" = (
+/obj/structure/window/reinforced,
+/obj/machinery/computer/atmos_control/tank{
+	frequency = 1441;
+	input_tag = "n2_in";
+	name = "Nitrogen Supply Control";
+	output_tag = "n2_out";
+	sensors = list("n2_sensor" = "Tank")
+	},
+/turf/open/floor/plasteel/red/side,
+/area/shuttle/ftl/atmos)
+"Ft" = (
+/obj/machinery/meter,
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/floor/plasteel/red/side{
+	dir = 6
+	},
+/area/shuttle/ftl/atmos)
+"Fu" = (
+/obj/machinery/meter,
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/plasteel/blue/side{
+	dir = 10
+	},
+/area/shuttle/ftl/atmos)
+"Fv" = (
+/obj/structure/window/reinforced,
+/obj/machinery/computer/atmos_control/tank{
+	frequency = 1441;
+	input_tag = "o2_in";
+	name = "Oxygen Supply Control";
+	output_tag = "o2_out";
+	sensors = list("o2_sensor" = "Tank")
+	},
+/turf/open/floor/plasteel/blue/side,
+/area/shuttle/ftl/atmos)
+"Fw" = (
+/obj/machinery/meter,
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/floor/plasteel/blue/side{
+	dir = 6
+	},
+/area/shuttle/ftl/atmos)
+"Fx" = (
+/obj/machinery/meter{
+	name = "Mixed Air Tank In"
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/plasteel/arrival{
+	dir = 10
+	},
+/area/shuttle/ftl/atmos)
+"Fy" = (
+/obj/structure/window/reinforced,
+/obj/machinery/computer/atmos_control/tank{
+	frequency = 1441;
+	input_tag = "air_in";
+	name = "Mixed Air Supply Control";
+	output_tag = "air_out";
+	sensors = list("air_sensor" = "Tank")
+	},
+/turf/open/floor/plasteel/arrival,
+/area/shuttle/ftl/atmos)
+"Fz" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/meter{
+	name = "Mixed Air Tank Out"
+	},
+/turf/open/floor/plasteel/arrival{
+	dir = 6
+	},
+/area/shuttle/ftl/atmos)
+"FA" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/computer/atmos_alert,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"FB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 38
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"FC" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -13729,14 +17291,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"CC" = (
+"FD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=FS";
+	location = "AS"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
+"FE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"CD" = (
+"FF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass,
 /obj/structure/disposalpipe/segment{
@@ -13744,13 +17317,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"CE" = (
+"FG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"CF" = (
+"FH" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -13761,7 +17334,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"CG" = (
+"FI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 1
 	},
@@ -13770,7 +17343,82 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"CH" = (
+"FJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L2"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"FK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L4"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"FL" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L6"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"FM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L8"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"FN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L10"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"FO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "L12"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"FP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	desc = "";
+	icon_state = "L14"
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"FQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"FR" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -13782,14 +17430,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"CI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"CJ" = (
+"FS" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -13806,7 +17447,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"CK" = (
+"FT" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -13818,7 +17459,51 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"CN" = (
+"FU" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"FV" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"FW" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"FX" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -13839,7 +17524,65 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"CP" = (
+"FY" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"FZ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Ga" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Gb" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Gc" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -13848,37 +17591,84 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"CQ" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	color = "#444444"
-	},
-/obj/machinery/computer/pmanagement,
+"Gd" = (
 /obj/structure/cable{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8";
+	pixel_y = 0
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engine_smes)
-"CR" = (
-/obj/effect/landmark/start{
-	name = "Station Engineer";
-	shuttle_abstract_movable = 1
+/mob/living/simple_animal/bot/secbot/beepsky{
+	name = "Officer Beepsky"
 	},
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/break_room)
-"CS" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"CT" = (
+"Ge" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Gf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=AFT";
+	location = "FS"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Gg" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Gh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Gi" = (
 /obj/effect/landmark{
 	name = "Observer-Start"
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"CU" = (
+"Gj" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Gk" = (
 /obj/machinery/door/airlock/external{
 	id_tag = null;
 	name = "Port Docking Bay 2";
@@ -13886,15 +17676,28 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/starboard)
-"CV" = (
+"Gl" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/starboard)
-"CW" = (
+"Gm" = (
+/obj/machinery/door/airlock/external{
+	id_tag = null;
+	name = "Port Docking Bay 2";
+	req_access_txt = "0"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
+"Gn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "36"
+	},
 /turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"CX" = (
+/area/shuttle/ftl/atmos)
+"Go" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1;
 	frequency = 1441;
@@ -13909,7 +17712,7 @@
 	},
 /turf/open/floor/engine/n2,
 /area/shuttle/ftl/atmos)
-"CY" = (
+"Gp" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "n2_sensor"
@@ -13921,7 +17724,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
 /area/shuttle/ftl/atmos)
-"CZ" = (
+"Gq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	external_pressure_bound = 0;
@@ -13943,7 +17746,7 @@
 	},
 /turf/open/floor/engine/n2,
 /area/shuttle/ftl/atmos)
-"Da" = (
+"Gr" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1;
 	frequency = 1441;
@@ -13958,7 +17761,7 @@
 	},
 /turf/open/floor/engine/o2,
 /area/shuttle/ftl/atmos)
-"Db" = (
+"Gs" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "o2_sensor"
@@ -13970,7 +17773,7 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2,
 /area/shuttle/ftl/atmos)
-"Dc" = (
+"Gt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	external_pressure_bound = 0;
@@ -13992,7 +17795,7 @@
 	},
 /turf/open/floor/engine/o2,
 /area/shuttle/ftl/atmos)
-"Dd" = (
+"Gu" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1;
 	frequency = 1441;
@@ -14007,7 +17810,7 @@
 	},
 /turf/open/floor/engine/air,
 /area/shuttle/ftl/atmos)
-"De" = (
+"Gv" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "air_sensor"
@@ -14019,7 +17822,7 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
 /area/shuttle/ftl/atmos)
-"Df" = (
+"Gw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
 	dir = 1;
 	external_pressure_bound = 0;
@@ -14041,15 +17844,17 @@
 	},
 /turf/open/floor/engine/air,
 /area/shuttle/ftl/atmos)
-"Dg" = (
+"Gx" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/thermomachine/heater,
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 4
+	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"Di" = (
+"Gy" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -14057,13 +17862,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"Dj" = (
+"Gz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"Dk" = (
+"GA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -14071,20 +17876,20 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Dl" = (
+"GB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Dm" = (
+"GC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Dn" = (
+"GD" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -14095,7 +17900,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Do" = (
+"GE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -14105,7 +17910,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Dp" = (
+"GF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -14119,7 +17924,7 @@
 	icon_state = "loadingarea"
 	},
 /area/shuttle/ftl/hallway/primary/starboard)
-"Dq" = (
+"GG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -14128,14 +17933,14 @@
 	icon_state = "loadingarea"
 	},
 /area/shuttle/ftl/hallway/primary/starboard)
-"Dr" = (
+"GH" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Ds" = (
+"GI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -14147,11 +17952,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Dt" = (
+"GJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Du" = (
+"GK" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -14163,7 +17968,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Dv" = (
+"GL" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -14174,13 +17979,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Dw" = (
+"GM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Dx" = (
+"GN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -14192,7 +17997,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Dy" = (
+"GO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -14205,13 +18010,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Dz" = (
+"GP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"DA" = (
+"GQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -14227,39 +18032,53 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"DB" = (
+"GR" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"GS" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
 	},
 /turf/open/floor/plasteel/escape/corner,
 /area/shuttle/ftl/hallway/primary/starboard)
-"DC" = (
+"GT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/escape,
 /area/shuttle/ftl/hallway/primary/starboard)
-"DD" = (
+"GU" = (
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 5";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"DE" = (
+"GV" = (
 /obj/machinery/light,
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"DF" = (
 /turf/open/floor/plasteel/escape/corner,
 /area/shuttle/ftl/hallway/primary/starboard)
-"DG" = (
+"GW" = (
+/turf/open/floor/plasteel/escape,
+/area/shuttle/ftl/hallway/primary/starboard)
+"GX" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/maintenance/engineering)
+"GY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/engineering)
+"GZ" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/atmos)
-"DH" = (
+"Ha" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -14276,15 +18095,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"DI" = (
+"Hb" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/lab)
-"DJ" = (
+"Hc" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/lab)
-"DK" = (
+"Hd" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -14299,7 +18118,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"DL" = (
+"He" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/science{
 	name = "Research Division Access";
@@ -14309,10 +18128,13 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"DM" = (
+"Hf" = (
+/turf/closed/wall/r_wall,
+/area/construction/Storage)
+"Hg" = (
 /turf/closed/wall,
-/area/shuttle/ftl/security/checkpoint/science)
-"DN" = (
+/area/construction/Storage)
+"Hh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -14320,22 +18142,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Security Checkpoint";
-	req_access = null;
-	req_access_txt = "1"
+/obj/machinery/door/airlock{
+	name = "Tool Storage"
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/security/checkpoint/science)
-"DO" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/shuttle/ftl/security/checkpoint/science)
-"DQ" = (
-/turf/closed/wall,
-/area/shuttle/ftl/assembly/robotics)
-"DR" = (
+/area/construction/Storage)
+"Hi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -14354,7 +18166,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/assembly/robotics)
-"DS" = (
+"Hj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay";
@@ -14367,13 +18179,24 @@
 	dir = 4
 	},
 /area/shuttle/ftl/assembly/robotics)
-"DT" = (
+"Hk" = (
+/turf/closed/wall,
+/area/shuttle/ftl/assembly/robotics)
+"Hl" = (
 /turf/closed/wall,
 /area/shuttle/ftl/maintenance/bar)
-"DU" = (
+"Hm" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "18";
+	req_one_access_txt = "0"
+	},
+/turf/open/space,
+/area/shuttle/ftl/maintenance/bar)
+"Hn" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/telecomms/computer)
-"DV" = (
+"Ho" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -14390,30 +18213,30 @@
 	dir = 2
 	},
 /area/shuttle/ftl/telecomms/computer)
-"DW" = (
+"Hp" = (
 /obj/structure/sign/securearea{
 	name = "SERVER ROOM";
 	desc = "A warning sign which reads 'SERVER ROOM'."
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/telecomms/computer)
-"DX" = (
+"Hq" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/telecomms/computer)
-"DY" = (
+"Hr" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hydroponics)
-"DZ" = (
+"Hs" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hydroponics)
-"Ea" = (
+"Ht" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Hydroponics";
@@ -14425,7 +18248,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/hydroponics)
-"Eb" = (
+"Hu" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 1;
@@ -14442,10 +18265,10 @@
 	dir = 4
 	},
 /area/shuttle/ftl/hydroponics)
-"Ec" = (
+"Hv" = (
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Ed" = (
+"Hw" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "'Mess Hall'";
@@ -14454,7 +18277,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Ee" = (
+"Hx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "'Mess Hall'";
@@ -14468,19 +18291,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Ef" = (
+"Hy" = (
 /obj/structure/window/fulltile,
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Eg" = (
+"Hz" = (
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/bar)
-"Eh" = (
+"HA" = (
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/bar)
-"Ei" = (
+"HB" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -14496,7 +18319,7 @@
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/bar)
-"Ej" = (
+"HC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Bar"
@@ -14505,10 +18328,10 @@
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/bar)
-"Ek" = (
+"HD" = (
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/sleep)
-"El" = (
+"HE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -14517,7 +18340,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Em" = (
+"HF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -14532,10 +18355,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
-"En" = (
+"HG" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Ep" = (
+"HH" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/glass_command{
+	emergency = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"HI" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/engineering)
+"HJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -14543,13 +18385,13 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"Eq" = (
+"HK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"Er" = (
+"HL" = (
 /obj/structure/disposalpipe/segment{
 	tag = "icon-pipe-c";
 	icon_state = "pipe-c";
@@ -14557,17 +18399,17 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"Es" = (
+"HM" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"Et" = (
+"HN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"Eu" = (
+"HO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	tag = "icon-pipe-c";
@@ -14581,10 +18423,10 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"Ev" = (
+"HP" = (
 /turf/closed/wall,
 /area/shuttle/ftl/research/lab)
-"Ew" = (
+"HQ" = (
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/glass/beaker/large{
 	pixel_x = -3;
@@ -14599,7 +18441,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"Ex" = (
+"HR" = (
 /obj/structure/table/glass,
 /obj/item/weapon/stock_parts/manipulator,
 /obj/item/weapon/stock_parts/capacitor,
@@ -14616,7 +18458,23 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"Ez" = (
+"HS" = (
+/obj/item/weapon/stock_parts/console_screen,
+/obj/structure/table/glass,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/scanning_module{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/weapon/stock_parts/scanning_module,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
+"HT" = (
 /obj/structure/table/glass,
 /obj/item/device/paicard,
 /obj/machinery/light{
@@ -14627,7 +18485,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"EA" = (
+"HU" = (
 /obj/structure/sign/securearea{
 	pixel_x = -32
 	},
@@ -14642,14 +18500,14 @@
 	dir = 9
 	},
 /area/shuttle/ftl/research/lab)
-"EB" = (
+"HV" = (
 /turf/open/floor/plasteel/warnwhite{
 	tag = "icon-white_warn (NORTH)";
 	icon_state = "white_warn";
 	dir = 1
 	},
 /area/shuttle/ftl/research/lab)
-"EC" = (
+"HW" = (
 /obj/machinery/camera{
 	c_tag = "Research Access";
 	dir = 8;
@@ -14661,28 +18519,25 @@
 	dir = 5
 	},
 /area/shuttle/ftl/research/lab)
-"ED" = (
+"HX" = (
 /obj/structure/sign/securearea{
 	pixel_x = 0
 	},
 /turf/closed/wall,
-/area/shuttle/ftl/security/checkpoint/science)
-"EE" = (
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
+/area/construction/Storage)
+"HY" = (
 /obj/structure/table,
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/checkpoint/science)
-"EF" = (
-/obj/item/device/radio/off,
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/plasteel/darkyellow,
+/area/construction/Storage)
+"HZ" = (
 /obj/item/weapon/crowbar,
-/obj/item/device/assembly/flash/handheld,
 /obj/structure/table,
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -14692,9 +18547,11 @@
 /obj/machinery/camera{
 	c_tag = "Research Security Checkpoint"
 	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/checkpoint/science)
-"EG" = (
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/clothing/gloves/color/fyellow,
+/turf/open/floor/plasteel/darkyellow,
+/area/construction/Storage)
+"Ia" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -14705,19 +18562,29 @@
 	pixel_x = -28;
 	pixel_y = 36
 	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/checkpoint/science)
-"EH" = (
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/checkpoint/science)
-"EI" = (
+/turf/open/floor/plasteel/darkyellow,
+/area/construction/Storage)
+"Ib" = (
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel/darkyellow,
+/area/construction/Storage)
+"Ic" = (
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/drone,
+/obj/item/weapon/storage/toolbox/drone,
+/turf/open/floor/plasteel/darkyellow,
+/area/construction/Storage)
+"Id" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 30;
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/checkpoint/science)
-"EJ" = (
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/drone,
+/obj/item/weapon/storage/toolbox/drone,
+/turf/open/floor/plasteel/darkyellow,
+/area/construction/Storage)
+"Ie" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -14735,7 +18602,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/assembly/robotics)
-"EK" = (
+"If" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
@@ -14756,7 +18623,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/assembly/robotics)
-"EL" = (
+"Ig" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -14777,7 +18644,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/assembly/robotics)
-"EM" = (
+"Ih" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -14792,7 +18659,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"EN" = (
+"Ii" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -14817,7 +18684,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"EO" = (
+"Ij" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -14836,7 +18703,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"EP" = (
+"Ik" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -14851,7 +18718,7 @@
 	dir = 2
 	},
 /area/shuttle/ftl/telecomms/computer)
-"EQ" = (
+"Il" = (
 /obj/structure/table,
 /obj/item/device/multitool{
 	pixel_x = 7
@@ -14867,13 +18734,13 @@
 	dir = 2
 	},
 /area/shuttle/ftl/telecomms/computer)
-"ER" = (
+"Im" = (
 /obj/machinery/computer/message_monitor,
 /turf/open/floor/plasteel/neutral{
 	dir = 2
 	},
 /area/shuttle/ftl/telecomms/computer)
-"ES" = (
+"In" = (
 /obj/machinery/computer/telecomms/monitor{
 	network = "tcommsat"
 	},
@@ -14881,7 +18748,7 @@
 	dir = 2
 	},
 /area/shuttle/ftl/telecomms/computer)
-"ET" = (
+"Io" = (
 /obj/machinery/computer/telecomms/server{
 	network = "tcommsat"
 	},
@@ -14889,26 +18756,26 @@
 	dir = 2
 	},
 /area/shuttle/ftl/telecomms/computer)
-"EU" = (
+"Ip" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/open/floor/plasteel/green/side{
 	dir = 9
 	},
 /area/shuttle/ftl/hydroponics)
-"EV" = (
+"Iq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
 /area/shuttle/ftl/hydroponics)
-"EW" = (
+"Ir" = (
 /turf/open/floor/plasteel/green/corner{
 	tag = "icon-greencorner (NORTH)";
 	icon_state = "greencorner";
 	dir = 1
 	},
 /area/shuttle/ftl/hydroponics)
-"EX" = (
+"Is" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -14921,14 +18788,14 @@
 	dir = 4
 	},
 /area/shuttle/ftl/hydroponics)
-"EY" = (
+"It" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
 /area/shuttle/ftl/hydroponics)
-"EZ" = (
+"Iu" = (
 /obj/structure/table,
 /obj/item/weapon/book/manual/hydroponics_pod_people,
 /turf/open/floor/plasteel/green/side{
@@ -14937,7 +18804,7 @@
 	dir = 5
 	},
 /area/shuttle/ftl/hydroponics)
-"Fa" = (
+"Iv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
@@ -14948,7 +18815,7 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Fb" = (
+"Iw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -14959,7 +18826,7 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Fc" = (
+"Ix" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -14975,19 +18842,19 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Fd" = (
+"Iy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Fe" = (
+"Iz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Ff" = (
+"IA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
@@ -14996,12 +18863,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Fg" = (
+"IB" = (
 /obj/structure/window/fulltile,
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/bar)
-"Fh" = (
+"IC" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/camera{
 	c_tag = "Bar North"
@@ -15010,7 +18877,7 @@
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/bar)
-"Fi" = (
+"ID" = (
 /obj/structure/disposalpipe/segment{
 	tag = "icon-pipe-c (EAST)";
 	icon_state = "pipe-c";
@@ -15020,7 +18887,7 @@
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/bar)
-"Fj" = (
+"IE" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -15036,12 +18903,12 @@
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/bar)
-"Fk" = (
+"IF" = (
 /turf/open/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/bar)
-"Fl" = (
+"IG" = (
 /obj/machinery/vending/cigarette{
 	pixel_x = 0;
 	pixel_y = 0
@@ -15058,20 +18925,20 @@
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/bar)
-"Fm" = (
+"IH" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/structure/table,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Fn" = (
+"II" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Fo" = (
+"IJ" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
@@ -15092,20 +18959,20 @@
 /obj/item/weapon/bedsheet,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Fp" = (
+"IK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Fq" = (
+"IL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Fr" = (
+"IM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
@@ -15117,77 +18984,80 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Fs" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+"IN" = (
+/obj/machinery/shower{
+	dir = 4
 	},
-/obj/structure/shuttle/engine/propulsion/burst/right{
-	tag = "icon-burst_r (NORTH)";
-	icon_state = "burst_r";
+/obj/structure/sink{
+	icon_state = "sink";
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/eastright,
+/turf/open/floor/plasteel/freezer,
+/area/storage/eva)
+"IO" = (
+/turf/open/floor/plasteel,
+/area/storage/eva)
+"IP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/storage/eva)
+"IQ" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel,
+/area/storage/eva)
+"IR" = (
+/obj/machinery/suit_storage_unit,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/space,
-/area/shuttle/ftl/subshuttle/pod_4)
-"Ft" = (
-/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/turf/open/floor/plasteel/darkblue/side,
+/area/storage/eva)
+"IS" = (
+/obj/machinery/suit_storage_unit,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkblue/side,
+/area/storage/eva)
+"IT" = (
+/obj/machinery/suit_storage_unit,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /obj/structure/window/reinforced{
 	dir = 4;
 	pixel_x = 0
 	},
-/obj/structure/shuttle/engine/propulsion/burst/left{
-	tag = "icon-burst_l (NORTH)";
-	icon_state = "burst_l";
-	dir = 1
-	},
-/turf/open/space,
-/area/shuttle/ftl/subshuttle/pod_4)
-"Fu" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "0"
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/ftl/subshuttle/pod_4)
-"Fv" = (
-/obj/structure/window/reinforced,
-/obj/structure/shuttle/engine/propulsion/burst{
-	tag = "icon-propulsion (NORTH)";
-	icon_state = "propulsion";
-	dir = 1
-	},
-/turf/open/space,
-/area/shuttle/ftl/subshuttle/pod_4)
-"Fw" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "0"
-	},
-/obj/effect/landmark/pod_port_spawner{
-	dir = 2;
-	dwidth = 2;
-	height = 11;
-	pod_id = "pod4";
-	pod_name = "Escape Shuttle B";
-	width = 9
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/ftl/subshuttle/pod_4)
-"Fx" = (
+/turf/open/floor/plasteel/darkblue/side,
+/area/storage/eva)
+"IU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"Fy" = (
+"IV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"Fz" = (
+"IW" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -15198,7 +19068,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"FA" = (
+"IX" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/light/small{
@@ -15210,35 +19080,35 @@
 /obj/item/weapon/storage/belt/utility,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"FB" = (
+"IY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/research/xenobiology)
-"FC" = (
+"IZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/shuttle/ftl/research/xenobiology)
-"FD" = (
+"Ja" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/hor)
-"FE" = (
+"Jb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/hor)
-"FF" = (
+"Jc" = (
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/hor)
-"FG" = (
+"Jd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -15248,13 +19118,13 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"FH" = (
+"Je" = (
 /obj/machinery/r_n_d/destructive_analyzer,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"FI" = (
+"Jf" = (
 /obj/effect/landmark/start{
 	name = "Scientist";
 	shuttle_abstract_movable = 1
@@ -15263,12 +19133,12 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"FJ" = (
+"Jg" = (
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"FK" = (
+"Jh" = (
 /obj/machinery/r_n_d/protolathe,
 /obj/machinery/camera{
 	c_tag = "Research and Development";
@@ -15279,7 +19149,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"FL" = (
+"Ji" = (
 /obj/machinery/shower{
 	dir = 4
 	},
@@ -15299,13 +19169,13 @@
 	dir = 8
 	},
 /area/shuttle/ftl/research/lab)
-"FM" = (
+"Jj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"FN" = (
+"Jk" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -15317,7 +19187,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/research/lab)
-"FO" = (
+"Jl" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -15326,15 +19196,15 @@
 	icon_state = "alarm0";
 	pixel_x = -22
 	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/checkpoint/science)
-"FP" = (
+/turf/open/floor/plasteel/darkyellow,
+/area/construction/Storage)
+"Jm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/checkpoint/science)
-"FQ" = (
+/turf/open/floor/plasteel/darkyellow,
+/area/construction/Storage)
+"Jn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
@@ -15343,25 +19213,22 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/checkpoint/science)
-"FR" = (
-/obj/machinery/computer/security,
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/checkpoint/science)
-"FS" = (
-/obj/machinery/computer/card,
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/checkpoint/science)
-"FT" = (
-/obj/machinery/computer/secure_data,
+/turf/open/floor/plasteel/darkyellow,
+/area/construction/Storage)
+"Jo" = (
+/turf/open/floor/plasteel/darkyellow,
+/area/construction/Storage)
+"Jp" = (
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/checkpoint/science)
-"FU" = (
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/drone,
+/obj/item/weapon/storage/toolbox/drone,
+/turf/open/floor/plasteel/darkyellow,
+/area/construction/Storage)
+"Jq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -15379,7 +19246,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/assembly/robotics)
-"FV" = (
+"Jr" = (
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 4
@@ -15392,12 +19259,12 @@
 	dir = 4
 	},
 /area/shuttle/ftl/assembly/robotics)
-"FW" = (
+"Js" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"FX" = (
+"Jt" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -15405,11 +19272,11 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"FY" = (
+"Ju" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"FZ" = (
+"Jv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -15419,7 +19286,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"Ga" = (
+"Jw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
@@ -15436,7 +19303,7 @@
 	dir = 2
 	},
 /area/shuttle/ftl/telecomms/computer)
-"Gb" = (
+"Jx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
 	},
@@ -15444,12 +19311,12 @@
 	dir = 2
 	},
 /area/shuttle/ftl/telecomms/computer)
-"Gc" = (
+"Jy" = (
 /turf/open/floor/plasteel/neutral{
 	dir = 2
 	},
 /area/shuttle/ftl/telecomms/computer)
-"Gd" = (
+"Jz" = (
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
@@ -15458,7 +19325,7 @@
 	dir = 2
 	},
 /area/shuttle/ftl/telecomms/computer)
-"Ge" = (
+"JA" = (
 /obj/machinery/light{
 	dir = 4
 	},
@@ -15469,27 +19336,27 @@
 	dir = 2
 	},
 /area/shuttle/ftl/telecomms/computer)
-"Gf" = (
+"JB" = (
 /obj/structure/closet/wardrobe/botanist,
 /turf/open/floor/plasteel{
 	icon_state = "green";
 	dir = 8
 	},
 /area/shuttle/ftl/hydroponics)
-"Gg" = (
+"JC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
-"Gh" = (
+"JD" = (
 /obj/effect/landmark/start{
 	name = "Botanist";
 	shuttle_abstract_movable = 1
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
-"Gi" = (
+"JE" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -15497,7 +19364,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
-"Gj" = (
+"JF" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -15508,7 +19375,7 @@
 	icon_state = "hydrofloor"
 	},
 /area/shuttle/ftl/hydroponics)
-"Gk" = (
+"JG" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/spray/plantbgone{
 	pixel_x = 0;
@@ -15537,15 +19404,15 @@
 	dir = 4
 	},
 /area/shuttle/ftl/hydroponics)
-"Gl" = (
+"JH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Gm" = (
+"JI" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Gn" = (
+"JJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
 	},
@@ -15555,14 +19422,14 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Go" = (
+"JK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/bar)
-"Gp" = (
+"JL" = (
 /obj/structure/chair/stool,
 /obj/structure/cable{
 	d1 = 1;
@@ -15574,13 +19441,13 @@
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/bar)
-"Gq" = (
+"JM" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/bar)
-"Gr" = (
+"JN" = (
 /obj/structure/chair/stool,
 /obj/item/device/radio/intercom{
 	pixel_x = 32
@@ -15589,11 +19456,11 @@
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/bar)
-"Gs" = (
+"JO" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Gt" = (
+"JP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4;
 	on = 1;
@@ -15602,13 +19469,13 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Gu" = (
+"JQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Gv" = (
+"JR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -15619,13 +19486,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Gw" = (
+"JS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Gx" = (
+"JT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -15639,41 +19506,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Gy" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall3";
-	dir = 2
+"JU" = (
+/obj/machinery/door/window/westleft,
+/turf/open/floor/plasteel/darkblue,
+/area/storage/eva)
+"JV" = (
+/turf/open/floor/plasteel/darkblue,
+/area/storage/eva)
+"JW" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
 	},
-/area/shuttle/ftl/subshuttle/pod_4)
-"Gz" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/ftl/subshuttle/pod_4)
-"GA" = (
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/ftl/subshuttle/pod_4)
-"GB" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel/shuttle/white,
-/area/shuttle/ftl/subshuttle/pod_4)
-"GC" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/chair,
-/turf/open/floor/plasteel/shuttle/white,
-/area/shuttle/ftl/subshuttle/pod_4)
-"GD" = (
+/turf/open/floor/plasteel/darkblue,
+/area/storage/eva)
+"JX" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/xenobiology)
-"GE" = (
+"JY" = (
 /turf/closed/wall,
 /area/shuttle/ftl/research/xenobiology)
-"GF" = (
+"JZ" = (
 /obj/structure/sign/biohazard,
 /turf/closed/wall,
 /area/shuttle/ftl/research/xenobiology)
-"GG" = (
+"Ka" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -15698,7 +19555,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"GH" = (
+"Kb" = (
 /obj/structure/table,
 /obj/item/weapon/extinguisher{
 	pixel_x = -6;
@@ -15729,7 +19586,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"GI" = (
+"Kc" = (
 /obj/structure/closet/secure_closet/RD,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
@@ -15746,7 +19603,7 @@
 	icon_state = "cafeteria"
 	},
 /area/shuttle/ftl/crew_quarters/hor)
-"GJ" = (
+"Kd" = (
 /obj/machinery/camera{
 	c_tag = "Research Director's Office";
 	network = list("SS13","RD")
@@ -15756,13 +19613,13 @@
 	icon_state = "cafeteria"
 	},
 /area/shuttle/ftl/crew_quarters/hor)
-"GK" = (
+"Ke" = (
 /obj/structure/displaycase/labcage,
 /turf/open/floor/plasteel{
 	icon_state = "cafeteria"
 	},
 /area/shuttle/ftl/crew_quarters/hor)
-"GL" = (
+"Kf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
@@ -15774,13 +19631,13 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"GM" = (
+"Kg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/research/lab)
-"GN" = (
+"Kh" = (
 /obj/machinery/computer/rdconsole/core,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -15792,7 +19649,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"GO" = (
+"Ki" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -15800,7 +19657,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"GP" = (
+"Kj" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
@@ -15808,7 +19665,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"GQ" = (
+"Kk" = (
 /obj/machinery/r_n_d/circuit_imprinter,
 /obj/item/weapon/reagent_containers/glass/beaker/sulphuric,
 /obj/machinery/light{
@@ -15826,7 +19683,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"GR" = (
+"Kl" = (
 /obj/structure/sink{
 	icon_state = "sink";
 	dir = 8;
@@ -15851,7 +19708,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/research/lab)
-"GS" = (
+"Km" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
@@ -15865,7 +19722,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"GT" = (
+"Kn" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/warnwhite{
 	tag = "icon-white_warn (EAST)";
@@ -15873,21 +19730,27 @@
 	dir = 4
 	},
 /area/shuttle/ftl/research/lab)
-"GU" = (
-/obj/structure/closet/wardrobe/red,
+"Ko" = (
 /obj/item/device/radio/intercom{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/checkpoint/science)
-"GV" = (
-/obj/structure/closet/secure_closet/security,
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/clothing/gloves/color/fyellow,
+/turf/open/floor/plasteel/darkyellow,
+/area/construction/Storage)
+"Kp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/checkpoint/science)
-"GW" = (
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/clothing/gloves/color/fyellow,
+/turf/open/floor/plasteel/darkyellow,
+/area/construction/Storage)
+"Kq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
@@ -15903,9 +19766,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/checkpoint/science)
-"GX" = (
+/turf/open/floor/plasteel/darkyellow,
+/area/construction/Storage)
+"Kr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -15920,7 +19783,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/assembly/robotics)
-"GY" = (
+"Ks" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
@@ -15937,7 +19800,7 @@
 	dir = 2
 	},
 /area/shuttle/ftl/telecomms/computer)
-"GZ" = (
+"Kt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
@@ -15957,7 +19820,7 @@
 	dir = 2
 	},
 /area/shuttle/ftl/telecomms/computer)
-"Ha" = (
+"Ku" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -15968,7 +19831,7 @@
 	dir = 2
 	},
 /area/shuttle/ftl/telecomms/computer)
-"Hb" = (
+"Kv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	d1 = 4;
@@ -15980,7 +19843,7 @@
 	dir = 2
 	},
 /area/shuttle/ftl/telecomms/computer)
-"Hc" = (
+"Kw" = (
 /obj/structure/rack{
 	dir = 8;
 	layer = 2.9
@@ -16003,25 +19866,25 @@
 	dir = 2
 	},
 /area/shuttle/ftl/telecomms/computer)
-"Hd" = (
+"Kx" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel{
 	icon_state = "green";
 	dir = 8
 	},
 /area/shuttle/ftl/hydroponics)
-"He" = (
+"Ky" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
-"Hf" = (
+"Kz" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
-"Hg" = (
+"KA" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
-"Hh" = (
+"KB" = (
 /obj/machinery/chem_master/condimaster,
 /obj/machinery/light_switch{
 	pixel_x = 28
@@ -16030,11 +19893,11 @@
 	dir = 4
 	},
 /area/shuttle/ftl/hydroponics)
-"Hi" = (
+"KC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Hj" = (
+"KD" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -16045,7 +19908,7 @@
 	icon_state = "cafeteria"
 	},
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Hk" = (
+"KE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -16057,7 +19920,7 @@
 	icon_state = "cafeteria"
 	},
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Hl" = (
+"KF" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -16065,7 +19928,7 @@
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/bar)
-"Hm" = (
+"KG" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable{
 	d1 = 1;
@@ -16075,15 +19938,15 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"Hn" = (
+"KH" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"Ho" = (
+"KI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Hp" = (
+"KJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -16093,12 +19956,36 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Hq" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/ftl/subshuttle/pod_4)
-"Hr" = (
+"KK" = (
+/obj/machinery/suit_storage_unit,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 1
+	},
+/area/storage/eva)
+"KL" = (
+/obj/machinery/suit_storage_unit,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 1
+	},
+/area/storage/eva)
+"KM" = (
+/obj/machinery/suit_storage_unit,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 1
+	},
+/area/storage/eva)
+"KN" = (
 /obj/structure/grille,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
@@ -16112,14 +19999,14 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
-"Hs" = (
+"KO" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /obj/structure/disposaloutlet,
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
-"Ht" = (
+"KP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -16128,13 +20015,13 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
-"Hu" = (
+"KQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
-"Hv" = (
+"KR" = (
 /obj/structure/grille,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16150,7 +20037,7 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
-"Hw" = (
+"KS" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -16162,7 +20049,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/research/xenobiology)
-"Hx" = (
+"KT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 4
@@ -16177,7 +20064,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"Hy" = (
+"KU" = (
 /obj/machinery/processor{
 	desc = "A machine used to process slimes and retrieve their extract.";
 	name = "Slime Processor"
@@ -16189,7 +20076,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"Hz" = (
+"KV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -16202,7 +20089,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/hor)
-"HA" = (
+"KW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
@@ -16219,7 +20106,7 @@
 	icon_state = "cafeteria"
 	},
 /area/shuttle/ftl/crew_quarters/hor)
-"HB" = (
+"KX" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start{
 	name = "Research Director";
@@ -16238,7 +20125,7 @@
 	icon_state = "cafeteria"
 	},
 /area/shuttle/ftl/crew_quarters/hor)
-"HC" = (
+"KY" = (
 /obj/machinery/light{
 	dir = 4
 	},
@@ -16279,13 +20166,13 @@
 	icon_state = "cafeteria"
 	},
 /area/shuttle/ftl/crew_quarters/hor)
-"HD" = (
+"KZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/hor)
-"HE" = (
+"La" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
@@ -16308,7 +20195,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"HF" = (
+"Lb" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass{
 	amount = 50;
@@ -16323,7 +20210,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"HG" = (
+"Lc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 1
 	},
@@ -16331,7 +20218,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"HH" = (
+"Ld" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/weapon/stock_parts/cell/high/plus,
@@ -16340,7 +20227,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"HI" = (
+"Le" = (
 /obj/structure/sink{
 	icon_state = "sink";
 	dir = 8;
@@ -16356,7 +20243,7 @@
 	dir = 10
 	},
 /area/shuttle/ftl/research/lab)
-"HJ" = (
+"Lf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
 	},
@@ -16367,13 +20254,13 @@
 	},
 /turf/open/floor/plasteel/warnwhite,
 /area/shuttle/ftl/research/lab)
-"HK" = (
+"Lg" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/warnwhite{
 	dir = 6
 	},
 /area/shuttle/ftl/research/lab)
-"HL" = (
+"Lh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -16386,8 +20273,8 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/shuttle/ftl/security/checkpoint/science)
-"HM" = (
+/area/construction/Storage)
+"Li" = (
 /obj/structure/table,
 /obj/item/weapon/book/manual/robotics_cyborgs{
 	pixel_x = 2;
@@ -16406,7 +20293,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"HN" = (
+"Lj" = (
 /obj/machinery/recharge_station,
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -16415,13 +20302,13 @@
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"HO" = (
+"Lk" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel{
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"HP" = (
+"Ll" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -16434,7 +20321,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/assembly/robotics)
-"HQ" = (
+"Lm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light_switch{
@@ -16447,28 +20334,28 @@
 	dir = 4
 	},
 /area/shuttle/ftl/assembly/robotics)
-"HR" = (
+"Ln" = (
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/plating,
 /area/shuttle/ftl/assembly/robotics)
-"HS" = (
+"Lo" = (
 /turf/open/floor/mech_bay_recharge_floor,
 /area/shuttle/ftl/assembly/robotics)
-"HT" = (
+"Lp" = (
 /obj/machinery/computer/mech_bay_power_console,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"HU" = (
+"Lq" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/telecomms/server)
-"HV" = (
+"Lr" = (
 /obj/structure/sign/securearea{
 	name = "SERVER ROOM";
 	desc = "A warning sign which reads 'SERVER ROOM'."
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/telecomms/server)
-"HW" = (
+"Ls" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -16483,18 +20370,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/telecomms/server)
-"HX" = (
+"Lt" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/telecomms/server)
-"HY" = (
+"Lu" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/telecomms/server)
-"HZ" = (
+"Lv" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
 	dir = 8
@@ -16504,17 +20391,17 @@
 	dir = 8
 	},
 /area/shuttle/ftl/hydroponics)
-"Ia" = (
+"Lw" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
-"Ib" = (
+"Lx" = (
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
-"Ic" = (
+"Ly" = (
 /obj/machinery/plantgenes,
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -16524,7 +20411,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/hydroponics)
-"Id" = (
+"Lz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/sink/kitchen{
 	pixel_y = 25
@@ -16535,17 +20422,17 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Ie" = (
+"LA" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"If" = (
+"LB" = (
 /obj/effect/landmark/start{
 	name = "Cook";
 	shuttle_abstract_movable = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Ig" = (
+"LC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Kitchen";
@@ -16553,13 +20440,13 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Ih" = (
+"LD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Ii" = (
+"LE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -16569,13 +20456,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Ij" = (
+"LF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/bar)
-"Ik" = (
+"LG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -16585,7 +20472,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/bar)
-"Il" = (
+"LH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
 	},
@@ -16593,7 +20480,7 @@
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/bar)
-"Im" = (
+"LI" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/cards/deck,
 /obj/structure/cable{
@@ -16604,14 +20491,14 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"In" = (
+"LJ" = (
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"Io" = (
+"LK" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"Ip" = (
+"LL" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
@@ -16632,7 +20519,7 @@
 /obj/item/weapon/bedsheet,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Iq" = (
+"LM" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -16642,7 +20529,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Ir" = (
+"LN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
@@ -16661,26 +20548,43 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Is" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+"LO" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plasteel,
+/area/storage/eva)
+"LP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
-/obj/structure/chair{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/storage/eva)
+"LQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 8
 	},
-/turf/open/floor/plasteel/shuttle/white,
-/area/shuttle/ftl/subshuttle/pod_4)
-"It" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/turf/open/floor/plasteel,
+/area/storage/eva)
+"LR" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/storage/eva)
+"LS" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle/white,
-/area/shuttle/ftl/subshuttle/pod_4)
-"Iu" = (
+/turf/open/floor/plasteel,
+/area/storage/eva)
+"LT" = (
+/obj/structure/ore_box,
+/turf/open/floor/plasteel,
+/area/storage/eva)
+"LU" = (
 /obj/structure/grille,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
@@ -16699,15 +20603,15 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
-"Iv" = (
+"LV" = (
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
-"Iw" = (
+"LW" = (
 /obj/effect/landmark/event_spawn,
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
-"Ix" = (
+"LX" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
 	dir = 8;
@@ -16727,7 +20631,7 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
-"Iy" = (
+"LY" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
 	name = "Containment Pen";
@@ -16739,7 +20643,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/research/xenobiology)
-"Iz" = (
+"LZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -16751,13 +20655,13 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"IA" = (
+"Ma" = (
 /obj/machinery/monkey_recycler,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"IB" = (
+"Mb" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable{
@@ -16772,7 +20676,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/hor)
-"IC" = (
+"Mc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 1
 	},
@@ -16785,13 +20689,13 @@
 	icon_state = "cafeteria"
 	},
 /area/shuttle/ftl/crew_quarters/hor)
-"ID" = (
+"Md" = (
 /obj/machinery/computer/card/minor/rd,
 /turf/open/floor/plasteel{
 	icon_state = "cafeteria"
 	},
 /area/shuttle/ftl/crew_quarters/hor)
-"IE" = (
+"Me" = (
 /obj/machinery/computer/aifixer,
 /obj/machinery/firealarm{
 	dir = 4;
@@ -16801,7 +20705,7 @@
 	icon_state = "cafeteria"
 	},
 /area/shuttle/ftl/crew_quarters/hor)
-"IF" = (
+"Mf" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "8"
@@ -16816,10 +20720,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/division)
-"IG" = (
+"Mg" = (
 /turf/closed/wall,
 /area/shuttle/ftl/research/division)
-"IH" = (
+"Mh" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
 /obj/machinery/status_display{
@@ -16832,7 +20736,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"II" = (
+"Mi" = (
 /obj/item/weapon/folder/white{
 	pixel_x = 3;
 	pixel_y = 7
@@ -16857,14 +20761,14 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"IJ" = (
+"Mj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/shuttle/ftl/research/lab)
-"IK" = (
+"Mk" = (
 /turf/closed/wall,
 /area/shuttle/ftl/research/server)
-"IL" = (
+"Ml" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
@@ -16885,7 +20789,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/science)
-"IM" = (
+"Mm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -16905,7 +20809,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/assembly/robotics)
-"IN" = (
+"Mn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -16920,7 +20824,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"IO" = (
+"Mo" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
@@ -16935,7 +20839,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"IQ" = (
+"Mp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	sortType = 14
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/robotics)
+"Mq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
@@ -16952,7 +20878,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"IR" = (
+"Mr" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -16961,7 +20887,7 @@
 	},
 /turf/open/floor/bluegrid,
 /area/shuttle/ftl/assembly/robotics)
-"IS" = (
+"Ms" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -16970,7 +20896,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"IT" = (
+"Mt" = (
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -16983,7 +20909,7 @@
 	},
 /turf/open/floor/bluegrid,
 /area/shuttle/ftl/assembly/robotics)
-"IU" = (
+"Mu" = (
 /obj/structure/cable{
 	icon_state = "0-4";
 	d2 = 4
@@ -17004,7 +20930,7 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/shuttle/ftl/telecomms/server)
-"IV" = (
+"Mv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
@@ -17019,7 +20945,7 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/shuttle/ftl/telecomms/server)
-"IW" = (
+"Mw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
 	},
@@ -17029,7 +20955,7 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/shuttle/ftl/telecomms/server)
-"IX" = (
+"Mx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/bluegrid{
 	icon_state = "dark";
@@ -17037,14 +20963,14 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/shuttle/ftl/telecomms/server)
-"IY" = (
+"My" = (
 /obj/machinery/telecomms/server/presets/common/birdstation,
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/shuttle/ftl/telecomms/server)
-"IZ" = (
+"Mz" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/device/radio/intercom{
 	pixel_x = -32
@@ -17054,7 +20980,7 @@
 	dir = 8
 	},
 /area/shuttle/ftl/hydroponics)
-"Ja" = (
+"MA" = (
 /obj/structure/disposalpipe/segment{
 	tag = "icon-pipe-c (EAST)";
 	icon_state = "pipe-c";
@@ -17062,13 +20988,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
-"Jb" = (
+"MB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
-"Jc" = (
+"MC" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -17081,22 +21007,22 @@
 	dir = 4
 	},
 /area/shuttle/ftl/hydroponics)
-"Jd" = (
+"MD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Je" = (
+"ME" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Jf" = (
+"MF" = (
 /obj/machinery/gibber,
 /turf/open/floor/plasteel{
 	icon_state = "cafeteria"
 	},
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Jg" = (
+"MG" = (
 /obj/structure/table,
 /obj/item/weapon/book/manual/chef_recipes,
 /obj/machinery/camera{
@@ -17111,21 +21037,32 @@
 	icon_state = "cafeteria"
 	},
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Jh" = (
+"MH" = (
 /obj/machinery/light{
 	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Ji" = (
+"MI" = (
+/obj/structure/table/reinforced,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/item/weapon/lighter,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/bar)
+"MJ" = (
 /obj/effect/landmark/start{
 	name = "Bartender";
 	shuttle_abstract_movable = 1
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"Jj" = (
+"MK" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/book/manual/barman_recipes,
 /obj/item/weapon/reagent_containers/glass/rag,
@@ -17136,7 +21073,7 @@
 /obj/item/weapon/gun/projectile/revolver/doublebarrel,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"Jk" = (
+"ML" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -17147,7 +21084,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Jl" = (
+"MM" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"MN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -17159,15 +21103,53 @@
 	pixel_x = 26;
 	pixel_y = 0
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Jm" = (
+"MO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/crew_quarters/sleep)
+"MP" = (
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/storage/eva)
+"MQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/storage/eva)
+"MR" = (
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/plasteel/shuttle/white,
-/area/shuttle/ftl/subshuttle/pod_4)
-"Jn" = (
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/storage/eva)
+"MS" = (
+/turf/closed/wall,
+/area/storage/eva)
+"MT" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/storage/eva)
+"MU" = (
 /obj/structure/grille,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
@@ -17185,7 +21167,7 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
-"Jo" = (
+"MV" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -17194,7 +21176,7 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
-"Jp" = (
+"MW" = (
 /obj/structure/grille,
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -17218,7 +21200,7 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
-"Jq" = (
+"MX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
 	id = "xenobio3";
@@ -17242,7 +21224,7 @@
 	dir = 4
 	},
 /area/shuttle/ftl/research/xenobiology)
-"Jr" = (
+"MY" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -17260,13 +21242,13 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"Js" = (
+"MZ" = (
 /obj/machinery/smartfridge/extract,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"Jt" = (
+"Na" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable{
@@ -17280,7 +21262,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/hor)
-"Ju" = (
+"Nb" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -17306,7 +21288,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/crew_quarters/hor)
-"Jv" = (
+"Nc" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable{
@@ -17321,12 +21303,12 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/hor)
-"Jw" = (
+"Nd" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/hor)
-"Jx" = (
+"Ne" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	d1 = 1;
@@ -17339,7 +21321,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"Jy" = (
+"Nf" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/science{
 	name = "Research Division Access";
@@ -17349,19 +21331,19 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"Jz" = (
+"Ng" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"JA" = (
+"Nh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"JB" = (
+"Ni" = (
 /obj/machinery/airalarm{
 	frequency = 1439;
 	locked = 1;
@@ -17371,18 +21353,27 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"JC" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/window/reinforced{
+"Nj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 10;
+	pixel_y = 34
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
 	dir = 1;
-	pixel_y = 2
+	name = "north bump";
+	pixel_y = 24
 	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/warning{
-	dir = 5
+/turf/open/floor/plasteel{
+	icon_state = "white"
 	},
-/area/shuttle/ftl/atmos)
-"JD" = (
+/area/shuttle/ftl/research/lab)
+"Nk" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -17397,7 +21388,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"JE" = (
+"Nl" = (
 /obj/structure/cable{
 	icon_state = "0-2";
 	d2 = 2
@@ -17406,7 +21397,7 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/server)
-"JF" = (
+"Nm" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4;
 	on = 1;
@@ -17421,7 +21412,7 @@
 	initial_gas_mix = "n2=500;TEMP=80"
 	},
 /area/shuttle/ftl/research/server)
-"JG" = (
+"Nn" = (
 /obj/machinery/computer/rdservercontrol,
 /obj/machinery/atmospherics/pipe/simple{
 	tag = "icon-intact (SOUTHWEST)";
@@ -17436,13 +21427,13 @@
 	initial_gas_mix = "n2=500;TEMP=80"
 	},
 /area/shuttle/ftl/research/server)
-"JH" = (
+"No" = (
 /obj/structure/sign/securearea{
 	pixel_x = 0
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/research/server)
-"JI" = (
+"Np" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -17452,7 +21443,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/science)
-"JJ" = (
+"Nq" = (
 /obj/structure/closet/wardrobe/robotics_black,
 /obj/item/device/radio/headset/headset_sci{
 	pixel_x = -3
@@ -17462,16 +21453,44 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"JK" = (
+"Nr" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"JL" = (
+"Ns" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"JN" = (
+"Nt" = (
+/obj/effect/landmark/start{
+	name = "Roboticist";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/robotics)
+"Nu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/robotics)
+"Nv" = (
+/obj/structure/disposalpipe/segment{
+	tag = "icon-pipe-c";
+	icon_state = "pipe-c";
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/robotics)
+"Nw" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/mechanical,
 /obj/machinery/airalarm{
@@ -17482,28 +21501,28 @@
 /obj/item/weapon/crowbar/large,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"JO" = (
+"Nx" = (
 /obj/machinery/telecomms/relay/preset/station,
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/shuttle/ftl/telecomms/server)
-"JP" = (
+"Ny" = (
 /obj/machinery/telecomms/bus/preset_one/birdstation,
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/shuttle/ftl/telecomms/server)
-"JQ" = (
+"Nz" = (
 /obj/machinery/telecomms/broadcaster/preset_left/birdstation,
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/shuttle/ftl/telecomms/server)
-"JR" = (
+"NA" = (
 /obj/machinery/blackbox_recorder,
 /obj/item/device/radio/intercom{
 	pixel_x = 32
@@ -17513,27 +21532,27 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/shuttle/ftl/telecomms/server)
-"JS" = (
+"NB" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel{
 	icon_state = "green";
 	dir = 8
 	},
 /area/shuttle/ftl/hydroponics)
-"JT" = (
+"NC" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
-"JU" = (
+"ND" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
-"JV" = (
+"NE" = (
 /turf/open/floor/plasteel/green/side{
 	dir = 4
 	},
 /area/shuttle/ftl/hydroponics)
-"JW" = (
+"NF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/eastleft{
@@ -17547,17 +21566,17 @@
 	name = "floor"
 	},
 /area/shuttle/ftl/crew_quarters/kitchen)
-"JX" = (
+"NG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"JY" = (
+"NH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"JZ" = (
+"NI" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/condiment/saltshaker{
 	pixel_x = -3;
@@ -17580,7 +21599,7 @@
 	icon_state = "cafeteria"
 	},
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Ka" = (
+"NJ" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable{
 	d1 = 1;
@@ -17591,34 +21610,48 @@
 /obj/item/weapon/reagent_containers/food/drinks/shaker,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"Kb" = (
+"NK" = (
 /obj/machinery/chem_dispenser/drinks,
 /obj/structure/table/reinforced,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"Kc" = (
-/obj/machinery/light{
-	icon_state = "tube1";
+"NL" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel,
+/area/storage/eva)
+"NM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/storage/eva)
+"NN" = (
+/obj/structure/chair{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+/turf/open/floor/plasteel,
+/area/storage/eva)
+"NO" = (
+/obj/structure/closet{
+	name = "Joyride Closet"
 	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/ftl/subshuttle/pod_4)
-"Kd" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/obj/item/key,
+/turf/open/floor/plasteel,
+/area/storage/eva)
+"NP" = (
+/obj/machinery/button/door{
+	id = "EvaGarage";
+	name = "Garage Doors";
+	pixel_x = 26;
+	pixel_y = -6
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/ftl/subshuttle/pod_4)
-"Ke" = (
+/turf/open/floor/plasteel,
+/area/storage/eva)
+"NQ" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
@@ -17626,7 +21659,7 @@
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/research/xenobiology)
-"Kf" = (
+"NR" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -17654,7 +21687,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"Kg" = (
+"NS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -17668,7 +21701,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"Kh" = (
+"NT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -17687,7 +21720,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"Ki" = (
+"NU" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -17706,7 +21739,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"Kj" = (
+"NV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -17729,7 +21762,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"Kk" = (
+"NW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -17747,7 +21780,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"Kl" = (
+"NX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -17769,7 +21802,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"Km" = (
+"NY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -17797,7 +21830,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"Kn" = (
+"NZ" = (
 /obj/structure/window/fulltile,
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -17813,7 +21846,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"Ko" = (
+"Oa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -17828,7 +21861,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"Kp" = (
+"Ob" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -17842,7 +21875,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"Kq" = (
+"Oc" = (
 /obj/effect/landmark/start{
 	name = "Scientist";
 	shuttle_abstract_movable = 1
@@ -17858,7 +21891,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"Kr" = (
+"Od" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
@@ -17872,7 +21905,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"Ks" = (
+"Oe" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -17887,7 +21920,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"Kt" = (
+"Of" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -17916,7 +21949,7 @@
 	initial_gas_mix = "n2=500;TEMP=80"
 	},
 /area/shuttle/ftl/research/server)
-"Ku" = (
+"Og" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -17929,7 +21962,7 @@
 	initial_gas_mix = "n2=500;TEMP=80"
 	},
 /area/shuttle/ftl/research/server)
-"Kv" = (
+"Oh" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -17950,7 +21983,7 @@
 	initial_gas_mix = "n2=500;TEMP=80"
 	},
 /area/shuttle/ftl/research/server)
-"Kw" = (
+"Oi" = (
 /obj/machinery/camera{
 	c_tag = "Robotics West";
 	dir = 4;
@@ -17968,14 +22001,14 @@
 	dir = 1
 	},
 /area/shuttle/ftl/assembly/robotics)
-"Kx" = (
+"Oj" = (
 /turf/open/floor/plasteel/warning{
 	tag = "icon-plasteel_warn (NORTH)";
 	icon_state = "plasteel_warn";
 	dir = 1
 	},
 /area/shuttle/ftl/assembly/robotics)
-"Ky" = (
+"Ok" = (
 /obj/structure/rack{
 	dir = 8;
 	layer = 2.9
@@ -17999,7 +22032,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/assembly/robotics)
-"Kz" = (
+"Ol" = (
 /obj/machinery/mecha_part_fabricator,
 /turf/open/floor/plasteel/warning{
 	tag = "icon-plasteel_warn (NORTH)";
@@ -18007,7 +22040,18 @@
 	dir = 1
 	},
 /area/shuttle/ftl/assembly/robotics)
-"KB" = (
+"Om" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (WEST)";
+	icon_state = "plasteel_warn";
+	dir = 8
+	},
+/area/shuttle/ftl/assembly/robotics)
+"On" = (
 /obj/structure/table,
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -18016,35 +22060,35 @@
 /obj/item/device/mmi,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"KC" = (
+"Oo" = (
 /obj/machinery/telecomms/processor/preset_one/birdstation,
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/shuttle/ftl/telecomms/server)
-"KD" = (
+"Op" = (
 /obj/machinery/announcement_system,
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/shuttle/ftl/telecomms/server)
-"KE" = (
+"Oq" = (
 /obj/machinery/telecomms/receiver/preset_left/birdstation,
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/shuttle/ftl/telecomms/server)
-"KF" = (
+"Or" = (
 /obj/machinery/message_server,
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/shuttle/ftl/telecomms/server)
-"KG" = (
+"Os" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/green/side{
 	tag = "icon-green (SOUTHWEST)";
@@ -18052,10 +22096,10 @@
 	dir = 10
 	},
 /area/shuttle/ftl/hydroponics)
-"KH" = (
+"Ot" = (
 /turf/open/floor/plasteel/green/side,
 /area/shuttle/ftl/hydroponics)
-"KI" = (
+"Ou" = (
 /obj/machinery/hydroponics/constructable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
@@ -18064,7 +22108,7 @@
 	},
 /turf/open/floor/plasteel/green/side,
 /area/shuttle/ftl/hydroponics)
-"KJ" = (
+"Ov" = (
 /obj/machinery/hydroponics/constructable,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 0;
@@ -18072,7 +22116,7 @@
 	},
 /turf/open/floor/plasteel/green/side,
 /area/shuttle/ftl/hydroponics)
-"KK" = (
+"Ow" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/weapon/shovel/spade,
 /obj/item/weapon/wrench,
@@ -18080,7 +22124,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/green/side,
 /area/shuttle/ftl/hydroponics)
-"KL" = (
+"Ox" = (
 /obj/machinery/airalarm{
 	dir = 1;
 	icon_state = "alarm0";
@@ -18092,15 +22136,15 @@
 	dir = 6
 	},
 /area/shuttle/ftl/hydroponics)
-"KM" = (
+"Oy" = (
 /obj/machinery/smartfridge,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"KN" = (
+"Oz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"KO" = (
+"OA" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /obj/machinery/firealarm{
@@ -18115,14 +22159,14 @@
 	icon_state = "cafeteria"
 	},
 /area/shuttle/ftl/crew_quarters/kitchen)
-"KP" = (
+"OB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/bar)
-"KQ" = (
+"OC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
 /obj/structure/cable{
@@ -18133,16 +22177,16 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"KR" = (
+"OD" = (
 /mob/living/carbon/monkey/punpun,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"KS" = (
+"OE" = (
 /obj/machinery/chem_dispenser/drinks/beer,
 /obj/structure/table/reinforced,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"KT" = (
+"OF" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
@@ -18163,35 +22207,49 @@
 /obj/item/weapon/bedsheet,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/sleep)
-"KU" = (
-/obj/structure/window/reinforced{
-	dir = 8
+"OG" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/obj/structure/chair{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"OH" = (
+/obj/structure/table,
+/obj/item/weapon/storage/firstaid,
+/turf/open/floor/plasteel,
+/area/storage/eva)
+"OI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/storage/eva)
+"OJ" = (
+/obj/vehicle/atv{
+	dir = 4;
+	step_x = 0
+	},
+/turf/open/floor/plasteel/delivery,
+/area/storage/eva)
+"OK" = (
+/turf/open/floor/plasteel/loadingarea{
 	dir = 4
 	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/shuttle/white,
-/area/shuttle/ftl/subshuttle/pod_4)
-"KV" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+/area/storage/eva)
+"OL" = (
+/obj/machinery/door/poddoor{
+	id = "EvaGarage";
+	name = "garage door"
 	},
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/shuttle/white,
-/area/shuttle/ftl/subshuttle/pod_4)
-"KW" = (
-/obj/machinery/door/window/southleft{
-	name = "Med Bay";
-	req_access_txt = "5"
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/ftl/subshuttle/pod_4)
-"KX" = (
+/turf/open/floor/plating/warnplate/side,
+/area/shuttle/ftl/hallway/primary/starboard)
+"OM" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -18208,7 +22266,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"KY" = (
+"ON" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -18217,12 +22275,12 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"KZ" = (
+"OO" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/division)
-"La" = (
+"OP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
 	},
@@ -18230,7 +22288,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"Lb" = (
+"OQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 4
 	},
@@ -18243,7 +22301,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"Lc" = (
+"OR" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -18255,7 +22313,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"Ld" = (
+"OS" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -18263,7 +22321,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/division)
-"Le" = (
+"OT" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
@@ -18281,7 +22339,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"Lf" = (
+"OU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/science{
 	name = "Research Division Access";
@@ -18294,7 +22352,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"Lg" = (
+"OV" = (
 /obj/structure/disposalpipe/segment{
 	tag = "icon-pipe-c (WEST)";
 	icon_state = "pipe-c";
@@ -18307,7 +22365,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"Lh" = (
+"OW" = (
 /obj/structure/rack,
 /obj/item/weapon/wrench,
 /obj/item/weapon/crowbar,
@@ -18315,7 +22373,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"Li" = (
+"OX" = (
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
@@ -18329,7 +22387,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"Lj" = (
+"OY" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel/warning{
 	tag = "icon-plasteel_warn (NORTH)";
@@ -18337,7 +22395,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/research/lab)
-"Lk" = (
+"OZ" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/light,
 /turf/open/floor/plasteel/warning{
@@ -18346,7 +22404,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/research/lab)
-"Ll" = (
+"Pa" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/warning{
 	tag = "icon-plasteel_warn (NORTH)";
@@ -18354,7 +22412,7 @@
 	dir = 1
 	},
 /area/shuttle/ftl/research/lab)
-"Lm" = (
+"Pb" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel/warning{
 	tag = "icon-plasteel_warn (NORTH)";
@@ -18362,13 +22420,13 @@
 	dir = 1
 	},
 /area/shuttle/ftl/research/lab)
-"Ln" = (
+"Pc" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/server)
-"Lo" = (
+"Pd" = (
 /obj/machinery/r_n_d/server/robotics,
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -18384,7 +22442,7 @@
 	initial_gas_mix = "n2=500;TEMP=80"
 	},
 /area/shuttle/ftl/research/server)
-"Lp" = (
+"Pe" = (
 /obj/machinery/r_n_d/server/core,
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9
@@ -18394,7 +22452,7 @@
 	initial_gas_mix = "n2=500;TEMP=80"
 	},
 /area/shuttle/ftl/research/server)
-"Lq" = (
+"Pf" = (
 /obj/structure/table,
 /obj/item/stack/sheet/plasteel{
 	amount = 10
@@ -18407,12 +22465,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"Lr" = (
+"Pg" = (
+/mob/living/simple_animal/bot/floorbot,
 /turf/open/floor/plasteel{
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"Ls" = (
+"Ph" = (
 /obj/structure/table,
 /obj/item/weapon/retractor,
 /obj/item/weapon/hemostat,
@@ -18427,7 +22486,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"Lt" = (
+"Pi" = (
 /obj/machinery/door/window{
 	dir = 1;
 	icon_state = "right";
@@ -18439,7 +22498,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"Lu" = (
+"Pj" = (
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
@@ -18448,7 +22507,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"Lv" = (
+"Pk" = (
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -18459,7 +22518,7 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/shuttle/ftl/telecomms/server)
-"Lw" = (
+"Pl" = (
 /obj/machinery/camera{
 	c_tag = "Telecomms Server Room";
 	dir = 1
@@ -18470,7 +22529,7 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/shuttle/ftl/telecomms/server)
-"Lx" = (
+"Pm" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 4
@@ -18481,7 +22540,7 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/shuttle/ftl/telecomms/server)
-"Ly" = (
+"Pn" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
@@ -18491,14 +22550,14 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/shuttle/ftl/telecomms/server)
-"Lz" = (
+"Po" = (
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/bluegrid{
 	name = "Mainframe Base";
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/shuttle/ftl/telecomms/server)
-"LA" = (
+"Pp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Hatch";
@@ -18506,28 +22565,28 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"LB" = (
+"Pq" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/shuttle/ftl/maintenance/bar)
-"LC" = (
+"Pr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/shuttle/ftl/maintenance/bar)
-"LD" = (
+"Ps" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"LE" = (
+"Pt" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"LF" = (
+"Pu" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"LG" = (
+"Pv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -18536,7 +22595,7 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"LH" = (
+"Pw" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
 /obj/item/weapon/reagent_containers/food/condiment/enzyme{
@@ -18544,7 +22603,7 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"LI" = (
+"Px" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -18553,7 +22612,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"LJ" = (
+"Py" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -18566,7 +22625,7 @@
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/bar)
-"LK" = (
+"Pz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
@@ -18582,7 +22641,7 @@
 	icon_state = "bar"
 	},
 /area/shuttle/ftl/crew_quarters/bar)
-"LL" = (
+"PA" = (
 /obj/machinery/door/window/southright{
 	dir = 4;
 	icon_state = "right";
@@ -18604,7 +22663,7 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"LM" = (
+"PB" = (
 /obj/machinery/camera{
 	c_tag = "Bar South";
 	dir = 1
@@ -18615,7 +22674,7 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"LN" = (
+"PC" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/machinery/firealarm{
 	dir = 4;
@@ -18623,7 +22682,7 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"LO" = (
+"PD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -18634,7 +22693,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
-"LP" = (
+"PE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
@@ -18645,65 +22704,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
-"LR" = (
-/obj/machinery/door/window/northright{
-	name = "Shuttle Brig";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plasteel/shuttle/red,
-/area/shuttle/ftl/subshuttle/pod_4)
-"LS" = (
-/obj/structure/window/reinforced{
+"PF" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	auto_name = 1;
 	dir = 4;
-	pixel_x = 0
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/shuttle/red,
-/area/shuttle/ftl/subshuttle/pod_4)
-"LT" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
+"PG" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
+/area/storage/eva)
+"PH" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/glass_command,
+/turf/open/floor/plasteel{
+	icon_state = "hydrofloor"
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/chair,
-/turf/open/floor/plasteel/shuttle/yellow,
-/area/shuttle/ftl/subshuttle/pod_4)
-"LU" = (
-/obj/machinery/door/window/northleft{
-	name = "Cockpit";
-	req_access_txt = "42"
-	},
-/turf/open/floor/plasteel/shuttle/yellow,
-/area/shuttle/ftl/subshuttle/pod_4)
-"LV" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/chair,
-/turf/open/floor/plasteel/shuttle/yellow,
-/area/shuttle/ftl/subshuttle/pod_4)
-"LW" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/open/floor/plasteel/shuttle/white,
-/area/shuttle/ftl/subshuttle/pod_4)
-"LX" = (
-/turf/open/floor/plasteel/shuttle/white,
-/area/shuttle/ftl/subshuttle/pod_4)
-"LY" = (
+/area/storage/eva)
+"PI" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -18713,7 +22741,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"LZ" = (
+"PJ" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/beakers{
 	pixel_x = 2;
@@ -18724,7 +22752,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"Ma" = (
+"PK" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/landmark/start{
 	name = "Scientist";
@@ -18738,7 +22766,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"Mb" = (
+"PL" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -18748,7 +22776,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"Mc" = (
+"PM" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -18772,7 +22800,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"Md" = (
+"PN" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass{
 	amount = 20;
@@ -18805,7 +22833,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"Me" = (
+"PO" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start{
 	name = "Roboticist";
@@ -18813,7 +22841,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"Mf" = (
+"PP" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
 /obj/item/weapon/surgical_drapes,
@@ -18825,12 +22853,12 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"Mg" = (
+"PQ" = (
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"Mh" = (
+"PR" = (
 /obj/structure/table/optable{
 	name = "Robotics Operating Table"
 	},
@@ -18843,11 +22871,11 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"Mi" = (
+"PS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/telecomms/server)
-"Mj" = (
+"PT" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/light/small{
@@ -18855,7 +22883,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"Mk" = (
+"PU" = (
 /obj/structure/disposalpipe/segment{
 	tag = "icon-pipe-c (EAST)";
 	icon_state = "pipe-c";
@@ -18868,7 +22896,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"Ml" = (
+"PV" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
 	icon_state = "pipe-j2s";
@@ -18882,7 +22910,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"Mm" = (
+"PW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
@@ -18897,7 +22925,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"Mn" = (
+"PX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18910,7 +22938,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"Mo" = (
+"PY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
@@ -18926,15 +22954,15 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"Mp" = (
+"PZ" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Mq" = (
+"Qa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"Mr" = (
+"Qb" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
@@ -18950,7 +22978,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"Ms" = (
+"Qc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -18966,7 +22994,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"Mt" = (
+"Qd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -18981,46 +23009,24 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/bar)
-"Mv" = (
-/turf/open/floor/plasteel/shuttle/red,
-/area/shuttle/ftl/subshuttle/pod_4)
-"Mw" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+"Qe" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "8"
 	},
-/turf/open/floor/plasteel/shuttle/red,
-/area/shuttle/ftl/subshuttle/pod_4)
-"Mx" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/shuttle/yellow,
-/area/shuttle/ftl/subshuttle/pod_4)
-"My" = (
-/turf/open/floor/plasteel/shuttle/yellow,
-/area/shuttle/ftl/subshuttle/pod_4)
-"Mz" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/turf/open/floor/plasteel/shuttle/yellow,
-/area/shuttle/ftl/subshuttle/pod_4)
-"MA" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel/shuttle/white,
-/area/shuttle/ftl/subshuttle/pod_4)
-"MB" = (
-/obj/machinery/sleeper{
-	icon_state = "sleeper-open";
-	dir = 8
-	},
-/turf/open/floor/plasteel/shuttle/white,
-/area/shuttle/ftl/subshuttle/pod_4)
-"MC" = (
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/sleep)
+"Qf" = (
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/storage/eva)
+"Qg" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -19034,13 +23040,19 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"MD" = (
+"Qh" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"MF" = (
+"Qi" = (
+/obj/machinery/computer/camera_advanced/xenobio,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
+"Qj" = (
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/plasma{
 	layer = 2.9
@@ -19055,7 +23067,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"MG" = (
+"Qk" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /obj/machinery/airalarm{
@@ -19067,7 +23079,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/division)
-"MH" = (
+"Ql" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
@@ -19088,7 +23100,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/science)
-"MI" = (
+"Qm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -19103,7 +23115,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/science)
-"MJ" = (
+"Qn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -19121,7 +23133,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/science)
-"MK" = (
+"Qo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -19141,7 +23153,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/science)
-"ML" = (
+"Qp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
@@ -19157,7 +23169,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/science)
-"MM" = (
+"Qq" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/regular{
 	empty = 1;
@@ -19176,7 +23188,7 @@
 /obj/item/device/healthanalyzer,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"MN" = (
+"Qr" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/weapon/stock_parts/cell/high/plus,
@@ -19191,7 +23203,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"MO" = (
+"Qs" = (
 /obj/structure/table,
 /obj/item/device/assembly/prox_sensor{
 	pixel_x = -8;
@@ -19217,17 +23229,17 @@
 /obj/item/weapon/crowbar,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"MP" = (
+"Qt" = (
 /obj/machinery/r_n_d/circuit_imprinter,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"MQ" = (
+"Qu" = (
 /obj/machinery/computer/rdconsole/robotics{
 	req_access_txt = "18"
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"MR" = (
+"Qv" = (
 /obj/structure/table,
 /obj/item/device/mmi,
 /obj/item/device/mmi,
@@ -19239,7 +23251,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"MS" = (
+"Qw" = (
 /obj/machinery/computer/operating{
 	name = "Robotics Operating Computer";
 	req_access_txt = "18"
@@ -19248,7 +23260,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"MT" = (
+"Qx" = (
 /obj/structure/table,
 /obj/item/weapon/circular_saw,
 /obj/item/weapon/scalpel{
@@ -19258,7 +23270,7 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"MU" = (
+"Qy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
@@ -19273,7 +23285,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"MV" = (
+"Qz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -19288,7 +23300,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"MW" = (
+"QA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -19304,14 +23316,14 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"MX" = (
+"QB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"MY" = (
+"QC" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -19323,7 +23335,7 @@
 /obj/item/weapon/storage/belt/utility,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"MZ" = (
+"QD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -19340,7 +23352,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"Na" = (
+"QE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	tag = "icon-intact (WEST)";
 	icon_state = "intact";
@@ -19357,7 +23369,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"Nb" = (
+"QF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	tag = "icon-intact (WEST)";
 	icon_state = "intact";
@@ -19375,7 +23387,7 @@
 /mob/living/simple_animal/mouse,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"Nc" = (
+"QG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
@@ -19391,1017 +23403,38 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"Nh" = (
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/maintenance/bar)
-"Ni" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle/red,
-/area/shuttle/ftl/subshuttle/pod_4)
-"Nj" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle/red,
-/area/shuttle/ftl/subshuttle/pod_4)
-"Nk" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/weapon/crowbar,
-/turf/open/floor/plasteel/shuttle/yellow,
-/area/shuttle/ftl/subshuttle/pod_4)
-"Nl" = (
-/obj/machinery/computer/emergency_shuttle,
-/turf/open/floor/plasteel/shuttle/yellow,
-/area/shuttle/ftl/subshuttle/pod_4)
-"Nm" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/table,
-/obj/item/weapon/storage/firstaid/regular{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/shuttle/yellow,
-/area/shuttle/ftl/subshuttle/pod_4)
-"Nn" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle/white,
-/area/shuttle/ftl/subshuttle/pod_4)
-"No" = (
-/obj/structure/table,
-/obj/item/weapon/storage/firstaid/fire,
-/obj/item/weapon/storage/firstaid/regular{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/weapon/crowbar,
-/turf/open/floor/plasteel/shuttle/white,
-/area/shuttle/ftl/subshuttle/pod_4)
-"Np" = (
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/research/division)
-"Nq" = (
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/maintenance/science)
-"Nr" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/science)
-"Ns" = (
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/assembly/robotics)
-"Nt" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/shuttle/ftl/assembly/robotics)
-"Nu" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/bar)
-"Nv" = (
-/turf/open/floor/plating,
-/turf/closed/wall/shuttle{
-	icon_state = "swall_f5";
-	dir = 2
-	},
-/area/shuttle/ftl/subshuttle/pod_4)
-"Nw" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall12";
-	dir = 2
-	},
-/area/shuttle/ftl/subshuttle/pod_4)
-"Nx" = (
-/turf/open/floor/plating,
-/turf/closed/wall/shuttle{
-	icon_state = "swall_f9";
-	dir = 2
-	},
-/area/shuttle/ftl/subshuttle/pod_4)
-"Ny" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engineering)
-"Nz" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/delivery,
-/area/shuttle/ftl/munitions)
-"NA" = (
-/obj/machinery/mac_barrel{
-	dir = 4;
-	id = "weapon_k_1"
-	},
-/turf/open/floor/plating/warnplate/side{
-	tag = "icon-plating_warn_side (EAST)";
-	icon_state = "plating_warn_side";
-	dir = 4
-	},
-/area/shuttle/ftl/munitions)
-"ND" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/northleft{
-	dir = 8;
-	icon_state = "left";
-	name = "Reception Window";
-	req_access_txt = "0"
-	},
-/obj/machinery/door/window/brigdoor{
-	base_state = "rightsecure";
-	dir = 4;
-	icon_state = "rightsecure";
-	name = "Head of Personnel's Desk";
-	req_access = null;
-	req_access_txt = "30"
-	},
-/obj/machinery/flasher{
-	id = "hopflash";
-	pixel_x = 0;
-	pixel_y = 28
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hop";
-	layer = 2.9;
-	name = "Privacy Shutters"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/heads)
-"NH" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+"QH" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L5"
-	},
-/area/shuttle/ftl/hallway/primary/port)
-"NI" = (
-/obj/machinery/meter{
-	name = "Mixed Air Tank In"
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plasteel/arrival{
-	dir = 10
-	},
-/area/shuttle/ftl/atmos)
-"NK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 10;
-	pixel_y = 34
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/lab)
-"NN" = (
-/obj/structure/rack,
-/obj/item/weapon/storage/toolbox/electrical{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/weapon/storage/toolbox/electrical,
-/obj/item/clothing/gloves/color/yellow{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/device/multitool{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/device/multitool,
-/obj/item/clothing/glasses/meson{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/clothing/glasses/meson,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"NT" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=AP";
-	location = "FP"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"NV" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/starboard)
-"NX" = (
-/obj/item/weapon/electronics/airlock{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/weapon/electronics/apc,
-/obj/structure/table,
-/obj/item/stack/cable_coil{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/stack/cable_coil,
-/obj/item/device/multitool{
-	pixel_x = -4;
-	pixel_y = -1
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"Ob" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L7"
-	},
-/area/shuttle/ftl/hallway/primary/port)
-"Of" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"Og" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/plasteel/warning{
-	tag = "icon-plasteel_warn (WEST)";
-	icon_state = "plasteel_warn";
-	dir = 8
-	},
-/area/shuttle/ftl/assembly/robotics)
-"Oh" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/warning{
-	dir = 9
-	},
-/area/shuttle/ftl/atmos)
-"Oi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/yellow/side,
-/area/shuttle/ftl/engine/break_room)
-"Oo" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 1
-	},
-/area/shuttle/ftl/engine/break_room)
-"Or" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/closet/crate,
-/obj/item/weapon/coin/silver{
-	pixel_x = -4;
-	pixel_y = -4;
-	pixel_z = 0
-	},
-/obj/item/weapon/coin/silver{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/weapon/coin/silver{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/weapon/coin/silver{
-	pixel_x = 4
-	},
-/obj/item/weapon/coin/silver,
-/obj/item/stack/sheet/mineral/gold{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/stack/sheet/mineral/gold,
-/obj/item/stack/sheet/mineral/gold{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/weapon/storage/belt/champion,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/ftl/security/nuke_storage)
-"Ot" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 1"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L1"
-	},
-/area/shuttle/ftl/hallway/primary/starboard)
-"Oz" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/bridge)
-"OB" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 4
-	},
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/item/device/multitool,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/mining)
-"OC" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/suit_storage_unit/engine,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engineering)
-"OD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	layer = 2.9;
-	name = "bridge blast door"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/bridge)
-"OJ" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "34"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/break_room)
-"OK" = (
-/obj/structure/table,
-/obj/item/weapon/book/manual/wiki/engineering_hacking{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/weapon/book/manual/wiki/engineering_construction,
-/obj/item/weapon/book/manual/wiki/engineering_guide{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/break_room)
-"OL" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"OM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	frequency = 1439;
-	locked = 1;
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"ON" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	icon_state = "intact";
-	dir = 10
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/warning/corner{
-	dir = 1
-	},
-/area/shuttle/ftl/engine/engine_smes)
-"OO" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/pump,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"OQ" = (
-/obj/machinery/computer/card/minor/hos,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/requests_console{
-	pixel_y = 32
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/hos)
-"OR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/warning{
-	dir = 9
-	},
-/area/shuttle/ftl/munitions)
-"OS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	desc = "";
-	icon_state = "L13";
-	name = "floor"
-	},
-/area/shuttle/ftl/hallway/primary/starboard)
-"OW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
-/area/shuttle/ftl/storage/tech)
-"OY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	icon_state = "L7"
-	},
-/area/shuttle/ftl/bridge)
-"OZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"Pb" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 1;
-	filter_type = "plasma";
-	on = 1
-	},
-/obj/machinery/button/massdriver{
-	id = "supermatter_eject";
-	pixel_x = -24;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/warning{
-	dir = 8
-	},
-/area/shuttle/ftl/engine/engine_smes)
-"Pe" = (
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/ftl/space)
-"Pf" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L3"
-	},
-/area/shuttle/ftl/hallway/primary/starboard)
-"Pg" = (
-/obj/machinery/door/airlock/glass_external{
-	name = "Escape Shuttle"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"Ph" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/break_room)
-"Pl" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = -8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/disposal)
-"Pm" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (EAST)";
+	tag = "icon-pipe-c (WEST)";
 	icon_state = "pipe-c";
-	dir = 4
-	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/brig)
-"Pn" = (
-/obj/machinery/airalarm{
-	frequency = 1439;
-	locked = 1;
-	pixel_y = 23
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 1
-	},
-/area/shuttle/ftl/engine/break_room)
-"Ps" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/office)
-"Pt" = (
-/obj/item/weapon/stock_parts/console_screen,
-/obj/structure/table/glass,
-/obj/item/weapon/stock_parts/console_screen,
-/obj/item/weapon/stock_parts/console_screen,
-/obj/item/weapon/stock_parts/matter_bin,
-/obj/item/weapon/stock_parts/matter_bin,
-/obj/item/weapon/stock_parts/scanning_module{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/weapon/stock_parts/scanning_module,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/lab)
-"Pz" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+	dir = 9
 	},
-/turf/open/floor/plasteel{
-	icon_state = "L9"
-	},
-/area/shuttle/ftl/hallway/primary/starboard)
-"PA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"PB" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"PD" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Tech Storage";
-	req_one_access_txt = "7;19"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"PG" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 6
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/warning{
-	dir = 1
-	},
-/area/shuttle/ftl/engine/engine_smes)
-"PI" = (
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 4"
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"PJ" = (
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/item/device/pipe_painter,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"PK" = (
-/obj/item/weapon/card/id/captains_spare,
-/obj/structure/table/wood,
-/obj/item/weapon/folder/blue,
-/obj/item/weapon/stamp/captain,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/captain)
-"PM" = (
-/obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"PP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=AFT";
-	location = "FS"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"PQ" = (
-/obj/structure/table,
-/obj/item/weapon/tank/internals/emergency_oxygen{
-	pixel_x = -8;
-	pixel_y = 0
-	},
-/obj/item/weapon/tank/internals/emergency_oxygen{
-	pixel_x = -8;
-	pixel_y = 0
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = 4;
-	pixel_y = 0
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = 4;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"PS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"PV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plasteel/arrival{
-	dir = 4
-	},
-/area/shuttle/ftl/hallway/primary/central)
-"PW" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/shuttle/ftl/munitions)
-"PZ" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	tag = "icon-intact (WEST)";
-	icon_state = "intact";
-	dir = 8;
-	color = "#444444"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engine_smes)
-"Qa" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/grille,
 /turf/open/floor/plating,
-/area/shuttle/ftl/space)
-"Qf" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -4
-	},
-/obj/item/stack/cable_coil,
-/obj/item/weapon/electronics/airlock,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/break_room)
-"Qg" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"Qh" = (
-/obj/item/weapon/storage/belt/utility,
-/obj/item/weapon/wrench,
-/obj/item/weapon/weldingtool,
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/structure/table,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/break_room)
-"Qk" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/shuttle/ftl/munitions)
-"Ql" = (
-/obj/machinery/conveyor{
-	id = "munitions";
-	tag = "munitions south"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/munitions)
-"Qo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/warning{
-	dir = 6
-	},
-/area/shuttle/ftl/munitions)
-"Qq" = (
+/area/shuttle/ftl/maintenance/bar)
+"QI" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel{
-	icon_state = "L1"
-	},
-/area/shuttle/ftl/bridge)
-"Qr" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"Qt" = (
-/obj/machinery/door/poddoor{
-	id = "weapon_k_1";
-	name = "munitions launcher bay door"
-	},
-/turf/open/floor/plating/warnplate/side{
-	tag = "icon-plating_warn_side (EAST)";
-	icon_state = "plating_warn_side";
-	dir = 4
-	},
-/area/shuttle/ftl/munitions)
-"Qy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L8"
-	},
-/area/shuttle/ftl/hallway/primary/starboard)
-"Qz" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/item/weapon/paper,
-/obj/machinery/door/window/westright{
-	tag = "icon-right";
-	name = "Security Checkpoint";
-	icon_state = "right";
-	dir = 2;
-	req_access_txt = "1"
-	},
-/turf/open/floor/plasteel/delivery,
-/area/shuttle/ftl/security/checkpoint/science)
-"QA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L8"
-	},
-/area/shuttle/ftl/hallway/primary/port)
-"QB" = (
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
+"QJ" = (
 /obj/machinery/airalarm{
 	dir = 1;
 	icon_state = "alarm0";
@@ -20415,3073 +23448,48 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"QH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/computer/cargo/request,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/office)
-"QI" = (
-/obj/machinery/vending/engivend{
-	req_access_txt = "34"
+"QK" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 8
-	},
-/area/shuttle/ftl/engine/break_room)
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
 "QL" = (
-/obj/effect/landmark/start{
-	name = "Roboticist";
-	shuttle_abstract_movable = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/maintenance/bar)
+"QM" = (
+/obj/structure/closet/crate/rcd,
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/assembly/robotics)
-"QP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L4"
-	},
-/area/shuttle/ftl/hallway/primary/starboard)
-"QR" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
-	},
-/turf/open/space,
-/area/shuttle/ftl/munitions)
-"QS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (WEST)";
-	icon_state = "pipe-c";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"QU" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/ftl/space)
-"QV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/shuttle/ftl/storage/tech)
-"QX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"QY" = (
-/obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"QZ" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics East";
-	dir = 8
-	},
-/obj/structure/closet/firecloset/full,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"Ra" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/item/clothing/glasses/meson,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 4
-	},
-/area/shuttle/ftl/engine/break_room)
-"Rb" = (
-/obj/structure/rack,
-/obj/item/weapon/gun/energy/ionrifle,
-/obj/item/clothing/suit/armor/laserproof,
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/darkwarning,
-/area/shuttle/ftl/security/armory)
-"Rd" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 1
-	},
-/area/shuttle/ftl/engine/break_room)
-"Re" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L6"
-	},
-/area/shuttle/ftl/hallway/primary/starboard)
-"Ri" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/central)
-"Rj" = (
-/obj/structure/rack,
-/obj/item/weapon/circuitboard/computer/security,
-/obj/item/weapon/circuitboard/computer/secure_data{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/weapon/circuitboard/computer/arcade/battle{
-	permeability_coefficient = 1;
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/circuitboard/computer/mining,
-/obj/item/weapon/circuitboard/machine/autolathe{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/camera,
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"Rl" = (
-/obj/structure/rack,
-/obj/item/weapon/circuitboard/machine/mac_barrel{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/circuitboard/machine/mac_breech,
-/obj/item/weapon/circuitboard/machine/phase_cannon{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"Rp" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start{
-	name = "Assistant"
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=FP";
-	location = "AFT"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/central)
-"Rr" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c";
-	icon_state = "pipe-c";
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"Ru" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"Rx" = (
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"Rz" = (
-/obj/structure/rack,
-/obj/item/weapon/circuitboard/computer/borgupload{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/circuitboard/computer/aiupload,
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"RE" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/security/brig)
-"RH" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engine_smes)
-"RL" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	tag = "icon-pump_map (WEST)";
-	icon_state = "pump_map";
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engine_smes)
-"RM" = (
-/obj/machinery/door/poddoor{
-	id = "trash";
-	name = "disposal bay door"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/disposal)
-"RN" = (
-/obj/machinery/computer/camera_advanced/xenobio,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
+/area/storage/eva)
+"QN" = (
+/turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/division)
-"RR" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/warning/corner{
-	dir = 4
-	},
-/area/shuttle/ftl/engine/engine_smes)
-"RT" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/warning{
-	dir = 8
-	},
-/area/shuttle/ftl/munitions)
-"RW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	desc = "";
-	icon_state = "L14"
-	},
-/area/shuttle/ftl/bridge)
-"RY" = (
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 8;
-	pixel_y = 24
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/neutral{
-	dir = 2
-	},
-/area/shuttle/ftl/engine/chiefs_office)
-"RZ" = (
-/obj/structure/table,
-/obj/item/weapon/folder/red,
-/obj/item/weapon/pen,
-/obj/item/weapon/hand_labeler,
-/obj/item/weapon/book/manual/wiki/security_space_law,
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/main)
-"Sa" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/virology)
-"Sb" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"Sc" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/machinery/computer/atmos_control/tank{
-	frequency = 1441;
-	input_tag = "n2o_in";
-	name = "Nitrous Oxide Supply Control";
-	output_tag = "n2o_out";
-	sensors = list("n2o_sensor" = "Tank")
-	},
-/turf/open/floor/plasteel/escape{
-	dir = 1
-	},
-/area/shuttle/ftl/atmos)
-"Sf" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
+"QO" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/maintenance/science)
+"QP" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/science)
+"QQ" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/assembly/robotics)
+"QR" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/assembly/robotics)
+"QS" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"Sg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Bridge Access";
-	dir = 1
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L4"
-	},
-/area/shuttle/ftl/bridge)
-"Si" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/assembly/robotics)
-"Sl" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/ftl/space)
-"So" = (
-/obj/machinery/door/airlock/glass_virology{
-	name = "Isolation A";
-	req_access_txt = "23"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/medical/virology)
-"Sq" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/ftl/hallway/primary/starboard)
-"Sx" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L9"
-	},
-/area/shuttle/ftl/bridge)
-"Sy" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/warning{
-	dir = 4
-	},
-/area/shuttle/ftl/cargo/office)
-"Sz" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/meter{
-	name = "Mixed Air Tank Out"
-	},
-/turf/open/floor/plasteel/arrival{
-	dir = 6
-	},
-/area/shuttle/ftl/atmos)
-"SD" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"SH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Port Primary Hallway 1";
-	dir = 1
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L2"
-	},
-/area/shuttle/ftl/hallway/primary/port)
-"SI" = (
-/obj/item/device/aicard,
-/obj/item/weapon/aiModule/reset{
-	pixel_y = 2
-	},
-/obj/structure/table,
-/obj/item/device/flashlight,
-/obj/item/device/flashlight,
-/obj/machinery/cell_charger,
-/obj/item/weapon/stock_parts/cell/high/plus,
-/obj/item/weapon/stock_parts/cell/high/plus,
-/obj/item/device/assembly/flash{
-	pixel_x = 6
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"SJ" = (
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/cargo)
-"SM" = (
-/obj/structure/window/reinforced,
-/obj/machinery/computer/atmos_control/tank{
-	frequency = 1441;
-	input_tag = "o2_in";
-	name = "Oxygen Supply Control";
-	output_tag = "o2_out";
-	sensors = list("o2_sensor" = "Tank")
-	},
-/turf/open/floor/plasteel/blue/side,
-/area/shuttle/ftl/atmos)
-"SN" = (
-/obj/structure/window/reinforced,
-/obj/machinery/computer/atmos_control/tank{
-	frequency = 1441;
-	input_tag = "air_in";
-	name = "Mixed Air Supply Control";
-	output_tag = "air_out";
-	sensors = list("air_sensor" = "Tank")
-	},
-/turf/open/floor/plasteel/arrival,
-/area/shuttle/ftl/atmos)
-"SO" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/machinery/computer/atmos_control/tank{
-	frequency = 1441;
-	input_tag = "tox_in";
-	name = "Plasma Supply Control";
-	output_tag = "tox_out";
-	sensors = list("tox_sensor" = "Tank")
-	},
-/turf/open/floor/plasteel/warning{
-	dir = 1
-	},
-/area/shuttle/ftl/atmos)
-"SP" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	tag = "icon-pump_map (EAST)";
-	icon_state = "pump_map";
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Engine North";
-	network = list("SS13","Supermatter")
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engine_smes)
-"SQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor,
-/obj/machinery/mineral/ore_redemption,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/office)
-"SS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel{
-	icon_state = "L10"
-	},
-/area/shuttle/ftl/bridge)
-"ST" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L9"
-	},
-/area/shuttle/ftl/hallway/primary/port)
-"SW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L10"
-	},
-/area/shuttle/ftl/hallway/primary/port)
-"SX" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engine_smes)
-"SY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"SZ" = (
+"QT" = (
 /turf/closed/wall/r_wall,
-/area/shuttle/ftl/engine/break_room)
-"Tb" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/rack,
-/obj/item/weapon/aiModule/core/full/corp,
-/obj/item/weapon/aiModule/reset{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel/circuit,
-/area/shuttle/ftl/turret_protected/ai)
-"Tc" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plasteel/escape{
-	dir = 4
-	},
-/area/shuttle/ftl/hallway/primary/central)
-"Te" = (
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/storage/tech)
-"Tj" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/starboard)
-"Tk" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/conveyor{
-	id = "cargo";
-	tag = "munitions south"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/office)
-"Tl" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	layer = 2.9;
-	name = "bridge blast door"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/bridge)
-"Tq" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	desc = "";
-	icon_state = "L13";
-	name = "floor"
-	},
-/area/shuttle/ftl/hallway/primary/port)
-"Tt" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/central)
-"Tv" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/vault,
-/area/shuttle/ftl/security/nuke_storage)
-"Tw" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"Ty" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (EAST)";
-	icon_state = "pipe-c";
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=AS";
-	location = "AP"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/central)
-"TC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engineering)
-"TF" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engine_smes)
-"TG" = (
-/obj/structure/closet/secure_closet/freezer/money,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/ftl/security/nuke_storage)
-"TH" = (
-/obj/item/weapon/stock_parts/subspace/amplifier,
-/obj/item/weapon/stock_parts/subspace/amplifier,
-/obj/item/weapon/stock_parts/subspace/amplifier,
-/obj/item/weapon/stock_parts/subspace/analyzer,
-/obj/item/weapon/stock_parts/subspace/analyzer,
-/obj/item/weapon/stock_parts/subspace/analyzer,
-/obj/item/weapon/stock_parts/subspace/ansible,
-/obj/item/weapon/stock_parts/subspace/ansible,
-/obj/item/weapon/stock_parts/subspace/ansible,
-/obj/item/weapon/stock_parts/subspace/crystal,
-/obj/item/weapon/stock_parts/subspace/crystal,
-/obj/item/weapon/stock_parts/subspace/crystal,
-/obj/item/weapon/stock_parts/subspace/filter,
-/obj/item/weapon/stock_parts/subspace/filter,
-/obj/item/weapon/stock_parts/subspace/filter,
-/obj/item/weapon/stock_parts/subspace/filter,
-/obj/item/weapon/stock_parts/subspace/filter,
-/obj/item/weapon/stock_parts/subspace/transmitter,
-/obj/item/weapon/stock_parts/subspace/transmitter,
-/obj/item/weapon/stock_parts/subspace/transmitter,
-/obj/item/weapon/stock_parts/subspace/treatment,
-/obj/item/weapon/stock_parts/subspace/treatment,
-/obj/item/weapon/stock_parts/subspace/treatment,
-/obj/structure/table,
-/obj/item/weapon/storage/belt/utility/full,
-/obj/item/weapon/storage/belt/utility/full,
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"TJ" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/machinery/computer/atmos_control/tank{
-	frequency = 1441;
-	input_tag = "co2_in";
-	name = "Carbon Dioxide Supply Control";
-	output_tag = "co2_out";
-	sensors = list("co2_sensor" = "Tank")
-	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 1
-	},
-/area/shuttle/ftl/atmos)
-"TK" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/ftl/space)
-"TL" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 Locker"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
-"TM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 8
-	},
-/turf/open/floor/plasteel/yellow/side,
-/area/shuttle/ftl/engine/break_room)
-"TN" = (
-/obj/machinery/door/airlock/glass_external{
-	name = "Escape Shuttle"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"TP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	sortType = 7
-	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/brig)
-"TQ" = (
-/obj/machinery/suit_storage_unit/engine,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 4
-	},
-/area/shuttle/ftl/engine/break_room)
-"TR" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"TT" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (WEST)";
-	icon_state = "pipe-c";
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/disposal)
-"TU" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engine_smes)
-"TW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"TX" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	sortType = 22
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"Ua" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/ftl/space)
-"Uc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/security/nuke_storage)
-"Ud" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/miner,
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/device/multitool,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/mining)
-"Uf" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L1"
-	},
-/area/shuttle/ftl/hallway/primary/port)
-"Uh" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/safe,
-/obj/item/clothing/head/bearpelt,
-/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/weapon/gun/projectile/revolver/russian,
-/obj/item/ammo_box/a357,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka/badminka,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/ftl/security/nuke_storage)
-"Ui" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L10"
-	},
-/area/shuttle/ftl/hallway/primary/starboard)
-"Uo" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/shuttle/ftl/security/main)
-"Uq" = (
-/obj/machinery/camera{
-	c_tag = "Port Primary Hallway 3";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"Us" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L3"
-	},
-/area/shuttle/ftl/bridge)
-"Uu" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c";
-	icon_state = "pipe-c";
-	dir = 2
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L8"
-	},
-/area/shuttle/ftl/bridge)
-"Uv" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/pump,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"Uw" = (
-/turf/open/floor/plasteel/yellow/side{
-	dir = 1
-	},
-/area/shuttle/ftl/engine/break_room)
-"Ux" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Secure Tech Storage";
-	req_one_access_txt = "19;29"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"UA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/ftl/space)
-"UB" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/cargo/plasmastorage)
-"UC" = (
-/obj/machinery/meter,
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plasteel/blue/side{
-	dir = 10
-	},
-/area/shuttle/ftl/atmos)
-"UJ" = (
-/obj/effect/landmark/start{
-	name = "Station Engineer";
-	shuttle_abstract_movable = 1
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/break_room)
-"UL" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/escape{
-	dir = 9
-	},
-/area/shuttle/ftl/atmos)
-"UN" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"UQ" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/warning{
-	dir = 4
-	},
-/area/shuttle/ftl/cargo/office)
-"US" = (
-/obj/machinery/door/airlock/external{
-	name = "Supply Dock Airlock";
-	req_access_txt = "0"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/shuttle/ftl/cargo/office)
-"UV" = (
-/obj/machinery/meter,
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plasteel/red/side{
-	dir = 10
-	},
-/area/shuttle/ftl/atmos)
-"UX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L12"
-	},
-/area/shuttle/ftl/hallway/primary/port)
-"UZ" = (
-/obj/structure/rack,
-/obj/item/weapon/circuitboard/computer/aifixer{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/circuitboard/computer/teleporter,
-/obj/item/weapon/circuitboard/computer/rdconsole{
-	pixel_x = 3;
-	pixel_y = -3;
-	pixel_z = 0
-	},
-/obj/item/weapon/circuitboard/computer/pandemic{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/circuitboard/machine/circuit_imprinter,
-/obj/item/weapon/circuitboard/machine/destructive_analyzer{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/weapon/circuitboard/machine/mechfab{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/circuitboard/machine/protolathe,
-/obj/item/weapon/circuitboard/machine/rdserver{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"Va" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door_timer{
-	id = "Cell 2";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/brig)
-"Vb" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L11"
-	},
-/area/shuttle/ftl/hallway/primary/port)
-"Vd" = (
-/obj/structure/table,
-/obj/item/weapon/storage/toolbox/electrical{
-	pixel_y = 5
-	},
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/break_room)
-"Ve" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"Vh" = (
-/obj/structure/rack,
-/obj/item/ammo_box/magazine/wt550m9/wtap{
-	pixel_x = 8;
-	pixel_y = -8
-	},
-/obj/item/ammo_box/magazine/wt550m9/wtap,
-/obj/item/ammo_box/magazine/wt550m9/wtap,
-/obj/item/ammo_box/magazine/wt550m9/wtap{
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/obj/item/ammo_box/magazine/wt550m9/wtap,
-/obj/item/ammo_box/magazine/wt550m9/wtap{
-	pixel_x = 8;
-	pixel_y = -8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/ftl/security/armory)
-"Vi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L6"
-	},
-/area/shuttle/ftl/hallway/primary/port)
-"Vl" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L12"
-	},
-/area/shuttle/ftl/hallway/primary/starboard)
-"Vn" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/warning/corner{
-	dir = 4
-	},
-/area/shuttle/ftl/engine/engine_smes)
-"Vp" = (
-/obj/structure/rack,
-/obj/item/weapon/gun/energy/gun/advtaser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/gun/energy/gun/advtaser,
-/obj/item/weapon/gun/energy/gun/advtaser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/ftl/security/armory)
-"Vq" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6;
-	initialize_directions = 6
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engine_smes)
-"Vt" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "captains_shutters";
-	name = "Captains Office"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/crew_quarters/captain)
-"Vu" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/bridge)
-"Vy" = (
-/obj/structure/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio3";
-	name = "containment blast door"
-	},
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/engine,
-/area/shuttle/ftl/turret_protected/ai)
-"Vz" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"VA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "engineering security door"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Equipment";
-	req_access_txt = "15"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"VB" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/rods{
-	amount = 50
-	},
-/obj/item/weapon/book/manual/ftl_wiki/supermatter,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/break_room)
-"VE" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L3"
-	},
-/area/shuttle/ftl/hallway/primary/port)
-"VI" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/security/nuke_storage)
-"VO" = (
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/munitions/loading)
-"VR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L4"
-	},
-/area/shuttle/ftl/hallway/primary/port)
-"VT" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/security/nuke_storage)
-"VV" = (
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/break_room)
-"VW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L2"
-	},
-/area/shuttle/ftl/hallway/primary/starboard)
-"VY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 22
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"Wa" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/turf/open/floor/plasteel/vault,
-/area/shuttle/ftl/security/nuke_storage)
-"Wd" = (
-/obj/structure/cable,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/ftl/space)
-"We" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/cargo)
-"Wg" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel{
-	desc = "";
-	icon_state = "L13";
-	name = "floor"
-	},
-/area/shuttle/ftl/bridge)
-"Wj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/warning{
-	dir = 6
-	},
-/area/shuttle/ftl/cargo/office)
-"Wk" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	layer = 2.9;
-	name = "bridge blast door"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/bridge)
-"Wm" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"Wr" = (
-/obj/machinery/door/airlock/external{
-	name = "Supply Dock Airlock";
-	req_access_txt = "0"
-	},
-/obj/docking_port/mobile/ftl{
-	dir = 2
-	},
-/obj/docking_port/stationary{
-	dheight = 8;
-	dir = 2;
-	dwidth = 49;
-	height = 73;
-	id = "ftl_start";
-	name = "Starting Area";
-	width = 97
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/shuttle/ftl/cargo/office)
-"Wt" = (
-/obj/machinery/camera{
-	c_tag = "Port Primary Hallway 4";
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"Ww" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	desc = "";
-	icon_state = "L14"
-	},
-/area/shuttle/ftl/hallway/primary/starboard)
-"Wx" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 28;
-	pixel_y = 22
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"Wz" = (
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"WC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/machinery/light_switch{
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/obj/machinery/camera{
-	c_tag = "Munitions West";
-	dir = 1;
-	pixel_x = 15
-	},
-/obj/structure/window/reinforced/crosswired{
-	dir = 8
-	},
-/turf/open/floor/plasteel/bot,
-/area/shuttle/ftl/munitions)
-"WF" = (
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/rods{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/weapon/electronics/airlock,
-/obj/item/weapon/stock_parts/cell/high/plus,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 30
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/storage)
-"WL" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L11"
-	},
-/area/shuttle/ftl/bridge)
-"WQ" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/escape{
-	dir = 5
-	},
-/area/shuttle/ftl/atmos)
-"WR" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 9
-	},
-/area/shuttle/ftl/atmos)
-"WS" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"WT" = (
-/obj/structure/filingcabinet/security,
-/obj/item/weapon/folder/documents,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/ftl/security/nuke_storage)
-"WU" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/starboard)
-"WW" = (
-/obj/machinery/vending/tool{
-	req_access_txt = "34"
-	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 9
-	},
-/area/shuttle/ftl/engine/break_room)
-"WX" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 10
-	},
-/area/shuttle/ftl/engine/break_room)
-"Xc" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/device/flashlight{
-	pixel_x = -2;
-	pixel_y = 9
-	},
-/obj/item/device/flashlight,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/break_room)
-"Xe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/yellow/side,
-/area/shuttle/ftl/engine/break_room)
-"Xf" = (
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access = null;
-	req_access_txt = "7;9"
-	},
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/shuttle/ftl/munitions/cannon)
-"Xk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"Xl" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/ftl/space)
-"Xm" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/nuclearbomb/selfdestruct,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/ftl/security/nuke_storage)
-"Xp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	sortType = 14
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/assembly/robotics)
-"Xs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/warning{
-	dir = 5
-	},
-/area/shuttle/ftl/munitions)
-"Xt" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/crew_quarters/sleep)
-"Xv" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/brig)
-"Xw" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/starboard)
-"Xx" = (
-/obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"Xz" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/sleep)
-"XC" = (
-/obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (EAST)";
-	icon_state = "pipe-c";
-	dir = 4
-	},
-/obj/machinery/computer/cargo,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/office)
-"XD" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/ftl/space)
-"XG" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Disposal Access";
-	req_access_txt = "40"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/disposal)
-"XL" = (
-/obj/machinery/camera/motion{
-	c_tag = "AI Chamber North";
-	network = list("SS13","MiniSat");
-	pixel_x = 0
-	},
-/obj/structure/rack,
-/obj/item/weapon/aiModule/core/freeformcore,
-/obj/item/weapon/aiModule/core/full/asimov{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel/circuit,
-/area/shuttle/ftl/turret_protected/ai)
-"XO" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/break_room)
-"XS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"XT" = (
-/obj/machinery/camera{
-	c_tag = "Secure Tech Storage";
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"XV" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 1";
-	name = "Cell 1 Locker"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
-"XW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/yellow/side,
-/area/shuttle/ftl/engine/break_room)
-"XX" = (
-/obj/machinery/mineral/stacking_unit_console{
-	dir = 2;
-	machinedir = 8;
-	pixel_y = 4
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/storage/tech)
-"XY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	desc = "";
-	icon_state = "L14"
-	},
-/area/shuttle/ftl/hallway/primary/port)
-"XZ" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/item/weapon/book/manual/ftl_wiki/supermatter,
-/turf/open/floor/plasteel/warning{
-	dir = 8
-	},
-/area/shuttle/ftl/engine/engine_smes)
-"Ya" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	icon_state = "pipe-j2s";
-	sortType = "0"
-	},
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/office)
-"Yc" = (
-/obj/machinery/conveyor{
-	id = "cargo";
-	tag = "munitions south"
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/office)
-"Ye" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light_switch{
-	pixel_x = 40;
-	pixel_y = 8
-	},
-/obj/effect/landmark/start{
-	name = "Quartermaster"
-	},
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/office)
-"Yi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L6"
-	},
-/area/shuttle/ftl/bridge)
-"Yk" = (
-/obj/structure/rack,
-/obj/item/weapon/circuitboard/computer/mecha_control{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/circuitboard/computer/robotics,
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"Yn" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 5
-	},
-/area/shuttle/ftl/atmos)
-"Yo" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/central)
-"Yp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L12"
-	},
-/area/shuttle/ftl/bridge)
-"Yq" = (
-/obj/structure/closet/secure_closet/engineering_welding,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 8
-	},
-/area/shuttle/ftl/engine/break_room)
-"Yz" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Security Office East";
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	pixel_x = 8;
-	pixel_y = -24
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/main)
-"YA" = (
-/obj/item/device/analyzer,
-/obj/item/device/healthanalyzer,
-/obj/item/device/plant_analyzer{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/weapon/stock_parts/micro_laser,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/capacitor,
-/obj/item/weapon/stock_parts/micro_laser/high,
-/obj/item/weapon/stock_parts/micro_laser/high,
-/obj/item/weapon/stock_parts/micro_laser/high,
-/obj/item/weapon/stock_parts/micro_laser/high,
-/obj/structure/table,
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"YB" = (
-/obj/structure/window/reinforced,
-/obj/machinery/computer/atmos_control/tank{
-	frequency = 1441;
-	input_tag = "n2_in";
-	name = "Nitrogen Supply Control";
-	output_tag = "n2_out";
-	sensors = list("n2_sensor" = "Tank")
-	},
-/turf/open/floor/plasteel/red/side,
-/area/shuttle/ftl/atmos)
-"YD" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 1
-	},
-/area/shuttle/ftl/engine/break_room)
-"YG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/item/weapon/folder,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westleft{
-	name = "Cargo Desk";
-	req_access_txt = "20"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/cargo/office)
-"YI" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 1
-	},
-/area/shuttle/ftl/security/nuke_storage)
-"YK" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plasteel/escape{
-	dir = 4
-	},
-/area/shuttle/ftl/hallway/primary/central)
-"YL" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/mob/living/simple_animal/bot/secbot/beepsky{
-	name = "Officer Beepsky"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"YM" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/shuttle/ftl/munitions)
-"YN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=FS";
-	location = "AS"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/central)
-"YO" = (
-/obj/structure/rack,
-/obj/item/weapon/circuitboard/computer/atmos_alert{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/circuitboard/computer/stationalert,
-/obj/item/weapon/circuitboard/computer/powermonitor{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"YP" = (
-/obj/item/weapon/melee/classic_baton/telescopic,
-/turf/open/space,
-/area/shuttle/ftl/space)
-"YQ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Hallway North"
-	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 4
-	},
-/area/shuttle/ftl/engine/engineering)
-"YR" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = -24;
-	pixel_z = 0
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/mob/living/simple_animal/pet/cat/Runtime,
-/turf/open/floor/plasteel/cmo,
-/area/shuttle/ftl/medical/cmo)
-"YS" = (
-/obj/machinery/button/door{
-	id = "Disposal Exit";
-	name = "Disposal Vent Control";
-	pixel_x = 25;
-	pixel_y = 4;
-	req_access_txt = "40"
-	},
-/obj/machinery/button/massdriver{
-	id = "trash";
-	pixel_x = 26;
-	pixel_y = -6
-	},
-/obj/structure/chair/stool,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/disposal)
-"YT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engineering)
-"YU" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/computer/atmos_alert,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"YV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/cargo)
-"YW" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/button/door{
-	desc = "A remote control-switch for the engineering security doors.";
-	id = "Engineering";
-	name = "Engineering Lockdown";
-	pixel_x = 24;
-	pixel_y = 24;
-	req_access_txt = "29"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/neutral{
-	dir = 2
-	},
-/area/shuttle/ftl/engine/chiefs_office)
-"YX" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L11"
-	},
-/area/shuttle/ftl/hallway/primary/starboard)
-"YY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -10
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/hos)
-"YZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door_timer{
-	id = "Cell 1";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/brig)
-"Za" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"Zb" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "18";
-	req_one_access_txt = "0"
-	},
-/turf/open/space,
-/area/shuttle/ftl/maintenance/bar)
-"Zc" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/item/weapon/lighter,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/bar)
-"Zd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/door_timer{
-	id = "Cell 3";
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/brig)
-"Ze" = (
-/obj/structure/noticeboard{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 1
-	},
-/area/shuttle/ftl/engine/break_room)
-"Zf" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/cargo)
-"Zg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/office)
-"Zh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
-"Zi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/cargo)
-"Zj" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/bridge)
-"Zk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/darkblue/side,
-/area/shuttle/ftl/bridge)
-"Zl" = (
-/obj/machinery/light_switch{
-	pixel_x = 24
-	},
-/obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c";
-	icon_state = "pipe-c";
-	dir = 2
-	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/brig)
-"Zm" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	layer = 2.9;
-	name = "bridge blast door"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/bridge)
-"Zn" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/space,
-/area/shuttle/ftl/munitions/cannon)
-"Zo" = (
-/obj/machinery/meter,
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plasteel/red/side{
-	dir = 6
-	},
-/area/shuttle/ftl/atmos)
-"Zp" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/shuttle/ftl/munitions/cannon)
-"Zq" = (
-/turf/closed/wall,
-/area/shuttle/ftl/storage/tech)
-"Zr" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/space,
-/area/shuttle/ftl/munitions/cannon)
-"Zs" = (
-/obj/machinery/door/airlock/external{
-	id_tag = null;
-	name = "Port Docking Bay 2";
-	req_access_txt = "0"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
-"Zt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/warning,
-/area/shuttle/ftl/cargo/office)
-"Zu" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	icon_state = "L5"
-	},
-/area/shuttle/ftl/bridge)
-"Zv" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plasteel/arrival{
-	dir = 4
-	},
-/area/shuttle/ftl/hallway/primary/central)
-"Zw" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/bar)
-"Zy" = (
-/obj/structure/rack,
-/obj/item/weapon/circuitboard/computer/cloning{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/item/weapon/circuitboard/computer/med_data{
-	pixel_x = 3;
-	pixel_y = -3;
-	pixel_z = 0
-	},
-/obj/item/weapon/circuitboard/machine/clonescanner{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/circuitboard/machine/clonepod,
-/obj/item/weapon/circuitboard/computer/scan_consolenew{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/shuttle/ftl/storage/tech)
-"ZA" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/central)
-"ZB" = (
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/engine/engine_smes)
-"ZC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/munitions/office)
-"ZD" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "munitions";
-	name = "munitions blast door"
-	},
-/obj/machinery/door/airlock/command{
-	name = "Munitions Officer";
-	req_access_txt = "43"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/munitions/office)
-"ZE" = (
-/turf/open/floor/plasteel/darkwarning,
-/area/shuttle/ftl/engine/engine_smes)
-"ZF" = (
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/engine_smes)
-"ZG" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L7"
-	},
-/area/shuttle/ftl/hallway/primary/starboard)
-"ZH" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "engineering security door"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/engine_smes)
-"ZI" = (
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engine_smes)
-"ZJ" = (
-/obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c";
-	icon_state = "pipe-c";
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/assembly/robotics)
-"ZK" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/space)
-"ZL" = (
-/obj/effect/landmark/ship_fire,
-/turf/open/space,
-/area/shuttle/ftl/space)
-"ZM" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/warning{
-	dir = 4
-	},
-/area/shuttle/ftl/hallway/primary/port)
-"ZN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/delivery,
-/area/shuttle/ftl/hallway/primary/port)
-"ZO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/warning{
-	dir = 8
-	},
-/area/shuttle/ftl/hallway/primary/port)
-"ZP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/delivery,
-/area/shuttle/ftl/hallway/primary/port)
-"ZQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/warning{
-	dir = 8
-	},
-/area/shuttle/ftl/hallway/primary/port)
-"ZR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/delivery,
-/area/shuttle/ftl/hallway/primary/port)
-"ZS" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/warning{
-	dir = 8
-	},
-/area/shuttle/ftl/hallway/primary/port)
-"ZT" = (
-/obj/machinery/ammo_rack/full/smart_homing,
-/turf/open/floor/plasteel{
-	icon_state = "delivery"
-	},
-/area/shuttle/ftl/munitions/loading)
-"ZU" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/shuttle/ftl/hallway/primary/starboard)
-"ZV" = (
-/obj/machinery/conveyor_switch{
-	id = "munitions_loading"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/munitions/loading)
-"ZW" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"ZX" = (
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/security/checkpoint/science)
-"ZY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L5"
-	},
-/area/shuttle/ftl/hallway/primary/starboard)
-"ZZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "L2"
-	},
-/area/shuttle/ftl/bridge)
+/area/storage/eva)
 
 (1,1,1) = {"
 aa
@@ -44156,20 +44164,17 @@ ab
 ab
 ab
 ab
-ls
-mf
-ls
+lC
+mu
+lC
 ab
 ab
-ox
-ox
-ox
-ox
-ox
-ox
-ab
-ab
-ab
+pw
+pw
+pw
+pw
+pw
+pw
 ab
 ab
 ab
@@ -44178,17 +44183,20 @@ ab
 ab
 ab
 ab
-ox
-ox
-ox
-ox
-ox
-ox
 ab
 ab
-ls
-Co
-ls
+ab
+pw
+pw
+pw
+pw
+pw
+pw
+ab
+ab
+lC
+Fn
+lC
 ab
 ab
 ab
@@ -44403,61 +44411,61 @@ ab
 ab
 ac
 ac
-bF
-bF
+bG
+bG
 ac
-eY
-eZ
-eZ
-eZ
-eY
-jZ
-jZ
-jp
-mg
-jZ
-jp
-jp
-oy
-oy
-oy
-oy
-oy
-oy
-ZB
-ZB
-ZB
-ZB
-ZB
-us
-ZB
-ZB
-ZB
-ZB
-ZB
-oy
-oy
-oy
-oy
-oy
-oy
-Au
-Au
-BC
-Cp
-BC
-Au
-BC
-BC
-GD
-Hr
-Iu
-Jn
-GD
-Hr
-Iu
-Jn
-GD
+fa
+fb
+fb
+fb
+fa
+ke
+ke
+ju
+mv
+ke
+ju
+ju
+px
+px
+px
+px
+px
+px
+py
+py
+py
+py
+py
+wb
+py
+py
+py
+py
+py
+px
+px
+AA
+AA
+AA
+AA
+zW
+zW
+CH
+Fo
+CH
+GX
+HI
+HI
+JX
+KN
+LU
+MU
+JX
+KN
+LU
+MU
+JX
 ab
 ab
 ab
@@ -44660,61 +44668,61 @@ ab
 ab
 ac
 az
-bG
-cK
-dX
-eZ
-gj
-ho
-ij
-eY
-ka
-kU
-So
-mh
-kU
-nx
-jp
-ZB
-ZB
-ZB
-ZB
-ZB
-ZB
-rW
-sx
-sT
-tt
-tP
-ZF
-vb
-vI
-zw
-wx
-wx
-ZI
-xL
-yn
-yn
-zl
-zl
-Av
-yn
-BD
-Cq
-CW
-CW
-Ep
-Fx
-GE
-Hs
-Iv
-Jo
-GE
-Hs
-Iv
-Jo
-GD
+bH
+cM
+dZ
+fb
+gl
+hq
+im
+fa
+kf
+ld
+lD
+mw
+ld
+ol
+ju
+py
+py
+py
+py
+py
+py
+ts
+tW
+uv
+uX
+vt
+wc
+wO
+xw
+xX
+yq
+yq
+zp
+zS
+AB
+AB
+BN
+BN
+De
+DQ
+Eo
+Fp
+Gn
+GY
+HJ
+IU
+JY
+KO
+LV
+MV
+JY
+KO
+LV
+MV
+JX
 ab
 ab
 ab
@@ -44917,61 +44925,61 @@ ab
 ab
 ac
 aA
-bH
-cL
-dY
-eZ
-gk
-hp
-YR
-eY
-kb
-kV
-jZ
-mh
-kU
-ny
-jp
-oz
-pl
-pl
-pl
-pl
-rw
-rX
-sy
-sU
+bI
+cN
+ea
+fb
+gm
+hr
+in
+fa
+kg
+le
+ke
+mw
+ld
+om
+ju
+pz
+qt
+qt
+qt
+qt
+sQ
 tt
-ZE
-ut
-vc
-vI
-vK
-wy
-wy
-ZI
-xM
-xP
-xP
-zm
-zm
-xM
-xP
-xP
-xP
-xP
-xP
-Eq
-Fy
-GE
-Ht
-Iw
-Jo
-GE
-Ht
-Iw
-Jo
-GD
+tX
+uw
+uX
+vu
+wd
+wP
+xw
+xY
+yr
+yr
+zp
+zT
+AC
+Bg
+BO
+BO
+Df
+Dq
+Ep
+Fq
+zW
+zW
+HK
+IV
+JY
+KP
+LW
+MV
+JY
+KP
+LW
+MV
+JX
 ab
 ab
 ab
@@ -45174,61 +45182,61 @@ ab
 ab
 ac
 aB
-bI
-cM
-dZ
-eZ
-gl
-hq
-il
-eY
-jp
-jp
-jp
-mi
-mP
-nz
-jp
-oA
-pm
-pm
-pm
-pm
-rx
-rY
-sz
-sV
+bJ
+cO
+eb
+fb
+gn
+hs
+io
+fa
+ju
+ju
+ju
+mx
+ns
+on
+ju
+pA
+qu
+qu
+qu
+qu
+sR
 tu
-tQ
-uu
-vd
-vJ
-lw
-uw
-wP
-ZI
-xM
-yo
-UL
-zn
-zR
-Aw
-Bd
-Bk
-UV
-CX
-xP
-Eq
-Fz
-GE
-Hu
-Iv
-Jo
-GE
-Hu
-Iv
-Jo
-GD
+tY
+ux
+uY
+vv
+we
+wQ
+xx
+xZ
+wg
+yL
+zp
+zT
+AD
+Bh
+BP
+Cz
+Dg
+Dm
+DX
+Fr
+Go
+zW
+HK
+IW
+JY
+KQ
+LV
+MV
+JY
+KQ
+LV
+MV
+JX
 ab
 ab
 ab
@@ -45431,61 +45439,61 @@ ab
 ab
 ac
 aC
-bJ
-bF
-bF
-fa
-eZ
-hr
-im
-jm
-kc
-kW
-jp
-mj
-mQ
-nA
-jp
-oB
-pm
-pm
-pm
-pm
-ry
-rZ
-sA
-sW
-ZB
-tR
-uv
-tR
-ZB
-PG
-wz
-wQ
-xr
-xM
-yp
-Sc
-zo
-zS
-Ax
-Be
-BE
-YB
-CY
-xP
+bK
+bG
+bG
+fc
+fb
+ht
+ip
+jr
+kh
+lf
+ju
+my
+nt
+oo
+ju
+pB
+qu
+qu
+qu
+qu
+sS
+tv
+tZ
+uy
+py
+vw
+wf
+vw
+py
+ya
+ys
+yM
+zq
+zT
+AE
+Bi
+BQ
+CA
+Dh
+DR
 Eq
-FA
-GE
-Hv
-Ix
-Jp
-GE
-Hv
-Ix
-Jp
-GD
+Fs
+Gp
+zW
+HK
+IX
+JY
+KR
+LX
+MW
+JY
+KR
+LX
+MW
+JX
 ab
 ab
 ab
@@ -45688,61 +45696,61 @@ ab
 ab
 ad
 aD
-bK
-cN
-ea
-fb
-ea
-hs
-in
-jn
-kd
-kX
-lu
-mk
-mR
-nB
-jp
-oC
-pn
-pn
-pn
-pn
-rz
-rX
-sB
-ON
-tv
-tS
-uw
-ve
-Pb
-Vn
-wA
+bL
+cP
+ec
+fd
+ec
+hu
+iq
+js
+ki
+lg
+lE
+mz
+nu
+op
+ju
+pC
+qv
+qv
+qv
+qv
+sT
+tt
+ua
+uz
+uZ
+vx
+wg
 wR
-xs
-xM
-yq
-WQ
-zp
+xy
+yb
+yt
+yN
+zr
 zT
-Ay
-Bf
-BF
-Zo
-CZ
-xP
-Eq
-FB
-GF
-Hw
-Iy
-Jq
-Ke
-Hw
-Iy
-Jq
-GD
+AF
+Bj
+BR
+CB
+Di
+DS
+Er
+Ft
+Gq
+zW
+HK
+IY
+JZ
+KS
+LY
+MX
+NQ
+KS
+LY
+MX
+JX
 ab
 ab
 ab
@@ -45945,61 +45953,61 @@ ab
 ab
 ad
 aE
-bL
-cO
-eb
-eb
-gm
-ht
-io
-jo
-ke
-kY
-jo
-Sa
-mS
-nC
-jp
-oD
-po
-pT
-qx
-qU
-rA
-SP
-sC
-sY
-sY
-tT
-ux
-vf
-vL
-wl
-wB
+bM
+cQ
+ed
+ed
+go
+hv
+ir
+jt
+kj
+lh
+jt
+mA
+nv
+oq
+ju
+pD
+qw
+rj
+rO
+so
+sU
+tw
+ub
+uA
+uA
+vy
+wh
 wS
-xt
-xM
-yr
-Oh
-zn
-zU
-Az
-Bg
-BG
-UC
-Da
-xP
-Er
-FC
-GG
-Hx
-Iz
-Jr
-Kf
-KX
-LY
-MC
-GD
+xz
+yc
+yu
+yO
+zs
+zT
+AG
+Bk
+BP
+CC
+Dj
+DT
+Es
+Fu
+Gr
+zW
+HL
+IZ
+Ka
+KT
+LZ
+MY
+NR
+OM
+PI
+Qg
+JX
 ab
 ab
 ab
@@ -46202,61 +46210,61 @@ ab
 ab
 ad
 aF
-bM
-cP
-cQ
-cQ
-cP
-hu
-cP
-jp
-jp
-jp
-jp
-mm
-jp
-jp
-jp
-RY
-pp
-pU
-pp
-oK
-rA
-sb
-sD
-sD
-tw
-tU
-XZ
-RR
-PZ
-TU
-Vq
-TF
-SX
-xM
-ys
-SO
-zo
-zV
-Az
-Bh
-zo
-SM
-Db
-xP
-Es
-FB
-GH
-Hy
-IA
-Js
-Kg
-KY
-LZ
-MD
-GD
+bN
+cR
+cS
+cS
+cR
+hw
+cR
+ju
+ju
+ju
+ju
+mB
+ju
+ju
+ju
+pE
+qx
+rk
+qx
+sp
+sU
+tx
+uc
+uc
+va
+vz
+wi
+wT
+xA
+yd
+yv
+yP
+zt
+zT
+AH
+Bl
+BQ
+CD
+Dj
+DU
+BQ
+Fv
+Gs
+zW
+HM
+IY
+Kb
+KU
+Ma
+MZ
+NS
+ON
+PJ
+Qh
+JX
 ab
 ab
 ab
@@ -46459,61 +46467,61 @@ ab
 ab
 ad
 aG
-bN
-cQ
-ec
-fc
-gn
-hv
-ip
-cP
-kf
-kZ
-kZ
-kZ
-kZ
-kZ
-nY
-YW
-pq
-pV
+bO
+cS
+ee
+fe
+gp
+hx
+is
+cR
+kk
+li
+li
+li
+li
+li
+oU
+pF
 qy
-qW
-rA
-sc
-sE
-sZ
-tx
-tV
-uz
-vh
-vN
-RH
-wD
+rl
+rP
+sq
+sU
+ty
+ud
+uB
+vb
+vA
+wj
 wU
-RL
-xM
-yt
-JC
-zq
+xB
+ye
+yw
+yQ
+zu
 zT
-AA
-Bi
-BF
-ft
-Dc
-xP
-Es
-FD
-FF
-Hz
-IB
-Jt
-Kh
-KZ
-KZ
-IG
-Np
+AI
+Bm
+BS
+CB
+Dk
+DV
+Er
+Fw
+Gt
+zW
+HM
+Ja
+Jc
+KV
+Mb
+Na
+NT
+OO
+OO
+Mg
+QN
 ab
 ab
 ab
@@ -46716,61 +46724,61 @@ ab
 ab
 ad
 aF
-bO
-cR
-ed
-fd
-go
-hw
-iq
-jq
-kg
-SZ
-SZ
-SZ
-SZ
-SZ
-SZ
-oG
-pr
-pW
+bP
+cT
+ef
+ff
+gq
+hy
+it
+jv
+kl
+lj
+lj
+lj
+lj
+lj
+lj
+pG
 qz
-qX
-rA
-sd
-sF
-ta
-ty
-tW
-uA
-vi
-vO
-CQ
-wE
+rm
+rQ
+sr
+sU
+tz
+ue
+uC
+vc
+vB
+wk
 wV
-wV
-xM
-yu
-WR
-zn
+xC
+yf
+yx
+yR
+yR
+zT
+AJ
+Bn
+BP
+Cz
+Dl
+DW
+Et
+Fx
+Gu
 zW
-AB
-Bj
-BH
-NI
-Dd
-xP
-Es
-FE
-GI
-HA
-IC
-Ju
-Ki
-La
-Ma
-RN
-KZ
+HM
+Jb
+Kc
+KW
+Mc
+Nb
+NU
+OP
+PK
+Qi
+OO
 ab
 ab
 ab
@@ -46973,61 +46981,61 @@ ab
 ab
 ad
 aH
-bP
-cS
-ee
-fe
-gp
-hx
-ir
-cP
-kh
-SZ
-WW
-QI
-Yq
-WX
-SZ
-oH
-oH
-pX
-oH
-qY
-rA
-ZB
-ZB
-ZB
-ZB
-tX
-uB
-vj
-ZH
-ZH
-ZH
-ZH
-ZH
-xM
-yv
-TJ
-zo
+bQ
+cU
+eg
+fg
+gr
+hz
+iu
+cR
+km
+lj
+lF
+mC
+nw
+or
+lj
+pH
+pH
+rn
+pH
+ss
+sU
+py
+py
+py
+py
+vC
+wl
+wW
+xD
+xD
+xD
+xD
+xD
 zT
-AC
-Bk
-BI
-SN
-De
-xP
-Es
-FF
-GJ
-HB
-ID
-Jv
-Kj
-Lb
-Mb
-MF
-KZ
+AK
+Bo
+BQ
+CB
+Dm
+DX
+Eu
+Fy
+Gv
+zW
+HM
+Jc
+Kd
+KX
+Md
+Nc
+NV
+OQ
+PL
+Qj
+OO
 ab
 ab
 ab
@@ -47230,61 +47238,61 @@ ab
 ab
 ad
 aF
-bQ
-cP
-ef
-ff
-gq
-hy
-is
-cP
-kh
-SZ
-YD
-VV
-vA
-uQ
-dn
+bR
+cR
+eh
+fh
+gs
+hA
+iv
+cR
+km
+lj
+lG
+mD
+nx
+os
+oV
+pI
 qA
-Ny
-pY
-qA
-qZ
-rB
-se
-qA
-TC
-tb
-tY
-uC
-qZ
-vP
-oI
-wF
-oI
-wF
-xN
-yw
-Yn
-zr
-zX
-AD
-Bl
-BJ
-Sz
-Df
-xP
-Es
-FF
-GK
-HC
-IE
-Jv
-Kk
-Lc
-Mc
-MG
-KZ
+ro
+pI
+st
+sV
+tA
+pI
+uD
+vd
+vD
+wm
+st
+xE
+yg
+yy
+yg
+yy
+zU
+AL
+Bp
+BT
+CE
+Dn
+DY
+Ev
+Fz
+Gw
+zW
+HM
+Jc
+Ke
+KY
+Me
+Nc
+NW
+OR
+PM
+Qk
+OO
 ab
 ab
 ab
@@ -47487,61 +47495,61 @@ ab
 ab
 ae
 aI
-bR
-cP
-cP
-cP
-cP
-cP
-cP
-cP
-kh
-SZ
-Ze
-Ph
-UJ
-XW
-oj
-YT
-pt
-pZ
+bS
+cR
+cR
+cR
+cR
+cR
+cR
+cR
+km
+lj
+lH
+mE
+ny
+ot
+oW
+pJ
 qB
-ra
-rC
-sf
-sf
-tc
-tz
-tZ
-sf
-vk
-vQ
-wn
-wG
-wW
-xv
-xO
-yx
+rp
+rR
+su
+sW
+tB
+tB
+uE
+ve
+vE
+tB
+wX
+xF
+yh
+yz
 yS
-zs
-zY
-AE
-Bm
-Cy
-YU
-Dg
-DG
-Et
-FF
-FF
-HD
-FF
-Jw
-Kl
-Ld
-IG
-IG
-Np
+zv
+zV
+AM
+Bq
+BU
+CF
+Do
+DZ
+Ew
+FA
+Gx
+GZ
+HN
+Jc
+Jc
+KZ
+Jc
+Nd
+NX
+OS
+Mg
+Mg
+QN
 ab
 ab
 ab
@@ -47744,61 +47752,61 @@ ab
 ab
 ae
 aJ
-bS
-cT
-eg
-eg
-eg
-eg
-eg
-eg
-ki
-OJ
-Uw
-VB
-Qf
-uP
-SZ
-YQ
-pu
-qa
-la
-la
-rD
-sg
-sG
-td
-la
-rD
-uD
-sG
-vR
-la
-rD
-wX
-sG
-xP
-xP
+bT
+cV
+ei
+ei
+ei
+ei
+ei
+ei
+kn
+lk
+lI
+mF
+nz
+ou
+lj
+pK
+qC
+rq
+rS
+rS
+sX
+tC
+uf
+uF
+rS
+sX
+wn
+uf
+xG
+rS
+sX
 yT
-Wx
-PQ
-QZ
-Ve
-BL
-Za
-BL
-DH
-Eu
-FG
-GL
-HE
-IF
-Jx
-Km
-Le
-IF
-MH
-Nq
+uf
+zW
+zW
+Br
+BV
+CG
+Dp
+Ea
+Ex
+FB
+Ex
+Ha
+HO
+Jd
+Kf
+La
+Mf
+Ne
+NY
+OT
+Mf
+Ql
+QO
 ab
 ab
 ab
@@ -48001,61 +48009,61 @@ ab
 ab
 ae
 aI
-bT
+bU
 aR
 aR
 aR
 aR
-hz
-hz
-hz
-hz
-SZ
-Pn
-Qh
-Vd
-Xe
-SZ
-oL
-pv
-qb
-la
-rb
-rE
-sh
-sh
-td
-tA
-rE
-sh
-vl
-vS
-la
-rE
-sh
-sh
-xQ
-xP
-xP
-VA
-Aa
-Aa
-Aa
-Aa
-xP
-Aa
-DI
-Ev
-Ev
-GM
-Ev
-IG
-Jy
-Kn
-Lf
-IG
-MI
-Nq
+hB
+hB
+hB
+hB
+lj
+lJ
+mG
+nA
+ov
+lj
+pL
+qD
+rr
+rS
+sv
+sY
+tD
+tD
+uF
+vf
+sY
+tD
+wY
+xH
+rS
+sY
+tD
+tD
+zX
+zW
+zW
+BW
+CH
+CH
+CH
+CH
+zW
+CH
+Hb
+HP
+HP
+Kg
+HP
+Mg
+Nf
+NZ
+OU
+Mg
+Qm
+QO
 ab
 ab
 ab
@@ -48258,61 +48266,61 @@ ab
 ab
 ae
 aK
-bU
-cU
-eh
-fg
-gr
-hA
-it
-js
-kj
-SZ
-Rd
-OK
-Xc
-zg
-SZ
-oM
-pw
-qc
-la
-rc
-rF
-rF
-rF
-td
-tB
-rF
-rF
-vm
-vT
-la
-rF
-rF
-rF
-xR
-xP
-PJ
-VY
-Ab
-ZW
-Bo
-Bo
-Aa
+bV
+cW
+ej
+fi
+gt
+hC
+iw
+jw
+ko
+lj
+lK
+mH
+nB
+ow
+lj
+pM
+qE
+rs
+rS
+sw
+sZ
+sZ
+sZ
+uF
+vg
+sZ
+sZ
+wZ
+xI
+rS
+sZ
+sZ
+sZ
+zY
+zW
+Bs
+BX
+CI
+Dq
+Eb
+Eb
+CH
 ab
-DJ
-Ew
-FH
-GN
-HF
-IH
-Jz
-Ko
-Lg
-Ev
-MI
-Nq
+Hc
+HQ
+Je
+Kh
+Lb
+Mh
+Ng
+Oa
+OV
+HP
+Qm
+QO
 ab
 ab
 ab
@@ -48515,61 +48523,61 @@ ab
 ab
 ae
 aL
-bV
-cV
-ei
-fh
-gs
-hB
-iu
-jt
-kk
-SZ
-uy
-CR
-XO
-Oi
-SZ
-oN
-px
-lG
-la
-rd
-rF
-rF
-sH
-te
-re
-rF
-uE
-vn
-vU
-la
-rF
-rF
-xw
-xS
-xP
-yV
-pS
-Ac
+bW
+cX
+ek
+fj
+gu
+hD
+ix
+jx
+kp
+lj
+lL
+mI
+nC
+ox
+lj
+pN
+qF
+rt
+rS
+sx
+sZ
+sZ
+ug
+uG
+sy
+sZ
+wo
+xa
+xJ
+rS
+sZ
+sZ
+zw
 zZ
-Bp
-Bp
-Aa
+zW
+Bt
+BY
+CJ
+Dq
+Ec
+Ec
+CH
 ab
-DJ
-Ex
-FI
-GO
-FJ
-FJ
-FJ
-Kp
-Lh
-Ev
-MI
-Nq
+Hc
+HR
+Jf
+Ki
+Jg
+Jg
+Jg
+Ob
+OW
+HP
+Qm
+QO
 ab
 ab
 ab
@@ -48772,61 +48780,61 @@ ab
 ab
 ad
 aM
-bW
-cW
-ej
-fi
-gt
-hA
-iv
-ju
-kl
-SZ
-Oo
-VV
-VV
-TM
-SZ
-oO
-py
-OC
-la
-re
-rF
-rF
-rF
-tf
-re
-rF
-rF
-vm
-vV
-la
-rF
-rF
-rF
-vV
-xP
-yW
-pS
-Ad
-AG
-Bq
-Bq
-Aa
+bX
+cY
+el
+fk
+gv
+hC
+iy
+jy
+kq
+lj
+lM
+mD
+mD
+oy
+lj
+pO
+qG
+ru
+rS
+sy
+sZ
+sZ
+sZ
+uH
+sy
+sZ
+sZ
+wZ
+xK
+rS
+sZ
+sZ
+sZ
+xK
+zW
+Bu
+BY
+CK
+Dr
+Ed
+Ed
+CH
 ab
-DJ
-Pt
-FJ
-GP
-HG
-FJ
-JA
-Kq
-Li
-Ev
-MI
-Nr
+Hc
+HS
+Jg
+Kj
+Lc
+Jg
+Nh
+Oc
+OX
+HP
+Qm
+QP
 ab
 ab
 ab
@@ -49029,61 +49037,61 @@ ab
 ab
 ad
 aN
-bX
-cX
-ek
-fj
-gu
-hA
-iw
-jv
-km
-SZ
-nX
-TQ
-Ra
-rQ
-SZ
-oL
-pv
-qb
-la
-rf
-rG
-si
-sI
-tg
-rf
-rG
-uF
-vo
-vW
-la
-rG
-rG
-rG
-xT
-xP
-yX
-sq
-SD
-Wz
-Br
-Br
+bY
+cZ
+em
+fl
+gw
+hC
+iz
+jz
+kr
+lj
+lN
+mJ
+nD
+oz
+lj
+pL
+qD
+rr
+rS
+sz
+ta
+tE
+uh
+uI
+sz
+ta
+wp
+xb
+xL
+rS
+ta
+ta
+ta
 Aa
+zW
+Bv
+BZ
+CL
+Ds
+Ee
+Ee
+CH
 ab
-DJ
-Ez
-FK
-GQ
-HH
-II
-FJ
-Kp
-Lj
-Ev
-MI
-Nr
+Hc
+HT
+Jh
+Kk
+Ld
+Mi
+Jg
+Ob
+OY
+HP
+Qm
+QP
 ab
 ab
 ab
@@ -49286,61 +49294,61 @@ ab
 ab
 ad
 aO
-bR
+bS
 aR
 ad
 aR
 aR
-hA
-ix
-jw
-kn
-SZ
-SZ
-SZ
-SZ
-SZ
-SZ
-oP
-pz
-qf
-la
-la
-la
-la
-lD
-la
-la
-la
-sJ
-la
-la
-la
-la
-la
-la
-sJ
-xP
-xP
-xM
-xP
-AI
-xP
-xP
-xP
-Aa
-DI
-Ev
-Ev
-GM
-Ev
-Ev
-JB
-Kp
-Lk
-Ev
-MI
-Nr
+hC
+iA
+jA
+ks
+lj
+lj
+lj
+lj
+lj
+lj
+pP
+qH
+rv
+rS
+rS
+rS
+rS
+ui
+rS
+rS
+rS
+wq
+rS
+rS
+rS
+rS
+rS
+rS
+wq
+zW
+zW
+zT
+zW
+Dt
+zW
+zW
+zW
+CH
+Hb
+HP
+HP
+Kg
+HP
+HP
+Ni
+Ob
+OZ
+HP
+Qm
+QP
 ab
 ab
 ab
@@ -49543,61 +49551,61 @@ ab
 ab
 ad
 aN
-bY
-cY
-el
-fk
+bZ
+da
+en
+fm
 aR
-hC
-iy
-jx
-ko
-lc
-lE
-ob
-ob
-nK
-ob
-oQ
-pA
-Tt
-Tc
-YK
-Zv
-PV
-mq
-th
-tC
-rH
-uG
-vp
-tC
-rH
-rH
-wY
-rg
-qg
-rH
-qC
-zy
-rH
-qg
-rH
-BM
-CA
-Di
-DK
-EA
-FL
-GR
-HI
-IJ
-NK
-Kr
-Ll
-Ev
-MJ
-Nr
+hE
+iB
+jB
+kt
+ll
+lO
+mK
+mK
+oA
+mK
+pQ
+qI
+rw
+rT
+sA
+tb
+tF
+uj
+uJ
+vh
+vF
+wr
+xc
+vh
+vF
+vF
+yU
+zx
+Ab
+vF
+Bw
+Ca
+vF
+Ab
+vF
+Ey
+FC
+Gy
+Hd
+HU
+Ji
+Kl
+Le
+Mj
+Nj
+Od
+Pa
+HP
+Qn
+QP
 ab
 ab
 ab
@@ -49800,61 +49808,61 @@ ab
 ab
 ad
 aP
-bZ
-cZ
-em
-fl
-gv
-hD
-iz
-jy
-kp
-ld
-ZA
-Ty
-oc
-oc
-oc
-oR
-pB
-Ri
-Cx
-Cx
-Yo
-Yo
-eS
-ti
-tD
-qD
-Rp
-vq
-tD
-qD
-qD
-qD
-qD
-xU
-qD
-qD
-zz
-Af
-qD
-qD
-BN
-YN
-uc
-DJ
-EB
-FM
-GS
-HJ
-DK
-JD
-Ks
-Lm
-Ev
-MI
-Nr
+ca
+db
+eo
+fn
+gx
+hF
+iC
+jC
+ku
+lm
+lP
+mL
+nE
+nE
+nE
+pR
+qJ
+rx
+rU
+rU
+tc
+tc
+uk
+uK
+vi
+vG
+ws
+xd
+vi
+vG
+vG
+vG
+vG
+Ac
+vG
+vG
+Cb
+CM
+vG
+vG
+Ez
+FD
+vJ
+Hc
+HV
+Jj
+Km
+Lf
+Hd
+Nk
+Oe
+Pb
+HP
+Qm
+QP
 ab
 ab
 ab
@@ -50057,61 +50065,61 @@ ab
 ab
 ad
 aQ
-ca
-da
-en
-fm
-gw
-hE
-iA
-iA
-kq
-le
-oS
-mx
-AJ
-od
-od
-oS
-pC
-qi
-qi
-qi
-od
-od
-sK
-tj
-tE
-ua
-uI
-vr
-vX
-od
-wH
-wZ
-wZ
-xV
-yy
-od
-qi
-od
-AJ
-od
-BO
-CC
-Dj
-DL
-EC
-FN
-GT
-HK
-IK
-JE
-Kt
-Ln
-IK
-MI
-Nr
+cb
+dc
+ep
+fo
+gy
+hG
+iD
+iD
+kv
+ln
+lQ
+mM
+nF
+oB
+oB
+lQ
+qK
+ry
+ry
+ry
+oB
+oB
+ul
+uL
+vj
+vH
+wt
+xe
+xM
+oB
+yA
+yV
+yV
+Ad
+AN
+oB
+ry
+oB
+nF
+oB
+EA
+FE
+Gz
+He
+HW
+Jk
+Kn
+Lg
+Mk
+Nl
+Of
+Pc
+Mk
+Qm
+QP
 ab
 ab
 ab
@@ -50314,61 +50322,61 @@ ab
 ab
 ae
 aR
-cb
-db
-eo
-fn
+cc
+dd
+eq
+fp
 aR
-hF
-iB
-jz
-kr
-lc
-lH
-my
-nd
-nM
-nM
-oT
-pD
-nM
-nM
-nM
-rI
-rI
-rI
-rI
-rI
-ub
-uJ
-vs
-vY
-vZ
-ND
-xa
-xx
-xW
-yz
-yY
-yY
-yY
-AK
-yY
-BP
-CD
-Dk
-ZX
-ED
-DM
-DM
-DM
-IK
-JF
-Ku
-Lo
-IK
-MI
-Nq
+hH
+iE
+jD
+kw
+ll
+lR
+mN
+nG
+oC
+oC
+pS
+qL
+oC
+oC
+oC
+td
+td
+td
+td
+td
+vI
+wu
+xf
+xN
+xO
+yB
+yW
+zy
+Ae
+AO
+Bx
+Bx
+Bx
+Du
+Bx
+EB
+FF
+GA
+Hf
+HX
+Hg
+Hg
+Hg
+Mk
+Nm
+Og
+Pd
+Mk
+Qm
+QO
 ab
 ab
 ab
@@ -50571,61 +50579,61 @@ ab
 ab
 ae
 aR
-cc
-dc
-ep
-fo
-gx
-hG
-iC
-jA
-ks
+cd
+de
+er
+fq
+gz
+hI
+iF
+jE
+kx
 aR
-lI
-mz
-ne
-nM
-oe
-oU
-pE
-qj
-qE
-nM
-rJ
-sj
-rK
-rK
-tF
-uc
-uK
-vt
-vY
-vZ
-wJ
-xb
-xy
-xX
-yz
-yY
-zA
-Ag
-AL
-yY
-BQ
-CE
-Dl
-DM
-EE
-FO
-GU
-DM
-IK
-JG
-Kv
-Lp
-IK
-MK
-Nq
+lS
+mO
+nH
+oC
+oX
+pT
+qM
+rz
+rV
+oC
+te
+tG
+um
+tf
+vk
+vJ
+wv
+xg
+xN
+xO
+yC
+yX
+zz
+Af
+AO
+Bx
+Cc
+CN
+Dv
+Bx
+EC
+FG
+GB
+Hg
+HY
+Jl
+Ko
+Hg
+Mk
+Nn
+Oh
+Pe
+Mk
+Qo
+QO
 ab
 ab
 ab
@@ -50831,58 +50839,58 @@ aR
 aR
 aR
 aR
-fp
+fr
 aR
 aR
 aR
 aR
 aR
 aR
-lJ
-mA
-ne
-nM
-of
-oV
-pF
-qk
-qk
-rh
-rK
-sk
-sL
-rI
-rI
-ud
-uL
-vu
-vY
-vZ
-wK
-xc
-xz
-xY
-yz
+lT
+mP
+nH
+oC
+oY
+pU
+qN
+rA
+rW
+sB
+tf
+tH
+tf
+uM
+td
+vK
+ww
+xh
+xN
+xO
+yD
 yY
-yY
-Ah
-AM
-Bv
-BR
-CE
-Dm
-DM
-EF
-FP
-GV
-DM
-IK
-JH
-IK
-IK
-IK
-MI
-Nq
+zA
+Ag
+AO
+Bx
+Bx
+CO
+Dw
+Ef
+ED
+FG
+GC
+Hg
+HZ
+Jm
+Kp
+Hg
+Mk
+No
+Mk
+Mk
+Mk
+Qm
+QO
 ab
 ab
 ab
@@ -51084,62 +51092,62 @@ ab
 ab
 ab
 af
-Zf
-cd
-dd
-Zi
-fq
-gy
-eq
-eq
-eq
-We
-YV
-UN
-TX
-nf
-nN
-og
-oW
-pG
-ql
-qF
-nM
-rK
-sl
-sM
-rI
-rI
-ue
-uM
-vv
-vY
-vZ
-ow
-xd
-xA
-xZ
-yA
+aS
+ce
+df
+es
+fs
+gA
+hJ
+hJ
+hJ
+ky
+lo
+lU
+mQ
+nI
+oD
+oZ
+pV
+qO
+rB
+rX
+oC
+tf
+tI
+un
+uN
+td
+vL
+wx
+xi
+xN
+xO
+yE
 yZ
 zB
-Ai
-AN
-yY
-BS
-CF
-Dn
-DN
-EG
-FQ
-GW
-HL
-IL
-JI
-JI
-JI
-JI
-ML
-Nq
+Ah
+AP
+By
+Cd
+CP
+Dx
+Bx
+EE
+FH
+GD
+Hh
+Ia
+Jn
+Kq
+Lh
+Ml
+Np
+Np
+Np
+Np
+Qp
+QO
 ab
 ab
 ab
@@ -51342,61 +51350,61 @@ ab
 ab
 ag
 aT
-ce
+cf
 aZ
 aZ
-fr
-gz
-hH
-hH
-hH
-SJ
-lg
-lK
-mz
-ne
-nO
-nO
-nO
-nO
-nO
-qG
-qG
-rL
-qG
-qG
-qG
-sQ
-uf
-Wk
-vw
-vZ
-vZ
-vZ
-xe
-vZ
-vZ
-wr
+ft
+gB
+hK
+hK
+hK
+kz
+lp
+lV
+mO
+nH
+oE
+oE
+oE
+oE
+oE
+rY
+rY
+rY
+rY
+rY
+rY
+us
+vM
+wy
+xj
+xO
+xO
+xO
 za
-za
-Aj
-za
-za
-BT
-CG
-Dm
-DO
-EH
-FR
-DM
-DM
-IM
-DQ
-DQ
-DQ
-DQ
-DQ
-Ns
+xO
+xO
+yl
+Bz
+Bz
+CQ
+Bz
+Bz
+EF
+FI
+GC
+Hg
+Ib
+Jo
+Hg
+Hg
+Mm
+Hk
+Hk
+Hk
+Hk
+Hk
+QQ
 ab
 ab
 ab
@@ -51599,61 +51607,61 @@ ab
 ab
 ag
 aU
-cf
-de
+cg
+dg
 aZ
-fs
-gA
-hI
-iD
-hH
-aS
-lg
-lK
-mz
-ne
-nO
-oh
-oX
-pH
-nP
-qH
-ri
-rM
-sm
-rN
+fu
+gC
+hL
+iG
+hK
+kA
+lp
+lV
+mO
+nH
+oE
+pa
+pW
+qP
+oF
+rZ
+sC
+tg
+tJ
+uo
 ab
-no
-ug
-uO
-vx
-OD
+vl
+vN
+wz
+xk
+xP
 ab
-wM
-xf
-xB
-ya
-yB
+yF
 zb
 zC
-Ak
-AO
-za
-BQ
-CE
-Dm
-Qz
-EH
-FS
-DQ
-HM
-IN
-JJ
-Kw
-Lq
-Md
-MM
-Ns
+Ai
+AQ
+BA
+Ce
+CR
+Dy
+Bz
+EC
+FG
+GC
+Hg
+Ic
+Jo
+Hk
+Li
+Mn
+Nq
+Oi
+Pf
+PN
+Qq
+QQ
 ab
 ab
 ab
@@ -51856,61 +51864,61 @@ ab
 ab
 ah
 aV
-cg
-df
+ch
+dh
 aZ
-OB
-gB
-hJ
-iE
-hH
-aS
-lg
-lL
-Uf
-SH
-nO
-oh
-oY
-pI
-nP
-qI
-rj
-ZC
-sn
-rN
+fv
+gD
+hM
+iH
+hK
+kA
+lp
+lW
+mR
+nJ
+oE
+pa
+pX
+qQ
+oF
+sa
+sD
+th
+tK
+uo
 ab
-Tl
-uh
-Qq
-ZZ
-Tl
+vm
+vO
+wA
+xl
+vm
 ab
-wM
-xf
-xC
-xC
-yC
+yF
 zb
 zD
-Al
-AP
-za
-Ot
-VW
-Dm
-DO
-EI
-FT
-DQ
-HN
-IN
-JK
-Kx
-JK
-JK
-MN
-Ns
+zD
+AR
+BA
+Cf
+CS
+Dz
+Bz
+EG
+FJ
+GC
+Hg
+Id
+Jp
+Hk
+Lj
+Mn
+Nr
+Oj
+Nr
+Nr
+Qr
+QQ
 ab
 ab
 ab
@@ -52113,61 +52121,61 @@ ab
 ab
 ah
 aW
-cg
-dg
+ch
+di
 aZ
-Ud
-gC
+fw
+gE
+hN
+iI
 hK
-iF
-hH
-aS
-lg
-lM
-VE
-VR
-nP
-oh
-oZ
-pI
-nP
-qJ
-rk
-ZD
-so
-sN
-rT
-tI
-Vu
-Us
-Sg
-tI
-wo
-wo
-xg
-xD
-xD
-yD
-zb
+kA
+lp
+lX
+mS
+nK
+oF
+pa
+pY
+qQ
+oF
+sb
+sE
+ti
+tL
+up
+to
+vn
+vP
+wB
+xm
+vn
+yi
+yi
+zc
 zE
-za
-Aj
-za
-Pf
-QP
-Do
-DM
-DM
-DM
-DQ
-HO
-IO
-JL
-Ky
-JK
-JK
-MO
-Nt
+zE
+AS
+BA
+Cg
+Bz
+CQ
+Bz
+EH
+FK
+GE
+Hg
+Hg
+Hg
+Hk
+Lk
+Mo
+Ns
+Ok
+Nr
+Nr
+Qs
+QR
 ab
 ab
 ab
@@ -52370,61 +52378,61 @@ ab
 ab
 ah
 aX
-ch
-dh
-er
-fv
-gD
-hH
-hH
-hH
-aS
-lg
-lK
-NH
-Vi
-nP
-oh
-oY
-pI
-pe
-qK
-rl
-rO
-sp
-sO
-tk
-tJ
-Oz
-Zu
-Yi
-wb
-wp
-wN
-xh
-xE
-yb
-yE
-zc
+ci
+dj
+et
+fx
+gF
+hK
+hK
+hK
+kA
+lp
+lV
+mT
+nL
+oF
+pa
+pX
+qQ
+qg
+sc
+sF
+tj
+tM
+uq
+uO
+vo
+vQ
+wC
+xn
+xQ
+yj
+yG
+zd
 zF
-Am
-AQ
-Bw
-ZY
-Re
-Dp
-DR
-EJ
-FU
-DR
-HP
-Xp
-QL
-Kz
-Lr
-JK
-MP
+Aj
+AT
+BB
+Ch
+CT
+DA
+BE
+EI
+FL
+GF
+Hi
+Ie
+Jq
+Hi
+Ll
+Mp
 Nt
+Ol
+Pg
+Nr
+Qt
+QR
 ab
 ab
 ab
@@ -52626,62 +52634,62 @@ ab
 ab
 ab
 ag
-WF
-ci
-di
-es
-fw
-gE
-hL
-hL
-hL
-kt
-hL
-lN
-Ob
-QA
-nP
-oh
-ZT
-pI
-pe
-qL
-rm
-ib
-Nz
-sP
-tl
-tK
-mB
-OY
-Uu
-wc
-wq
-wO
-xi
-xF
-yc
-yF
-zd
+aY
+cj
+dk
+eu
+fy
+gG
+hO
+hO
+hO
+kB
+hO
+lY
+mU
+nM
+oF
+pa
+pZ
+qQ
+qg
+sd
+sG
+tk
+tN
+ur
+uP
+vo
+vR
+wD
+xo
+xR
+yk
+yH
+ze
 zG
-An
-AR
-Bx
-ZG
-Qy
-Dq
-DS
-EK
-FV
-GX
-HQ
-IQ
-Si
-Kz
-Lr
-Me
-MQ
-Nt
+Ak
+AU
+BC
+Ci
+CU
+DB
+Eg
+EJ
+FM
+GG
+Hj
+If
+Jr
+Kr
+Lm
+Mq
+Nu
+Ol
+Pg
+PO
+Qu
+QR
 ab
 ab
 ab
@@ -52884,61 +52892,61 @@ ab
 ab
 ag
 aZ
-ce
-dj
+cf
+dl
 aZ
-fx
-gF
-hM
-iG
-jB
-iH
-hM
-lK
-ST
-SW
-nP
-oh
-VO
-pI
-pe
-Xs
-rn
-Qo
-WC
-rT
-rT
-tI
-ul
-Sx
-SS
-tI
-wo
-wo
-xj
-xG
-yd
-yG
-ze
+fz
+gH
+hP
+iJ
+jF
+iK
+hP
+lV
+mV
+nN
+oF
+pa
+qa
+qQ
+qg
+se
+sH
+tl
+tO
+to
+to
+vn
+vS
+wE
+xp
+vn
+yi
+yi
+zf
 zH
-Ao
-AS
-Bx
-Pz
-Ui
-Dr
-DQ
-EL
-DQ
-DQ
-HR
-IR
-ZJ
-Og
-Ls
-Mf
-MR
-Nt
+Al
+AV
+BD
+Cj
+CV
+DC
+Eg
+EK
+FN
+GH
+Hk
+Ig
+Hk
+Hk
+Ln
+Mr
+Nv
+Om
+Ph
+PP
+Qv
+QR
 ab
 ab
 ab
@@ -53141,61 +53149,61 @@ ab
 ab
 ai
 ba
-cj
-dk
-et
-fy
-gG
-hN
-iH
-iH
-iH
-hM
-lI
-Vb
-UX
-nP
-oh
+ck
+dm
+ev
+fA
+gI
+hQ
+iK
+iK
+iK
+hP
+lS
+mW
+nO
+oF
 pa
-pJ
-qm
-qM
-ro
-Ql
-yN
-rS
+qb
+qR
+rC
+sf
+sI
+tm
+tP
+tp
 ab
-no
-um
-WL
-Yp
-OD
+vl
+vT
+wF
+xq
+xP
 ab
-wM
-xk
-xH
-ye
-yH
-Bw
+yF
+zg
 zI
-PK
-AT
-Bx
-YX
-Vl
-Ds
-DT
-EM
-FW
-DQ
-HS
-IS
-JK
-JK
-Lt
-Mg
-MS
-Ns
+Am
+AW
+BE
+Ck
+CW
+DD
+Eg
+EL
+FO
+GI
+Hl
+Ih
+Js
+Hk
+Lo
+Ms
+Nr
+Nr
+Pi
+PQ
+Qw
+QQ
 ab
 ab
 ab
@@ -53398,61 +53406,61 @@ ab
 ab
 ai
 bb
-ck
-dl
-eu
-fz
-gH
-hM
-iI
-iH
-ku
-hM
-lK
-Tq
-XY
+cl
+dn
+ew
+fB
+gJ
+hP
+iL
+iK
+kC
+hP
+lV
+mX
 nP
-oh
-pb
-pe
-pe
-OR
-rp
-RT
-ss
-rS
+oF
+pa
+qc
+qg
+qg
+sg
+sJ
+tn
+tQ
+tp
 ab
-Tl
-uk
-Wg
-RW
-Tl
+vm
+vU
+wG
+xr
+vm
 ab
-wM
-xl
-xI
-yf
-yI
-Vt
+yF
+zh
 zJ
-Aq
-AU
-By
-OS
-Ww
-Dm
-DT
+An
+AX
+BF
+Cl
+CX
+DE
+Eh
 EM
-FX
-DQ
-HT
-IT
-JN
-KB
-Lu
-Mh
-MT
-Ns
+FP
+GC
+Hl
+Ih
+Jt
+Hk
+Lp
+Mt
+Nw
+On
+Pj
+PR
+Qx
+QQ
 ab
 ab
 ab
@@ -53654,62 +53662,62 @@ ab
 ab
 ab
 ai
-XC
-Ye
-dm
-ev
-fA
-gI
-hM
-iJ
-jC
-jC
-hM
-lK
-mD
-nj
-nP
-oh
-pb
-pK
-qn
-qN
-rq
-rT
-NA
-sQ
-sQ
-sQ
-un
-Wk
-vF
-sQ
-wr
-wr
-wr
-wr
-wr
-wr
-xm
-zK
-xm
-AV
-xm
-BQ
-CI
-Dt
-DT
-EN
-FY
-DQ
-DQ
-DQ
-DQ
-DQ
-DQ
-DQ
-DQ
-Ns
+bc
+cm
+do
+ex
+fC
+gK
+hP
+iM
+jG
+jG
+hP
+lV
+mY
+nQ
+oF
+pa
+qc
+qS
+rD
+sh
+sK
+to
+tR
+us
+us
+us
+vV
+wy
+xs
+us
+yl
+yl
+yl
+yl
+yl
+yl
+zi
+Cm
+zi
+DF
+zi
+EC
+FQ
+GJ
+Hl
+Ii
+Ju
+Hk
+Hk
+Hk
+Hk
+Hk
+Hk
+Hk
+Hk
+QQ
 ab
 ab
 ab
@@ -53911,62 +53919,62 @@ aa
 ab
 ab
 ai
-Ya
-cm
-he
-ew
-fB
-gJ
-hM
+bd
+cn
+dp
+ey
+fD
+gL
+hP
+iN
 iK
-iH
-jC
-hM
-lK
-mz
-nk
-nQ
-ok
-pc
-pe
-vz
-qO
-rr
-rT
-st
-sR
-tm
-tL
-uo
-uU
-vG
-wd
-ws
-sR
-xm
-xm
-yg
-yJ
-Vy
-zL
-Vy
-AW
-xm
-BQ
-CE
-Dm
-Zb
-EO
-FZ
-FZ
-FZ
-FZ
-FZ
-FZ
-FZ
-FZ
-MU
-Nh
+jG
+hP
+lV
+mO
+nR
+oG
+pb
+qd
+qg
+rE
+si
+sL
+to
+tS
+ut
+uQ
+vp
+vW
+wH
+xt
+xS
+ym
+ut
+zi
+zi
+Ao
+AY
+BG
+Cn
+BG
+DG
+zi
+EC
+FG
+GC
+Hm
+Ij
+Jv
+Jv
+Jv
+Jv
+Jv
+Jv
+Jv
+Jv
+Qy
+QL
 ab
 ab
 ab
@@ -54170,60 +54178,60 @@ aa
 aj
 be
 ai
-YG
-ex
+dq
+ez
 be
-gK
-hM
-UB
-hM
-hM
-hM
-ZM
-mF
-nl
-nR
-ol
-pd
-pL
-qp
-qP
-rs
-rS
-st
-sR
-tn
-tM
-up
-uV
-Zj
-Zk
-wt
-Zm
-Zn
-xm
-yh
-yK
-yK
-zM
-yK
-AX
-xm
-BQ
-CE
-Dm
-DU
-DU
-DU
-DU
-HU
-HU
-HU
-HU
-HU
-HU
-MV
-Nh
+gM
+hP
+iO
+hP
+hP
+hP
+lZ
+mZ
+nS
+oH
+pc
+qe
+qT
+rF
+sj
+sM
+tp
+tS
+ut
+uR
+vq
+vX
+wI
+xu
+xT
+yn
+yI
+zj
+zi
+Ap
+AZ
+AZ
+Co
+AZ
+DH
+zi
+EC
+FG
+GC
+Hn
+Hn
+Hn
+Hn
+Lq
+Lq
+Lq
+Lq
+Lq
+Lq
+Qz
+QL
 ab
 ab
 ab
@@ -54424,63 +54432,63 @@ aa
 aa
 aa
 aa
-Wr
+ak
 bf
-am
-dp
-ey
-fC
-gL
-Yc
-Tk
-iM
-iM
-lh
-ZN
-ZP
-ZR
-nS
-om
-ZV
-pe
-qq
-qO
-rt
-rS
-st
-sR
-to
-tM
-ts
+co
+dr
+eA
+fE
+gN
+hR
+iP
+jH
+jH
+lq
+ma
+na
+nT
+oI
+pd
+qf
+qg
+rG
+si
+sN
+tp
+tS
+ut
+uS
+vq
 uW
-vH
-we
-ts
-sR
-Zp
-xm
-XL
-yL
-yL
-zN
-yK
-AY
-xm
-BS
-CH
-Du
-DV
-EP
-Ga
-GY
-HV
-IU
-JO
-KC
-Lv
-HU
-MV
-Nu
+wJ
+xv
+xU
+uW
+ut
+zk
+zi
+Aq
+Ba
+Ba
+Cp
+AZ
+DI
+zi
+EE
+FR
+GK
+Ho
+Ik
+Jw
+Ks
+Lr
+Mu
+Nx
+Oo
+Pk
+Lq
+Qz
+QS
 ab
 ab
 ab
@@ -54684,60 +54692,60 @@ aa
 al
 bf
 ai
-dq
-ez
-fD
-QH
-gM
-Ps
-jD
-Zt
-SQ
-ZO
-ZQ
-ZS
-nO
-on
+ds
+eB
+fF
+gO
+hS
+iQ
+jI
+kD
+lr
+mb
+nb
+nU
+oE
 pe
-pe
-qr
-qO
-ru
-rS
-st
-sR
+qg
+qg
+rH
+si
+sO
 tp
-tM
-uq
-uX
-ts
-we
-wu
-sR
-Zp
-xm
-Tb
-yL
+tS
+ut
+uT
+vq
+vY
+wK
+uW
+xU
+yo
+ut
+zk
 zi
-zO
-xm
-xm
-xm
-BV
-CE
-Dm
-DW
-EQ
-Gb
-GZ
-HW
-IV
-JP
-KD
-Lw
-HU
-MV
-Nu
+Ar
+Ba
+BH
+Cq
+zi
+zi
+zi
+EN
+FG
+GC
+Hp
+Il
+Jx
+Kt
+Ls
+Mv
+Ny
+Op
+Pl
+Lq
+Qz
+QS
 ab
 ab
 ab
@@ -54938,63 +54946,63 @@ aa
 aa
 aa
 aa
-US
-bf
 am
-dr
-eA
-fE
-gN
-Sy
-hR
-UQ
-Wj
-Zg
-lP
-mG
-nm
-nT
-oo
+bf
+co
+dt
+eC
+fG
+gP
+hT
+iR
+jJ
+kE
+ls
+mc
+nc
+nV
+oJ
 pf
-pM
-qs
-qQ
-rv
-rS
-st
-sR
-tq
-tM
-up
-uY
-up
-we
-ts
-sR
-Zp
-xm
-yk
-yL
-zj
-zP
-Ar
-xm
-xm
-BQ
-CE
-Dm
-DX
-ER
-Gc
-Ha
-HX
-IW
-JQ
-KE
-Lx
-HU
-MV
-Nu
+qh
+qU
+rI
+sk
+sP
+tp
+tS
+ut
+uU
+vq
+vX
+wL
+vX
+xU
+uW
+ut
+zk
+zi
+As
+Ba
+BI
+Cr
+CY
+zi
+zi
+EC
+FG
+GC
+Hq
+Im
+Jy
+Ku
+Lt
+Mw
+Nz
+Oq
+Pm
+Lq
+Qz
+QS
 ab
 ab
 ab
@@ -55197,61 +55205,61 @@ aa
 aa
 aj
 bg
-cn
-cn
-cn
+cp
+cp
+cp
 bg
-cn
-cn
-cn
-cn
-kw
-cn
-lQ
-mz
-ni
-nU
-nU
-nU
-nU
-nU
-nU
-nU
-nU
-st
-sR
-tr
-tN
-ur
-uZ
-ur
-wf
-wv
-sR
-Zp
-xm
-yl
-yK
+cp
+cp
+cp
+cp
+kF
+cp
+md
+mO
+nW
+oK
+oK
+oK
+oK
+oK
+oK
+oK
+oK
+tS
+ut
+uV
+vr
+vZ
+wM
+vZ
+xV
+yp
+ut
 zk
-zQ
-xm
-xm
-xm
-BW
-CE
-Dm
-DX
-ES
-Gd
-Hb
-HY
-IX
-IX
-IX
-Ly
-Mi
-Mn
-Nh
+zi
+At
+AZ
+BJ
+Cs
+zi
+zi
+zi
+EO
+FG
+GC
+Hq
+In
+Jz
+Kv
+Lu
+Mx
+Mx
+Mx
+Pn
+PS
+PX
+QL
 ab
 ab
 ab
@@ -55454,61 +55462,61 @@ ab
 ab
 an
 bh
-co
-co
-co
-fF
-co
-co
-iP
-fG
-kx
-fG
-lI
-mz
-nn
-nV
-op
+cq
+cq
+cq
+fH
+cq
+cq
+iS
+fI
+kG
+fI
+lS
+mO
+nX
+oL
 pg
-pN
-qt
-qR
-nW
-nU
-su
-sR
-ts
-tO
-ts
-va
-ts
-wg
-ts
-sR
-Zr
-xJ
-xJ
-xJ
-xJ
-xJ
-xJ
-AZ
-xJ
-BX
-CE
-Dm
-DX
-ET
-Ge
-Hc
-HX
-IY
-JR
-KF
-Lz
-HU
-MV
-Nh
+qi
+qV
+rJ
+sl
+oM
+oK
+tT
+ut
+uW
+vs
+uW
+wN
+uW
+xW
+uW
+ut
+zl
+zK
+zK
+zK
+zK
+zK
+zK
+DJ
+zK
+EP
+FG
+GC
+Hq
+Io
+JA
+Kw
+Lt
+My
+NA
+Or
+Po
+Lq
+Qz
+QL
 ab
 ab
 ab
@@ -55710,62 +55718,62 @@ ab
 ab
 ab
 an
-Zh
-cp
-ds
-eB
-fG
-fG
-fG
-iQ
-co
-ky
-lj
-lF
-mz
-ne
-nW
-oq
+bi
+cr
+du
+eD
+fI
+fI
+fI
+iT
+cq
+kH
+lt
+me
+mO
+nH
+oM
 ph
-pO
-qu
-qS
-nW
-nU
-st
-sR
-sR
-sR
-sR
-sR
-sR
-sR
-sR
-sR
-xn
-xK
-ym
-yM
-yM
-yM
-Xf
-Ba
-Bz
-BY
-CE
-Dv
-DU
-DU
-DU
-DU
-HU
-HU
-HU
-HU
-HU
-HU
-MV
-Nh
+qj
+qW
+rK
+sm
+oM
+oK
+tS
+ut
+ut
+ut
+ut
+ut
+ut
+ut
+ut
+ut
+zm
+zL
+Au
+Bb
+Bb
+Bb
+CZ
+DK
+Ei
+EQ
+FG
+GL
+Hn
+Hn
+Hn
+Hn
+Lq
+Lq
+Lq
+Lq
+Lq
+Lq
+Qz
+QL
 ab
 ab
 ab
@@ -55968,29 +55976,29 @@ ab
 ab
 an
 bj
-cq
-cq
-cq
-cq
-cq
-cq
-iR
-cq
-kz
-cq
-lL
-mz
-ne
-nW
-or
-ph
-pP
-qv
-RM
-nW
-nU
-Qt
-nU
+cs
+cs
+cs
+cs
+cs
+cs
+iU
+cs
+kI
+cs
+lW
+mO
+nH
+oM
+pi
+qj
+qX
+rL
+sn
+oM
+oK
+tU
+oK
 ab
 ab
 ab
@@ -55998,31 +56006,31 @@ ab
 ab
 ab
 ab
-sS
-xp
-rU
-rV
-rV
-rV
-rV
-At
-Bb
-At
-BZ
-CE
-Dm
-DY
-EU
-Gf
-Hd
-HZ
-IZ
-JS
-KG
-DT
-Mj
-MV
-Nh
+yJ
+zn
+zM
+yK
+yK
+yK
+yK
+Da
+DL
+Da
+ER
+FG
+GC
+Hr
+Ip
+JB
+Kx
+Lv
+Mz
+NB
+Os
+Hl
+PT
+Qz
+QL
 ab
 ab
 ab
@@ -56224,62 +56232,62 @@ ab
 ab
 ab
 an
-Zh
-cq
-Rb
-eC
-fH
-gO
-Vp
-Vh
-jF
-kA
-cq
-lM
-mz
-ne
-nW
-os
-ph
-ph
-qw
+bi
+cs
+dv
+eE
+fJ
+gQ
+hU
+iV
+jK
+kJ
+cs
+lX
+mO
+nH
+oM
+pj
+qj
+qj
+rM
 ab
 ab
-QR
-Qk
-PW
-ab
-ab
-ab
+tq
+tV
+uu
 ab
 ab
 ab
 ab
-rV
-xq
-rV
-sw
-sw
-sw
-sw
-xJ
-Bc
-BA
-BZ
-CE
-Dw
-DZ
-EV
-Gg
-He
-He
-He
-He
-KH
-LA
-Mk
-MW
-Nu
+ab
+ab
+ab
+yK
+zo
+yK
+Av
+Av
+Av
+Av
+zK
+DM
+Ej
+ER
+FG
+GM
+Hs
+Iq
+JC
+Ky
+Ky
+Ky
+Ky
+Ot
+Pp
+PU
+QA
+QS
 ab
 ab
 ab
@@ -56481,62 +56489,62 @@ ab
 ab
 ab
 an
-Zh
-cq
-du
-eD
-fI
-gP
-fI
-iT
-fI
-kB
-cq
-lK
-mz
-ne
-nW
-ot
-pi
-pQ
-qw
+bi
+cs
+dw
+eF
+fK
+gR
+fK
+iW
+fK
+kK
+cs
+lV
+mO
+nH
+oM
+pk
+qk
+qY
+rM
 ab
 ab
-YM
+tr
 ab
-YM
-ab
-ab
-ab
+tr
 ab
 ab
 ab
 ab
-rV
-ab
-rV
 ab
 ab
 ab
-sw
-sw
-sw
-BA
-BZ
-CE
-Dm
-Ea
-EW
-Gh
-Hf
-Ia
-Ja
-JT
-KI
-LB
-Ml
-MX
-Nu
+yK
+ab
+yK
+ab
+ab
+ab
+Av
+Av
+Av
+Ej
+ER
+FG
+GC
+Ht
+Ir
+JD
+Kz
+Lw
+MA
+NC
+Ou
+Pq
+PV
+QB
+QS
 ab
 ab
 ab
@@ -56738,25 +56746,25 @@ ab
 ab
 ab
 an
-Zh
-cq
-dv
-eE
-fJ
-gQ
-hS
-iU
-jG
-kC
-cq
-lK
-mz
-ne
-nW
-ou
-pj
-pR
-qw
+bi
+cs
+dx
+eG
+fL
+gS
+hV
+iX
+jL
+kL
+cs
+lV
+mO
+nH
+oM
+pl
+ql
+qZ
+rM
 ab
 ab
 ab
@@ -56764,7 +56772,7 @@ ab
 ab
 ab
 ab
-YP
+wa
 ab
 ab
 ab
@@ -56778,22 +56786,22 @@ ab
 ab
 ab
 ab
-BB
-Ca
-CJ
-Dx
-Eb
-EX
-Gi
-Hg
-Ib
-Jb
-Gh
-KJ
-DT
-Mm
-MY
-Nu
+Ek
+ES
+FS
+GN
+Hu
+Is
+JE
+KA
+Lx
+MB
+JD
+Ov
+Hl
+PW
+QC
+QS
 ab
 ab
 ab
@@ -56995,25 +57003,25 @@ ab
 ab
 ab
 an
-Zh
-cq
-cq
-cq
-cq
-gR
-cq
-cq
-jH
-kD
-cq
-lK
-PS
-nf
-XG
-Pl
-YS
+bi
+cs
+cs
+cs
+cs
+gT
+cs
+cs
+jM
+kM
+cs
+lV
+nd
 nI
-TT
+oN
+pm
+qm
+ra
+rN
 ab
 ab
 ab
@@ -57029,28 +57037,28 @@ ab
 ab
 ab
 ab
-ZK
-TK
-TK
-Sl
-Wd
+Aw
+Bc
+Bc
+Ct
+Db
 ab
-BB
-Cb
-CK
-Dm
-DY
-EY
-Gj
-He
-He
-Jb
-JU
-KK
-LC
-Mn
-DT
-Nh
+Ek
+ET
+FT
+GC
+Hr
+It
+JF
+Ky
+Ky
+MB
+ND
+Ow
+Pr
+PX
+Hl
+QL
 ab
 ab
 ab
@@ -57252,25 +57260,25 @@ ab
 ab
 ab
 an
-Zh
-cr
-dw
-eF
-fK
-gS
-hT
-iV
-fP
-kE
-jd
-lJ
-mA
-ne
-Te
-XX
-Te
-Te
-Te
+bi
+ct
+dy
+eH
+fM
+gU
+hW
+iY
+fR
+kN
+jg
+lT
+mP
+nH
+oO
+pn
+oO
+oO
+oO
 ab
 ab
 ab
@@ -57285,29 +57293,29 @@ ab
 ab
 ab
 ab
-Pe
-ml
-ml
-ml
-VI
-ml
-Pe
-Tj
-Xk
-Ru
-Dt
-DY
-EZ
-Gk
-Hh
-Ic
-Jc
-JV
-KL
-DT
-Mo
-MU
-Nh
+zN
+Ax
+Ax
+Ax
+Cu
+Ax
+zN
+El
+EU
+FU
+GJ
+Hr
+Iu
+JG
+KB
+Ly
+MC
+NE
+Ox
+Hl
+PY
+Qy
+QL
 ab
 ab
 ab
@@ -57509,25 +57517,25 @@ ab
 ab
 ab
 an
-Zh
-cr
-dx
-eG
-fL
-gT
-hU
-iW
-fP
-kE
-jd
-lH
-my
-nd
-Zq
-UZ
-Rx
-Rl
-Te
+bi
+ct
+dz
+eI
+fN
+gV
+hX
+iZ
+fR
+kN
+jg
+lR
+mN
+nG
+oP
+po
+qn
+rb
+oO
 ab
 ab
 ab
@@ -57542,29 +57550,29 @@ ab
 ab
 ab
 ab
-UA
-ml
-TG
-hP
-Or
-Uc
-NV
-WU
-Sb
-SY
-Dk
-Ec
-Ec
-Ec
-Ec
-Ec
-Ec
-JW
-KM
-Ec
-Ec
-MV
-Nh
+zO
+Ax
+Bd
+BK
+Cv
+Dc
+DN
+Em
+EV
+FV
+GA
+Hv
+Hv
+Hv
+Hv
+Hv
+Hv
+NF
+Oy
+Hv
+Hv
+Qz
+QL
 ab
 ab
 ab
@@ -57767,24 +57775,24 @@ ab
 ab
 an
 bk
-cs
-OQ
-eH
-fM
-gU
-hV
-iX
-jI
-kF
-jd
-oi
-XS
-TW
-OW
-NN
-aY
-lO
-Te
+cu
+dA
+eJ
+fO
+gW
+hY
+ja
+jN
+kO
+jg
+mf
+ne
+ni
+oQ
+pp
+qo
+rc
+oO
 ab
 ab
 ab
@@ -57799,29 +57807,29 @@ ab
 ab
 ab
 ab
-QU
-VT
-Xm
-Wa
-Tv
-pk
-Sq
-ZU
-zf
-Tw
-Dw
-Ed
-Fa
-Gl
-Hi
-Id
-Jd
-JX
-Ie
-LD
-Ec
-MV
-Nh
+zP
+Ay
+Be
+BL
+Cw
+Dd
+DO
+En
+EW
+FW
+GM
+Hw
+Iv
+JH
+KC
+Lz
+MD
+NG
+LA
+Ps
+Hv
+Qz
+QL
 ab
 ab
 ab
@@ -58023,25 +58031,25 @@ ab
 ab
 ab
 ao
-Zh
-cr
-dz
-eI
-fN
-gV
-YY
-iY
-jJ
-kG
-jd
-lK
-OL
-OZ
-PD
-tG
-tG
-Zy
-Te
+bi
+ct
+dB
+eK
+fP
+gX
+hZ
+jb
+jO
+kP
+jg
+lV
+nf
+nY
+oR
+pq
+pq
+rd
+oO
 ab
 ab
 ab
@@ -58056,29 +58064,29 @@ ab
 ab
 ab
 ab
-XD
-ml
-WT
-YI
-Uh
-ml
-Xw
-BB
-Qr
-CN
-Dx
-Ee
-Fb
-Gm
-Hj
-Ie
-Je
-Ie
-Ie
-LE
-Mp
-MZ
-Nh
+zQ
+Ax
+Bf
+BM
+Cx
+Ax
+DP
+Ek
+EX
+FX
+GN
+Hx
+Iw
+JI
+KD
+LA
+ME
+LA
+LA
+Pt
+PZ
+QD
+QL
 ab
 ab
 ab
@@ -58280,25 +58288,25 @@ ab
 ab
 ab
 ao
-Zh
-cr
-cr
-cr
-cr
-gW
-cr
-cr
-jK
-kH
-jd
-lK
-mz
-Uq
-QV
-Rj
-Wm
-YO
-Te
+bi
+ct
+ct
+ct
+ct
+gY
+ct
+ct
+jP
+kQ
+jg
+lV
+mO
+nZ
+oS
+pr
+qp
+re
+oO
 ab
 ab
 ab
@@ -58313,29 +58321,29 @@ ab
 ab
 ab
 ab
-Ua
-ml
-ml
-ml
-VI
-ml
-Ua
-BB
-Ce
-CK
-Dr
-Ec
-Fc
-Gm
-Hj
-If
-Ie
-If
-Ie
-LF
-Ec
-Na
-Nh
+zR
+Ax
+Ax
+Ax
+Cu
+Ax
+zR
+Ek
+EY
+FT
+GH
+Hv
+Ix
+JI
+KD
+LB
+LA
+LB
+LA
+Pu
+Hv
+QE
+QL
 ab
 ab
 ab
@@ -58537,25 +58545,25 @@ ab
 ab
 ab
 an
-Zh
+bi
 an
-dA
-eJ
-fO
-RZ
-hX
-iZ
-jL
+dC
+eL
+fQ
+gZ
 ia
-jd
-lK
-mz
-ne
-Zq
-TH
-Rx
-YA
-Te
+jc
+jQ
+id
+jg
+lV
+mO
+nH
+oP
+ps
+qn
+rf
+oO
 ab
 ab
 ab
@@ -58571,28 +58579,28 @@ ab
 ab
 ab
 ab
-Xl
-TK
-TK
+Az
+Bc
+Bc
+Cy
+Db
+ab
+Ek
+ET
+FT
+GC
+Hy
+Iy
+JI
+KD
+LA
+MF
+NH
+Oz
+Pv
 Qa
-Wd
-ab
-BB
-Cb
-CK
-Dm
-Ef
-Fd
-Gm
-Hj
-Ie
-Jf
-JY
-KN
-LG
-Mq
-Mn
-Nh
+PX
+QL
 ab
 ab
 ab
@@ -58796,23 +58804,23 @@ ab
 an
 bl
 an
-dB
-eK
-fP
-gY
-hY
-ja
-jM
-kI
+dD
+eM
+fR
+ha
+ib
 jd
-lK
-mz
-ne
-Zq
-SI
-Rx
-NX
-Te
+jR
+kR
+jg
+lV
+mO
+nH
+oP
+pt
+qn
+rg
+oO
 ab
 ab
 ab
@@ -58834,22 +58842,22 @@ ab
 ab
 ab
 ab
-BB
-Cb
-CK
-Dm
-Ef
-Fd
-Gm
-Hk
-Ie
-Jg
-JZ
-KO
-LH
-Ec
-Na
-Nh
+Ek
+ET
+FT
+GC
+Hy
+Iy
+JI
+KE
+LA
+MG
+NI
+OA
+Pw
+Hv
+QE
+QL
 ab
 ab
 ab
@@ -59052,24 +59060,24 @@ ab
 ab
 an
 bm
-ct
-dC
-dC
-dC
-gZ
-hZ
-jb
-jb
-jb
-jd
-lM
-mz
-ne
-Te
-Te
-Ux
-Te
-Te
+cv
+dE
+dE
+dE
+hb
+ic
+je
+je
+je
+jg
+lX
+mO
+nH
+oO
+oO
+qq
+oO
+oO
 ab
 ab
 ab
@@ -59091,22 +59099,22 @@ ab
 ab
 ab
 ab
-BB
-Cb
-CK
-Dm
-Ef
-Fe
-Gn
-Ec
-Ig
-Ec
-Ec
-Ec
-Ec
-Ec
-Nb
-Nh
+Ek
+ET
+FT
+GC
+Hy
+Iz
+JJ
+Hv
+LC
+Hv
+Hv
+Hv
+Hv
+Hv
+QF
+QL
 ab
 ab
 ab
@@ -59308,25 +59316,25 @@ ab
 ab
 ab
 an
-bi
+bn
 an
-dD
-eL
-fQ
-ha
-ia
-jc
-jc
-jc
-jd
-lK
-mz
-ne
-Te
-nc
-TR
-XT
-Te
+dF
+eN
+fS
+hc
+id
+jf
+jf
+jf
+jg
+lV
+mO
+nH
+oO
+pu
+qr
+rh
+oO
 ab
 ab
 ab
@@ -59348,22 +59356,22 @@ ab
 ab
 ab
 ab
-BA
-OM
-CK
-Dm
-Ec
-Ff
-Gl
-Gl
-Ih
-Jh
-JY
-KN
-LI
-Mr
-Nc
-Nh
+Ej
+EZ
+FT
+GC
+Hv
+IA
+JH
+JH
+LD
+MH
+NH
+Oz
+Px
+Qb
+QG
+QL
 ab
 ab
 ab
@@ -59565,25 +59573,25 @@ ab
 ab
 ab
 an
-bi
+bn
 an
-dE
-eM
-fR
-hb
-Yz
-jd
-jd
-jd
-jd
-lK
-mz
-nq
-Te
-Rz
-Cu
-Yk
-Te
+dG
+eO
+fT
+hd
+ie
+jg
+jg
+jg
+jg
+lV
+mO
+oa
+oO
+pv
+qs
+ri
+oO
 ab
 ab
 ab
@@ -59605,22 +59613,22 @@ ab
 ab
 ab
 ab
-BA
-Cb
-CK
-Do
-Ec
-Ef
-Ef
-Ef
-Ii
-Ef
-Ef
-Ef
-Ec
-Ms
-DT
-Nh
+Ej
+ET
+FT
+GE
+Hv
+Hy
+Hy
+Hy
+LE
+Hy
+Hy
+Hy
+Hv
+Qc
+Hl
+QL
 ab
 ab
 ab
@@ -59822,25 +59830,25 @@ ab
 ab
 ab
 an
-bi
+bn
 an
-dF
-eN
-fS
-ha
-ia
-je
-jN
-kJ
-lk
-lK
-mz
-ne
-Te
-Te
-Te
-Te
-Te
+dH
+eP
+fU
+hc
+id
+jh
+jS
+kS
+lu
+lV
+mO
+nH
+oO
+oO
+oO
+oO
+oO
 ab
 ab
 ab
@@ -59862,22 +59870,22 @@ ab
 ab
 ab
 ab
-BA
-Cf
-CK
-Dm
-Eg
+Ej
+Fa
+FT
+GC
+Hz
 ab
 ab
-Fg
-Ij
-Fg
+IB
+LF
+IB
 ab
 ab
-Eg
-Mo
-MU
-Nh
+Hz
+PY
+Qy
+QL
 ab
 ab
 ab
@@ -60079,20 +60087,20 @@ ab
 ab
 ab
 an
-bi
+bn
 an
-dG
-eO
-fT
-ha
-ia
-Uo
-jO
-kK
-ll
-lK
-mz
-ne
+dI
+eQ
+fV
+hc
+id
+ji
+jT
+kT
+lv
+lV
+mO
+nH
 ay
 ab
 ab
@@ -60119,22 +60127,22 @@ ab
 ab
 ab
 ab
-BA
-Cb
-CK
-Dm
-Eg
-Fg
-Fg
-Fg
-Ik
-Fg
-Fg
-Fg
-Eg
-Eg
-MV
-Nh
+Ej
+ET
+FT
+GC
+Hz
+IB
+IB
+IB
+LG
+IB
+IB
+IB
+Hz
+Hz
+Qz
+QL
 ab
 ab
 ab
@@ -60336,21 +60344,21 @@ ab
 ab
 ab
 ap
-bn
+bo
 ap
 ap
 ap
-fU
-hc
-ic
+fW
+he
+if
 ar
-jP
-kL
+jU
+kU
 ar
-lR
-mz
-ne
-me
+mg
+mO
+nH
+mt
 ab
 ab
 ab
@@ -60376,22 +60384,22 @@ ab
 ab
 ab
 ab
-BB
-Cb
-CK
-Dm
-Eh
-Fh
-Fk
-Fk
-Il
-Fk
-Fk
-Fk
-LJ
-Eg
-MV
-Nh
+Ek
+ET
+FT
+GC
+HA
+IC
+IF
+IF
+LH
+IF
+IF
+IF
+Py
+Hz
+Qz
+QL
 ab
 ab
 ab
@@ -60593,21 +60601,21 @@ ab
 ab
 ab
 aq
-bo
-cu
-dH
-eP
-fV
-Pm
-TP
-jg
-jQ
-jQ
-lm
-lS
-mI
-WS
-me
+bp
+cw
+dJ
+eR
+fX
+hf
+ig
+jj
+jV
+jV
+lw
+mh
+ng
+ob
+mt
 ab
 ab
 ab
@@ -60633,22 +60641,22 @@ ab
 ab
 ab
 ab
-BB
-Cb
-CK
-Dr
-Eg
-Fi
-Go
-Hl
-Hl
-Hl
-Hl
-KP
-LK
-Mt
-vM
-Nu
+Ek
+ET
+FT
+GH
+Hz
+ID
+JK
+KF
+KF
+KF
+KF
+OB
+Pz
+Qd
+QH
+QS
 ab
 ab
 ab
@@ -60850,62 +60858,62 @@ ab
 ab
 ab
 aq
-bp
-cv
-dI
+bq
+cx
+dK
 aq
-fW
-Xv
-Zl
-jh
-jR
-kM
-ln
-lT
+fY
+hg
+ih
+jk
+jW
+kV
+lx
+mi
+nh
+oc
+mt
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+Ek
+Fb
+FY
+GO
+HB
+IE
+JL
+KG
+LI
+MI
+NJ
+OC
+PA
+Hz
+QI
 QS
-nr
-me
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-BB
-Ch
-Rr
-Dy
-Ei
-Fj
-Gp
-Hm
-Im
-Zc
-Ka
-KQ
-LL
-Eg
-Sf
-Nu
 ab
 ab
 ab
@@ -61107,20 +61115,20 @@ ab
 ab
 ab
 aq
-bp
-cw
-dJ
+bq
+cy
+dL
 ap
-fX
-hf
+fZ
+hh
 ar
 ar
 ar
 ar
-lo
-lJ
-TW
-OO
+ly
+lT
+ni
+od
 ay
 ab
 ab
@@ -61147,22 +61155,22 @@ ab
 ab
 ab
 ab
-BA
-Xx
-Vz
-Dt
 Ej
-Fk
-Gq
-Hn
-In
-Ji
-In
-KR
-LM
-Eg
-Sf
-Nu
+Fc
+FZ
+GJ
+HC
+IF
+JM
+KH
+LJ
+MJ
+LJ
+OD
+PB
+Hz
+QI
+QS
 ab
 ab
 ab
@@ -61364,20 +61372,20 @@ ab
 ab
 ab
 ap
-bq
-cx
-dK
-eQ
-fY
-hg
-if
-ji
-jS
-kN
+br
+cz
+dM
+eS
+ga
+hi
+ii
+jl
+jX
+kW
 as
-lJ
-TW
-Uv
+lT
+ni
+oe
 ay
 ab
 ab
@@ -61404,22 +61412,22 @@ ab
 ab
 ab
 ab
-BA
-QY
-Vz
-Dt
-Eg
-Fl
-Gr
-Hn
-Io
-Jj
-Kb
-KS
-LN
-Eg
-Sf
-Nh
+Ej
+Fd
+FZ
+GJ
+Hz
+IG
+JN
+KH
+LK
+MK
+NK
+OE
+PC
+Hz
+QI
+QL
 ab
 ab
 ab
@@ -61621,20 +61629,20 @@ ab
 ab
 ab
 ap
-br
-cy
-dL
+bs
+cA
+dN
 aq
-fZ
-hh
-ig
-XV
-jT
-kO
-lp
-lK
-Qg
-yO
+gb
+hj
+ij
+jm
+jY
+kX
+lz
+lV
+nj
+of
 ay
 ab
 ab
@@ -61661,22 +61669,22 @@ ab
 ab
 ab
 ab
-BA
-PM
-PB
-Dm
-Eg
-Eg
-Eg
-Eg
-Eg
-Eg
-Eg
-Eg
-Eg
-Eg
-QB
-Nh
+Ej
+Fe
+Ga
+GC
+Hz
+Hz
+Hz
+Hz
+Hz
+Hz
+Hz
+Hz
+Hz
+Hz
+QJ
+QL
 ab
 ab
 ab
@@ -61878,20 +61886,20 @@ ab
 ab
 ab
 ap
-bs
-cz
-dM
+bt
+cB
+dO
 aq
-fW
-YZ
+fY
+hk
 ar
 ar
 ar
 ar
-lq
-lK
-PA
-Wt
+lA
+lV
+nk
+og
 ay
 ab
 ab
@@ -61918,22 +61926,22 @@ ab
 ab
 ab
 ab
-BA
-PI
-PB
-Dm
-Ek
-Fm
-Gs
-Ek
-Fm
-Gs
-Ek
-Fm
-Gs
-Ek
-Sf
-Nh
+Ej
+Ff
+Ga
+GC
+HD
+IH
+JO
+HD
+IH
+JO
+HD
+IH
+JO
+HD
+QI
+QL
 ab
 ab
 ab
@@ -62139,17 +62147,17 @@ ar
 ar
 ar
 ar
-ga
-hj
-ih
-jk
-jU
-kN
+gc
+hl
+ik
+jn
+jZ
+kW
 as
-lK
-mK
-mK
-me
+lV
+nl
+nl
+mt
 ab
 ab
 ab
@@ -62175,22 +62183,22 @@ ab
 ab
 ab
 ab
-BB
-QX
-Of
-Dm
 Ek
-Fn
-Gt
-Ek
-Fn
-Gt
-Ek
-Fn
-Gt
-Ek
-Sf
-Nh
+Fg
+Gb
+GC
+HD
+II
+JP
+HD
+II
+JP
+HD
+II
+JP
+HD
+QI
+QL
 ab
 ab
 ab
@@ -62392,21 +62400,21 @@ ab
 ab
 ab
 ar
-bt
-cA
-dN
+bu
+cC
+dP
 ar
-gb
-hk
-ig
-TL
-jT
-kO
-lp
-lK
-mK
-mK
-me
+gd
+hm
+ij
+jo
+jY
+kX
+lz
+lV
+nl
+nl
+mt
 ab
 ab
 ab
@@ -62432,22 +62440,22 @@ ab
 ab
 ab
 ab
-BB
-Cb
-CP
-Dm
 Ek
-Fo
-Gu
-Ek
-Ip
-Gu
-Ek
-KT
-Gu
-Ek
-Sf
-Nh
+ET
+Gc
+GC
+HD
+IJ
+JQ
+HD
+LL
+JQ
+HD
+OF
+JQ
+HD
+QI
+QL
 ab
 ab
 ab
@@ -62649,21 +62657,21 @@ ab
 ab
 ab
 as
-bu
-bu
-bu
+bv
+bv
+bv
 ar
-gc
-Va
-ar
-ar
+ge
+hn
 ar
 ar
-lq
-lU
-mK
-mK
-me
+ar
+ar
+lA
+mj
+nl
+nl
+mt
 ab
 ab
 ab
@@ -62689,22 +62697,22 @@ ab
 ab
 ab
 ab
-BB
-Cb
-YL
-Dl
 Ek
-Fp
-Gv
-Ek
-Fp
-Jk
-Ek
-Fp
-LO
-Ek
-Sf
-Nu
+ET
+Gd
+GB
+HD
+IK
+JR
+HD
+IK
+ML
+HD
+IK
+PD
+HD
+QI
+QS
 ab
 ab
 ab
@@ -62906,20 +62914,20 @@ ab
 ab
 ab
 at
-bv
-cB
-dO
-eR
-gd
-hm
-ii
-jl
-jV
-kN
+bw
+cD
+dQ
+eT
+gf
+ho
+il
+jp
+ka
+kW
 as
-lK
-NT
-mK
+lV
+nm
+nl
 ay
 ab
 ab
@@ -62946,22 +62954,22 @@ ab
 ab
 ab
 ab
-BA
-Cb
-hd
-Dz
-El
-Fq
-Gw
-Ho
-Iq
-Gw
-Ho
-Fq
-LP
-Ek
-Sf
-Nu
+Ej
+ET
+Ge
+GP
+HE
+IL
+JS
+KI
+LM
+MM
+KI
+IL
+PE
+HD
+QI
+QS
 ab
 ab
 ab
@@ -63163,20 +63171,20 @@ ab
 ab
 ab
 ar
-bw
-cC
-dP
-RE
-ge
-Zd
-ig
-jj
-jT
-kO
-lp
-lV
-mL
-mK
+bx
+cE
+dR
+eU
+gg
+hp
+ij
+jq
+jY
+kX
+lz
+mk
+nn
+nl
 ay
 ab
 ab
@@ -63203,22 +63211,22 @@ ab
 ab
 ab
 ab
-BA
-Ch
-PP
-DA
-Em
-Fr
-Gx
-Hp
-Ir
-Jl
-Hp
-qo
-Xz
-Xt
-Zw
-Nu
+Ej
+EX
+Gf
+GQ
+HF
+IM
+JT
+KJ
+LN
+MN
+KJ
+OG
+PF
+Qe
+QK
+QS
 ab
 ab
 ab
@@ -63431,9 +63439,9 @@ ar
 ar
 ar
 ar
-lW
-lW
-lW
+ml
+ml
+ml
 ay
 ab
 ab
@@ -63460,22 +63468,22 @@ ab
 ab
 ab
 ab
-BA
-Ci
-Ci
-Ci
-En
-En
-En
-En
-En
-En
-En
-En
-En
-En
-Nh
-Nh
+Ej
+Fh
+Gg
+GR
+HG
+HG
+HG
+HG
+HG
+MO
+HG
+HG
+HG
+HG
+QL
+QL
 ab
 ab
 ab
@@ -63677,20 +63685,20 @@ ab
 ab
 ab
 au
-bx
+by
 aw
 aw
 aw
-bx
+by
 aw
 aw
 aw
-bx
-kP
+by
+kY
 ay
-lX
-mK
-nt
+mm
+nl
+oh
 ay
 ab
 ab
@@ -63717,22 +63725,22 @@ ab
 ab
 ab
 ab
-BA
-Cj
-CS
-CS
-BA
-Fs
-Gy
-Hq
-Hq
-Hq
-Gy
-Hq
-Hq
-Hq
-Gy
-Nv
+Ej
+Fi
+ER
+Gj
+Ej
+IN
+IN
+IN
+LO
+MP
+NL
+OH
+PG
+Qf
+Qf
+QT
 ab
 ab
 ab
@@ -63934,21 +63942,21 @@ ab
 ab
 ab
 av
-by
-cD
-dQ
-eT
-gf
-eT
-eT
-eT
-jW
-kQ
+bz
+cF
+dS
+eV
+gh
+eV
+eV
+eV
+kb
+kZ
 ay
-lY
-mK
-nu
-me
+mn
+nl
+oi
+mt
 ab
 ab
 ab
@@ -63974,22 +63982,22 @@ ab
 ab
 ab
 ab
-BB
-Ck
-CS
-DB
-BA
-Ft
-Gz
-GA
-GA
-GA
-Kc
-GA
+Ek
+Fj
+ER
+GS
+Ej
+IO
+IO
+IO
+IO
+MQ
+NM
+OI
+IO
+IO
 LR
-Mv
-Ni
-Nw
+QT
 ab
 ab
 ab
@@ -64191,21 +64199,21 @@ ab
 ab
 ab
 av
-bz
-cE
-dR
-eU
-gg
-gg
-gg
-eT
-eT
-kR
-TN
-lZ
-mK
-nu
-me
+bA
+cG
+dT
+eW
+gi
+gi
+gi
+eV
+eV
+la
+lB
+mo
+nl
+oi
+mt
 ab
 ab
 ab
@@ -64231,22 +64239,22 @@ ab
 ab
 ab
 ab
-BB
-Ck
-CS
-DC
-Pg
-Fu
-GA
-GA
-Is
-Jm
-Is
-Is
-LS
-Mw
-Nj
-Nw
+Ek
+Fj
+Gh
+GT
+HH
+IP
+IP
+IP
+LP
+MR
+NN
+NN
+IO
+IO
+QM
+QT
 ab
 ab
 ab
@@ -64448,21 +64456,21 @@ ab
 ab
 ab
 aw
-bA
-cF
-dS
+bB
+cH
+dU
+eX
+gj
+gj
+gj
 eV
-gh
-gh
-gh
-eT
-jX
-kP
+kc
+kY
 ay
-ma
-mM
-nu
-me
+mp
+no
+oi
+mt
 ab
 ab
 ab
@@ -64488,22 +64496,22 @@ ab
 ab
 ab
 ab
-BB
-Ck
-CT
-DD
-BA
-Fs
-GB
-GA
-It
-It
-It
-KU
-LT
-Mx
-Nk
-Hq
+Ek
+Fj
+Gi
+GU
+Ek
+IQ
+IO
+IO
+LQ
+MS
+MS
+MS
+PH
+MS
+MS
+QT
 ab
 ab
 ab
@@ -64705,20 +64713,20 @@ ab
 ab
 ab
 aw
-bB
-cG
-dT
-eT
-eT
-eT
-eT
-eT
-jY
-kS
+bC
+cI
+dV
+eV
+eV
+eV
+eV
+eV
+kd
+lb
 ay
-mb
-mK
-nv
+mq
+nl
+oj
 ay
 ab
 ab
@@ -64745,22 +64753,22 @@ ab
 ab
 ab
 ab
-BA
-Cl
-CS
-DE
-BA
-Fv
-GC
-GA
-GA
-GA
-GA
-GA
-LU
-My
-Nl
-Hq
+Ej
+Fk
+Gj
+Gj
+Ek
+IR
+JU
+KK
+LR
+MS
+NO
+IO
+IO
+IO
+IO
+QT
 ab
 ab
 ab
@@ -64962,20 +64970,20 @@ ab
 ab
 ab
 aw
-bC
-cH
-dU
-eW
-gg
-gg
-gg
-eT
-jX
-kQ
+bD
+cJ
+dW
+eY
+gi
+gi
+gi
+eV
+kc
+kZ
 ay
-mc
-mK
-nu
+mr
+nl
+oi
 ay
 ab
 ab
@@ -65002,22 +65010,22 @@ ab
 ab
 ab
 ab
-BA
-Ck
-CS
-DF
-BA
-Ft
-GB
-GA
-Is
-Is
-Is
-KV
-LV
-Mz
-Nm
-Hq
+Ej
+Fj
+Gj
+GV
+Ej
+IS
+JV
+KL
+IO
+MT
+IO
+OJ
+OJ
+OJ
+IO
+QT
 ab
 ab
 ab
@@ -65219,20 +65227,20 @@ ab
 ab
 ab
 av
-bD
-cI
-dV
-eX
-gh
-gh
-gh
-eT
-eT
-kT
-TN
-lZ
-mK
-nw
+bE
+cK
+dX
+eZ
+gj
+gj
+gj
+eV
+eV
+lc
+lB
+mo
+nl
+ok
 ay
 ab
 ab
@@ -65259,22 +65267,22 @@ ab
 ab
 ab
 ab
-BA
-Cm
-CS
-DC
-Pg
-Fw
-GA
-GA
-It
-It
-It
-KU
-LW
-MA
-Nn
-Nw
+Ej
+Fl
+Gj
+GW
+Ej
+IS
+JV
+KL
+IO
+MT
+IO
+OK
+OK
+OK
+IO
+QT
 ab
 ab
 ab
@@ -65476,20 +65484,20 @@ ab
 ab
 ab
 av
-bE
-cJ
-dW
-eT
-gi
-eT
-eT
-eT
-jW
-kP
+bF
+cL
+dY
+eV
+gk
+eV
+eV
+eV
+kb
+kY
 ay
-md
-mN
-me
+ms
+np
+mt
 ay
 ab
 ab
@@ -65516,22 +65524,22 @@ ab
 ab
 ab
 ab
-BA
-Cn
-CU
-BB
-BA
-Fs
-Gz
-GA
-GA
-GA
-Kd
-KW
-LX
-MB
-No
-Nw
+Ej
+Fm
+Gk
+Ek
+Ej
+IS
+JV
+KL
+LS
+MS
+IO
+OJ
+OJ
+OJ
+IO
+QT
 ab
 ab
 ab
@@ -65733,20 +65741,20 @@ ab
 ab
 ab
 ax
-bx
+by
 aw
 aw
 aw
-bx
+by
 aw
 aw
 aw
-bx
-kQ
+by
+kZ
 ay
-me
-mO
-me
+mt
+nq
+mt
 ay
 ab
 ab
@@ -65773,22 +65781,22 @@ ab
 ab
 ab
 ab
-BA
-BB
-CV
-BB
-BA
-Ft
-Gy
-Hq
-Hq
-Hq
-Gy
-Hq
-Hq
-Hq
-Gy
-Nx
+Ej
+Ek
+Gl
+Ek
+Ej
+IT
+JW
+KM
+LT
+MS
+NP
+OK
+OK
+OK
+IO
+QT
 ab
 ab
 ab
@@ -66001,9 +66009,9 @@ ay
 ay
 ay
 ay
-me
-Zs
-me
+mt
+nr
+mt
 ay
 ab
 ab
@@ -66030,22 +66038,22 @@ ab
 ab
 ab
 ab
-BA
-BB
-lb
-BB
-BA
-BA
-BA
-BA
-BA
-BA
-BA
-BA
-BA
-BA
-BA
-BA
+Ej
+Ek
+Gm
+Ek
+Ej
+Ej
+Ej
+Ej
+Ej
+Ej
+Ej
+OL
+OL
+OL
+Ej
+Ej
 ab
 ab
 ab
@@ -66261,33 +66269,33 @@ ab
 ab
 ab
 ab
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
+oT
+oT
+oT
+oT
+oT
+oT
+oT
+oT
+oT
+oT
+oT
+oT
+oT
+oT
+oT
+oT
+oT
+oT
+oT
+oT
+oT
+oT
+oT
+oT
+oT
+oT
+oT
 ab
 ab
 ab
@@ -66297,11 +66305,11 @@ ab
 ab
 ab
 ab
+lC
 ab
 ab
 ab
-ab
-ab
+lC
 ab
 ab
 ab


### PR DESCRIPTION
Wow I changed a lot. This should fix a lot of issues people have had with the map. The main features are reorganized atmos, a tool storage and emergency storage, and a EVA room replacing the south shuttle.

![image](https://cloud.githubusercontent.com/assets/20388263/19445484/77a0da42-9462-11e6-939c-1714925eba5e.png)

:cl: Map is much better now
Fix: Atmos heater direction
add: Freezer Board to tech storage
tweak: Atmos layout
add: EVA Room 
remove: South Shuttle
tweak: Replaces security checkpoint with tool storage
add: Emergency storage next to bridge
fix: Activates emergency access on munitions and EVA.
/:cl:
