### PR TITLE
Allows the ORM to be accessed by various crew.

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -10,7 +10,7 @@
 	anchored = 1
 	input_dir = NORTH
 	output_dir = SOUTH
-	req_one_access = list(access_mining, access_cargo)
+	req_one_access = list(access_cargo, access_mining, access_research, access_engine)
 	var/stk_types = list()
 	var/stk_amt   = list()
 	var/stack_list[0] //Key: Type.  Value: Instance of type.


### PR DESCRIPTION
Well, we recently had a round where the ORM could not be accessed by even science, leading to some issues in allowing R&D to get minerals at all without cargo help.

This should fix it, allowing crew that would logically need things from R&D-Engineering, cargo, and science-to use the ORM.


:cl: BATMAN
add: The ORM can be accessed by engineering, cargo, and science, instead of just cargo.
/:cl:

