### PR TITLE
adds the GECK to cargo

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -500,6 +500,42 @@
 					/obj/item/clothing/mask/breath)
 	crate_name = "space suit crate"
 	crate_type = /obj/structure/closet/crate/secure
+	
+/datum/supply_pack/engineering/colonization
+	name = "G.E.C.K colonization kit"
+	cost = 15000
+	access = access_ce
+	contains= list(/obj/item/weapon/rcd/combat,
+			/obj/item/weapon/rcd/combat,
+			/obj/item/weapon/rcd_ammo/large,
+			/obj/item/weapon/rcd_ammo/large,
+			/obj/machinery/power/port_gen/pacman,
+			/obj/item/stack/cable_coil,
+			/obj/item/stack/cable_coil,
+			/obj/item/stack/sheet/metal/fifty,
+			/obj/item/stack/sheet/metal/fifty,
+			/obj/item/stack/sheet/glass/fifty,
+			/obj/item/stack/sheet/glass/fifty,
+			/obj/item/weapon/stock_parts/cell/high,
+			/obj/item/weapon/stock_parts/cell/high,
+			/obj/item/weapon/electronics/apc,
+			/obj/item/weapon/electronics/apc,
+			/obj/item/weapon/electronics/airalarm,
+			/obj/item/weapon/electronics/airalarm,
+			/obj/item/stack/sheet/plasteel/fifty,
+			/obj/item/stack/sheet/mineral/plasma,
+			/obj/machinery/portable_atmospherics/canister/oxygen,
+			/obj/item/weapon/pipe_dispenser,
+			/obj/machinery/hydroponics/constructable,
+			/obj/machinery/hydroponics/constructable,
+			/obj/item/stack/tile/grass,
+			/obj/item/stack/tile/pod,
+			/obj/item/stack/tile/pod,
+			/obj/item/weapon/storage/box/rndboards,
+			/obj/item/weapon/storage/box/permits)
+	crate_name = "advanced colonization crate"
+	crate_type = /obj/structure/closet/crate/secure/engineering	
+			
 
 /datum/supply_pack/engineering/shieldgen
 	name = "Anti-breach Shield Projector Crate"


### PR DESCRIPTION
Unless I fucked up, this should take care of #237 . Adds the GECK, requiring CE access to open, and coming equipped with EVERYTHING needed to start a new colony.

It has.

Two industrial 500 unit RCDs.

Two RCD ammo's, large.

A pac-MAN.

Two stacks of cable coil.

Two stacks of metal.

Two stacks of glass.

Two power cells, highcap.

Two APC circuitboards.

Two air alarm circuitboards.

Plasma sheets, for the PACMAN.

An o2 canister.

An RPD.

A hydroponics tray, for growing your own food.

Grass tiles, for producing O2 via grass. Yes, they do that.

Pod tiles, for theme.

A box of RND circuitboards, for producing circuits you're missing.

A box of construction permits, for labeling areas so you can actually build in them.

Expensive, but worth it.
:cl: LORD OF BONGOS
add: Added the G.E.C.K colonization kit to cargo, containing everything needed to colonize a planet. Needs CE access to open. Or, you know, you can just welderbomb it open, but whatevs
/:cl:

