### PR TITLE
Replaces LEGION with a legion when the necropolis gate is knocked on.

### DIFF
--- a/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
@@ -38,18 +38,18 @@
 		volume += 20
 		sleep(10)
 	sleep(10)
-	visible_message("<span class='userdanger'>Something horrible emerges from the Necropolis!</span>")
+	visible_message("<span class='userdanger'>Something fairly underwhelming has emerged from the Necropolis!</span>")
 	message_admins("[key_name_admin(user)] has summoned Legion!")
-	log_game("[key_name(user)] summoned Legion.")
+	log_game("[key_name(user)] tried to summon Legion.")
 	for(var/mob/M in player_list)
 		if(M.z == z)
-			M << "<span class='userdanger'>Discordant whispers flood your mind in a thousand voices. Each one speaks your name, over and over. Something horrible has come.</span>"
+			M << "<span class='userdanger'>Discordant whispers flood your mind in a thousand voices. Each one whispers 'IOU one bossfight'. Something underwhelming has come.</span>"
 			M << 'sound/creatures/legion_spawn.ogg'
 			flash_color(M, flash_color = "#FF0000", flash_time = 50)
 	var/image/door_overlay = image('icons/effects/effects.dmi', "legiondoor")
-	notify_ghosts("Legion has been summoned in the [get_area(src)]!", source = src, alert_overlay = door_overlay, action = NOTIFY_JUMP)
+	notify_ghosts("Some tiny little mob has been summoned in the [get_area(src)]!", source = src, alert_overlay = door_overlay, action = NOTIFY_JUMP)
 	is_anyone_home = FALSE
-	new/mob/living/simple_animal/hostile/megafauna/legion(get_step(src.loc, SOUTH))
+	new/mob/living/simple_animal/hostile/asteroid/hivelord/legion(get_step(src.loc, SOUTH))
 
 /obj/structure/lavaland_door/singularity_pull()
 	return 0


### PR DESCRIPTION
Due to some bugs involving Legion restartingt he weather system and also being impossible to deal with for a bunch of morons and making people panic and overreact, Legion behind the necropolis gate has been reduced to a regular legion. Main reason is that people keep knocking on it during a colony build or something, luring him to the colony and everything devolves into skull blowjobs. I might make a replacement gate or something for admins to summon/as a random encounter so Legion can still spawn, but not as easy as it is now.


:cl: SOMETHING HORRIBLE HAS COME
add: Legion is taking a vacation in the Bahamas. Something less deadly is behind the necropolis gate now.
/:cl:

