### PR TITLE
The "Long-Awaited Fixes" update

### DIFF
--- a/_maps/map_files/SpaceSHIP/SpaceSHIP.dmm
+++ b/_maps/map_files/SpaceSHIP/SpaceSHIP.dmm
@@ -2765,22 +2765,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay)
-"fp" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/cmo,
-/area/shuttle/ftl/medical/medbay)
 "fq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
@@ -4064,6 +4048,19 @@
 	dir = 1
 	},
 /area/shuttle/ftl/security/nuke_storage)
+"hQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
 "hR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
@@ -6245,6 +6242,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"mE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/bridge/eva)
 "mF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -8577,20 +8590,6 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel/delivery,
 /area/shuttle/ftl/crew_quarters/emergency_storage)
-"rK" = (
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/emergency_storage)
 "rM" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/office)
@@ -9968,6 +9967,25 @@
 	},
 /turf/open/floor/plasteel/yellow/side,
 /area/shuttle/ftl/engine/break_room)
+"uR" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/camera{
+	c_tag = "Dormitories";
+	dir = 8
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
 "uU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -10283,6 +10301,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"vE" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
 "vF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -11442,6 +11466,16 @@
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
+"yi" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
 "yk" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -14041,6 +14075,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
+"DE" = (
+/obj/structure/table,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/division)
 "DG" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
@@ -14925,6 +14965,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
+"Fw" = (
+/obj/machinery/light_switch{
+	pixel_x = -22;
+	pixel_y = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology";
+	dir = 4;
+	network = list("SS13","RD")
+	},
+/obj/machinery/computer/camera_advanced/xenobio,
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (EAST)";
+	icon_state = "plasteel_warn";
+	dir = 4
+	},
+/area/shuttle/ftl/research/xenobiology)
 "Fx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -15840,13 +15897,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Hq" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/bridge/eva)
 "Hr" = (
 /obj/structure/grille,
 /obj/machinery/door/poddoor/preopen{
@@ -16380,40 +16430,6 @@
 /obj/structure/bed,
 /obj/item/weapon/bedsheet,
 /turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/sleep)
-"Iq" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/sleep)
-"Ir" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/camera{
-	c_tag = "Dormitories";
-	dir = 8
-	},
-/obj/item/device/radio/intercom{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
 "It" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
@@ -17355,34 +17371,6 @@
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/research/xenobiology)
-"Kf" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/camera{
-	c_tag = "Xenobiology";
-	dir = 4;
-	network = list("SS13","RD")
-	},
-/obj/machinery/light_switch{
-	pixel_x = -22;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/xenobiology)
 "Kg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -17679,24 +17667,6 @@
 	initial_gas_mix = "n2=500;TEMP=80"
 	},
 /area/shuttle/ftl/research/server)
-"Kw" = (
-/obj/machinery/camera{
-	c_tag = "Robotics West";
-	dir = 4;
-	network = list("SS13","RD")
-	},
-/obj/structure/table,
-/obj/item/device/assembly/flash/handheld,
-/obj/item/device/assembly/flash/handheld,
-/obj/item/device/assembly/flash/handheld,
-/obj/item/device/assembly/flash/handheld,
-/obj/item/device/assembly/flash/handheld,
-/turf/open/floor/plasteel/warning{
-	tag = "icon-plasteel_warn (NORTH)";
-	icon_state = "plasteel_warn";
-	dir = 1
-	},
-/area/shuttle/ftl/assembly/robotics)
 "Kx" = (
 /turf/open/floor/plasteel/warning{
 	tag = "icon-plasteel_warn (NORTH)";
@@ -19238,6 +19208,13 @@
 	icon_state = "L7"
 	},
 /area/shuttle/ftl/hallway/primary/port)
+"Od" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
 "Of" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -19491,6 +19468,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"OP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "5"
+	},
+/turf/open/floor/plasteel/cmo,
+/area/shuttle/ftl/medical/medbay)
 "OQ" = (
 /obj/machinery/computer/card/minor/hos,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -19618,6 +19611,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"Pj" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge/eva)
 "Pl" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -19722,6 +19722,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
+"Px" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1;
+	d2 = 2
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/emergency_storage)
 "Pz" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -19958,6 +19972,25 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"Qj" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
 "Qk" = (
 /obj/structure/lattice,
 /turf/open/space,
@@ -20243,6 +20276,25 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"Rm" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/turf/open/space,
+/area/shuttle/ftl/munitions/cannon)
 "Rn" = (
 /turf/closed/wall,
 /area/shuttle/ftl/medical/medbay_lobby)
@@ -20386,12 +20438,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
-"RN" = (
-/obj/machinery/computer/camera_advanced/xenobio,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/division)
 "RR" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -21354,6 +21400,27 @@
 	dir = 10
 	},
 /area/shuttle/ftl/atmos)
+"UD" = (
+/obj/structure/table,
+/obj/item/device/mmi/posibrain{
+	pixel_y = 5
+	},
+/obj/machinery/camera{
+	c_tag = "Robotics West";
+	dir = 4;
+	network = list("SS13","RD")
+	},
+/obj/item/device/assembly/flash/handheld,
+/obj/item/device/assembly/flash/handheld,
+/obj/item/device/assembly/flash/handheld,
+/obj/item/device/assembly/flash/handheld,
+/obj/item/device/assembly/flash/handheld,
+/turf/open/floor/plasteel/warning{
+	tag = "icon-plasteel_warn (NORTH)";
+	icon_state = "plasteel_warn";
+	dir = 1
+	},
+/area/shuttle/ftl/assembly/robotics)
 "UJ" = (
 /obj/effect/landmark/start{
 	name = "Station Engineer";
@@ -21773,10 +21840,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"VZ" = (
-/obj/item/weapon/gun/projectile/revolver,
-/turf/open/space,
-/area/shuttle/ftl/space)
 "Wa" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -22123,23 +22186,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/bridge/eva)
-"WK" = (
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 0;
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
@@ -45728,7 +45774,7 @@ GE
 Hv
 Ix
 Jp
-GE
+Ke
 Hv
 Ix
 Jp
@@ -45985,7 +46031,7 @@ GF
 Hw
 Iy
 Jq
-Ke
+Fw
 Hw
 Iy
 Jq
@@ -46242,7 +46288,7 @@ GG
 Hx
 Iz
 Jr
-Kf
+Qj
 KX
 LY
 MC
@@ -47016,7 +47062,7 @@ Ju
 Ki
 La
 Ma
-RN
+DE
 KZ
 ab
 ab
@@ -51078,7 +51124,7 @@ aR
 aR
 aR
 aR
-fp
+OP
 Rn
 Rn
 Rn
@@ -51095,7 +51141,7 @@ pF
 XB
 qk
 Xr
-rK
+Px
 sk
 Xn
 XF
@@ -51896,7 +51942,7 @@ DQ
 HM
 IN
 JJ
-Kw
+UD
 Lq
 Md
 MM
@@ -55992,7 +56038,7 @@ sR
 xn
 xK
 ym
-yM
+Rm
 yM
 yM
 Xf
@@ -61370,7 +61416,7 @@ TW
 OO
 ay
 ab
-VZ
+ab
 ab
 ab
 ab
@@ -63200,8 +63246,8 @@ Dz
 El
 Fq
 Gw
-Ho
-Iq
+vE
+yi
 Gw
 Ho
 Fq
@@ -63457,8 +63503,8 @@ DA
 Em
 Fr
 Gx
-Hp
-Ir
+hQ
+uR
 Jl
 Hp
 qo
@@ -63714,8 +63760,8 @@ Ci
 En
 En
 En
-En
 Ys
+En
 En
 En
 En
@@ -63971,8 +64017,8 @@ Wn
 En
 Wq
 Wv
-Wq
-Hq
+Pj
+Od
 Yv
 Fs
 Fs
@@ -65002,7 +65048,7 @@ Yv
 Yv
 Yv
 Yv
-WK
+mE
 WP
 KU
 KU

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -112,8 +112,6 @@ var/datum/subsystem/mapping/SSmapping
 				world.log << "Not unloading [P.z_levels[1]] for [P.name]"
 				continue
 			for(var/z_level in P.z_levels)
-				if("[z_level]" != z_level_txt)
-					continue
 				for(var/datum/sub_turf_block/STB in split_block(locate(1, 1, z_level), locate(255, 255, z_level)))
 					for(var/turf/T in STB.return_list())
 						for(var/A in T.contents)


### PR DESCRIPTION
:cl: monster860
fix: Fix the slime console problem.
fix: Removes the revolver floating in space
fix: Fixes medbay maint door access
rscadd: Adds a positronic brain to Robotics
fix: Fix broken piping in dorms/eva
fix: Fix APC being in the wrong direction in EVA
rscadd: Adds missing APC to phase cannon area
fix: Fix pixel offsets on APC in emergency storage
fix: Fixes z-levels being improperly unloaded, resulting in 2 z-levels getting merged together.
/:cl:

Fix #227
Fix #132
Fix #225
Fix #214 
Fix #111
Fix #228