### PR TITLE
Add in guides to MO/BO

### DIFF
--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -1000,3 +1000,17 @@
 	author = "Nanotrasen"
 	title = "The Tao of Supermatter Engines"
 	page_link = "Supermatter_Engine"
+	
+/obj/item/weapon/book/manual/ftl_wiki/munitions_manual
+	name = "Mass Accelerator Cannon User's Guide"
+	icon_state ="bookHacking"
+	author = "Nanotrasen"
+	title = "Mass Accelerator Cannon User's Guide"
+	page_link = "Guide_to_munitions"
+	
+/obj/item/weapon/book/manual/ftl_wiki/bo_guide
+	name = "Bridge Officer's Orientation Guide"
+	icon_state ="bookHacking"
+	author = "Russell Spitzer"		//vanity.jpeg
+	title = "Bridge Officer's Orientation Guide"
+	page_link = "Guide_to_Bridge_Officer"


### PR DESCRIPTION
:cl: EvilJackCarver
add: Added two more wikibooks to the code. One points to the Guide to Munitions, the other points to the Guide to Bridge Officer. Both are admin-spawn only until a time comes when they're added to the map.
wip: The Guide to Bridge Officer wikipage is still somewhat of a work in progress.
/:cl:

Adds in two wikibooks: Guide to Munitions, and Guide to Bridge Officer.

`/obj/item/weapon/book/manual/ftl_wiki/munitions_manual` 
`/obj/item/weapon/book/manual/ftl_wiki/bo_guide` 

Currently only admin-spawn, and both have the same cover as the Hacking book. 