### PR TITLE
Moar Ship Objectives

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -418,6 +418,22 @@ var/datum/subsystem/ticker/ticker
 				robo.laws.show_laws(world)
 
 	mode.declare_completion()//To declare normal completion.
+	
+	// Declare ship objectives
+	world << "<br><FONT size=3><B>The ship objectives were:</B></FONT>"
+	var/count = 1
+	var/redtext = 0
+	for(var/datum/objective/objective in SSstarmap.ship_objectives)
+		if(objective.check_completion() && !objective.failed)
+			world << "<br><b>Objective #[count]</b>: [objective.explanation_text] <span class='greenannounce'>Success!</span>"
+		else
+			world << "<br><b>Objective #[count]</b>: [objective.explanation_text] <span class='boldannounce'>Fail.</span>"
+			redtext = 1
+		count++
+	if(redtext)
+		world << "<br><b><span class='boldannounce'>The ship has failed.</span></b>"
+	else
+		world << "<br><b><span class='greenannounce'>The ship was successful.</span></b>"
 
 	//calls auto_declare_completion_* for all modes
 	for(var/handler in typesof(/datum/game_mode/proc))
@@ -440,6 +456,8 @@ var/datum/subsystem/ticker/ticker
 	log_game("Antagonists at round end were...")
 	for(var/i in total_antagonists)
 		log_game("[i]s[total_antagonists[i]].")
+	
+	
 
 	//Adds the del() log to world.log in a format condensable by the runtime condenser found in tools
 	if(SSgarbage.didntgc.len)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -480,7 +480,9 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 			var/count = 0
 			for(var/datum/objective/O in SSstarmap.ship_objectives)
 				count++
-				if(O.check_completion())
+				if(O.failed)
+					dat += "<B>Objective #[count]</B>: [O.explanation_text] <font color='red'><B>Failed.</B></font><br>"
+				else if(O.check_completion())
 					dat += "<B>Objective #[count]</B>: [O.explanation_text] <font color='green'><B>Success!</B></font><br>"
 				else
 					dat += "<B>Objective #[count]</B>: [O.explanation_text] <font color='yellow'>Incomplete.</font><br>"
@@ -605,7 +607,9 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 			var/count = 0
 			for(var/datum/objective/O in SSstarmap.ship_objectives)
 				count++
-				if(O.check_completion())
+				if(O.failed)
+					dat += "<B>Objective #[count]</B>: [O.explanation_text] <font color='red'><B>Failed.</B></font><br>"
+				else if(O.check_completion())
 					dat += "<B>Objective #[count]</B>: [O.explanation_text] <font color='green'><B>Success!</B></font><br>"
 				else
 					dat += "<B>Objective #[count]</B>: [O.explanation_text] <font color='red'>Fail.</font><br>"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1637,3 +1637,15 @@
 	cost = 800
 	contains = list(/obj/item/weapon/book/space_catalog)
 	crate_name = "space catalog crate"
+
+/datum/supply_pack/delivery_mission
+	group = "Mission Items"
+	cost = 0 // Free
+	sensitivity = 0
+	var/datum/objective/ftl/delivery/objective
+
+/datum/supply_pack/delivery_mission/fill(obj/structure/closet/crate/C)
+	..()
+	for(var/obj/O in C)
+		objective.delivery_item = O
+	objective.has_purchased_item = 1


### PR DESCRIPTION
:cl: monster860
rscadd: Adds a new "deliver" objective. Currently, it's limited to delivering syndicate intel.
rscadd: Adds the ability for missions to be failed instead of just incomplete.
rscadd: Adds end-round objective announcements
rscadd: Adds a new go-home objective created after too many objectives are completed or after 1.5 hours to end the round once this go-home objective is completed
/:cl: