### PR TITLE
Miscellaneous Sec buffs

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -108,7 +108,7 @@
 
 /obj/item/weapon/storage/belt/security
 	name = "security belt"
-	desc = "Can hold security gear like handcuffs and flashes."
+	desc = "Can hold security gear like handcuffs, flashes, or a service handgun."
 	icon_state = "securitybelt"
 	item_state = "security"//Could likely use a better one.
 	storage_slots = 5
@@ -130,7 +130,10 @@
 		/obj/item/weapon/melee/classic_baton/telescopic,
 		/obj/item/device/radio,
 		/obj/item/clothing/gloves/,
-		/obj/item/weapon/restraints/legcuffs/bola
+		/obj/item/weapon/restraints/legcuffs/bola,
+		/obj/item/weapon/gun/projectile/automatic/pistol,
+		/obj/item/ammo_box/magazine/m10mm,
+		/obj/item/weapon/gun/energy/gun/advtaser
 		)
 
 /obj/item/weapon/storage/belt/security/full/New()

--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -104,8 +104,10 @@ Strip out?
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	r_pocket = /obj/item/device/assembly/flash/handheld
 	l_pocket = /obj/item/weapon/restraints/handcuffs
-	suit_store = /obj/item/weapon/gun/energy/gun/advtaser
-	backpack_contents = list(/obj/item/weapon/melee/baton/loaded=1)
+	suit_store = /obj/item/weapon/gun/projectile/automatic/pistol		//stechkin
+	backpack_contents = list(/obj/item/weapon/melee/baton/loaded=1,\
+		/obj/item/weapon/gun/energy/gun/advtaser=1,\
+		/obj/item/ammo_box/magazine/m10mm=2)				//2 spare mags
 
 	backpack = /obj/item/weapon/storage/backpack/security
 	satchel = /obj/item/weapon/storage/backpack/satchel_sec
@@ -214,8 +216,10 @@ var/list/sec_departments = list("engineering", "supply", "medical", "science")
 	shoes = /obj/item/clothing/shoes/jackboots
 	l_pocket = /obj/item/weapon/restraints/handcuffs
 	r_pocket = /obj/item/device/assembly/flash/handheld
-	suit_store = /obj/item/weapon/gun/energy/gun/advtaser
-	backpack_contents = list(/obj/item/weapon/melee/baton/loaded=1)
+	suit_store = /obj/item/weapon/gun/projectile/automatic/pistol		//stechkin
+	backpack_contents = list(/obj/item/weapon/melee/baton/loaded=1,\
+		/obj/item/weapon/gun/energy/gun/advtaser=1,\
+		/obj/item/ammo_box/magazine/m10mm=2)				//2 spare mags
 
 	backpack = /obj/item/weapon/storage/backpack/security
 	satchel = /obj/item/weapon/storage/backpack/satchel_sec


### PR DESCRIPTION
:cl: EvilJackCarver
experiment: Security Officers and the Warden are no longer glorified mallcops, and now spawn with a lethal-capable weapon on their armour. Two magazines spawn in the backpack; more ammo can be printed from a hacked autolathe. The Taser that spawned in the armour slot previously now spawns in the backpack.
tweak: Security belt can now holster a service pistol, magazines for said service pistol, and a Taser.
/:cl:

Security officers and Warden now spawn with a Stechkin in their armour slot. Two magazines for it spawn in the backpack. The Taser the Stechkin replaces is now in the backpack.

This should help with the unconscious mentality against using lethals. 