### PR TITLE
Adds 10 boxes of 10mm to the sec vendor

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -818,7 +818,8 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	icon_deny = "sec-deny"
 	req_access_txt = "1"
 	products = list(/obj/item/weapon/restraints/handcuffs = 8,/obj/item/weapon/restraints/handcuffs/cable/zipties = 10,/obj/item/weapon/grenade/flashbang = 4,/obj/item/device/assembly/flash/handheld = 5,
-					/obj/item/weapon/reagent_containers/food/snacks/donut = 12,/obj/item/weapon/storage/box/evidence = 6,/obj/item/device/flashlight/seclite = 4,/obj/item/weapon/restraints/legcuffs/bola/energy = 7)
+					/obj/item/weapon/reagent_containers/food/snacks/donut = 12,/obj/item/weapon/storage/box/evidence = 6,/obj/item/device/flashlight/seclite = 4,/obj/item/weapon/restraints/legcuffs/bola/energy = 7,
+					/obj/item/ammo_box/c10mm = 10)
 	contraband = list(/obj/item/clothing/glasses/sunglasses = 2,/obj/item/weapon/storage/fancy/donut_box = 2)
 	premium = list(/obj/item/weapon/coin/antagtoken = 1)
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -246,6 +246,19 @@
 	access = access_armory
 	crate_type = /obj/structure/closet/crate/secure/weapon
 
+/datum/supply_pack/security/armory/stechkin_ammo
+	name = "10mm Ammunition Crate"
+	cost = 3500
+	contains = list(/obj/item/ammo_box/c10mm,
+					/obj/item/ammo_box/c10mm,
+					/obj/item/ammo_box/c10mm,
+					/obj/item/ammo_box/c10mm,
+					/obj/item/ammo_box/c10mm,
+					/obj/item/ammo_box/magazine/m10mm,
+					/obj/item/ammo_box/magazine/m10mm)
+	crate_name = "10mm ammunition crate"
+	sensitivity = 1					//highly doubt the syndies would give sec ammo
+
 /datum/supply_pack/security/armory/riothelmets
 	name = "Riot Helmets Crate"
 	cost = 1500

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -248,7 +248,7 @@
 
 /datum/supply_pack/security/armory/stechkin_ammo
 	name = "10mm Ammunition Crate"
-	cost = 3500
+	cost = 3000
 	contains = list(/obj/item/ammo_box/c10mm,
 					/obj/item/ammo_box/c10mm,
 					/obj/item/ammo_box/c10mm,


### PR DESCRIPTION
## ***COMMITS DONE - READY FOR MERGE***

:cl: EvilJackCarver
add: Security vendors now contain ten boxes of 10mm ammunition. If Security graduated at the top of the Imperial Stormtrooper Marksmanship Academy, they can get more from trading stations.
/:cl:

10 boxes sounds excessive, but Sec does tend to go through guns and ammo during rounds. Any thoughts on that amount? Or should we playtest and see how many boxes Sec goes through per officer per round first, and make a decision based on that?

Also, second question: Should I add a couple of magazines to the vendor in case an unrobust sec officer loses one of their spares? I'm thinking no, but I still want other opinions.

(Side note: Per `/code/modules/projectiles/ammunition/boxes.dm`, 1 box of 10mm is 20 rounds.)

(~~also this is kinda untested~~ Tested 2016-12-13 T 22:52 GMT-0600)