### PR TITLE
Prevents HoP from adding BO slots

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -30,6 +30,7 @@ var/time_last_changed_position = 0
 		"Assistant",
 		"Cyborg",
 		"Captain",
+		"Bridge Officer",
 		"Head of Personnel",
 		"Head of Security",
 		"Chief Engineer",


### PR DESCRIPTION
did i do a good?

:cl: honkmeister2k17
tweak: blacklisted BO from having its slots adjusted from the HoP computer
/:cl:
