### PR TITLE
Rewords event announcements to fit our setting

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -23,7 +23,7 @@
 
 /datum/round_event/ion_storm/announce()
 	if(announceEvent == ION_ANNOUNCE || (announceEvent == ION_RANDOM && prob(ionAnnounceChance)))
-		priority_announce("Ion storm detected near the station. Please check all AI-controlled equipment for errors.", "Anomaly Alert", 'sound/AI/ionstorm.ogg')
+		priority_announce("Ion storm detected near the ship. Please check all AI-controlled equipment for errors.", "Anomaly Alert", 'sound/AI/ionstorm.ogg')
 
 
 /datum/round_event/ion_storm/start()
@@ -97,19 +97,19 @@
 		if(1 to 3) //There are # X on the station
 			switch(rand(1,3)) //What is X?
 				if(1) //X is a threat
-					message = "THERE ARE [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ionthreats] ON THE STATION..."
+					message = "THERE ARE [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ionthreats] ON THE SHIP..."
 				if(2) //X is a crewmember/job
-					message = "THERE ARE [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ioncrew1] ON THE STATION"
+					message = "THERE ARE [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ioncrew1] ON THE SHIP"
 				if(3) //X is an object
-					message = "THERE ARE [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ionobjects] ON THE STATION"
+					message = "THERE ARE [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ionobjects] ON THE SHIP"
 		if(4 to 6) //You can't call the shuttle because X is on the station
 			switch(rand(1,3)) //What is X?
 				if(1) //X is a threat
-					message = "THE SHUTTLE CANNOT BE CALLED BECAUSE OF [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ionthreats] ON THE STATION"
+					message = "THE SHUTTLE CANNOT BE FUELED BECAUSE OF [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ionthreats] ON THE SHIP"
 				if(2) //X is a crewmember/job
-					message = "THE SHUTTLE CANNOT BE CALLED BECAUSE OF [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ioncrew1] ON THE STATION"
+					message = "THE SHUTTLE CANNOT BE FUELED BECAUSE OF [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ioncrew1] ON THE SHIP"
 				if(3) //X is an object
-					message = "THE SHUTTLE CANNOT BE CALLED BECAUSE OF [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ionobjects] ON THE STATION"
+					message = "THE SHUTTLE CANNOT BE FUELED BECAUSE OF [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ionobjects] ON THE SHIP"
 		if(7 to 8) //A crewmember is now X
 			switch(rand(1,2)) //Who is X?
 				if(1) //A specific crewmember
@@ -189,15 +189,15 @@
 				if(3) //X is the station
 					switch(rand(1,5)) //What does it require?
 						if(1) //It requires threats
-							message = "THE STATION REQUIRES [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ionthreats]"
+							message = "THE SHIP REQUIRES [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ionthreats]"
 						if(2) //It requires crewmembers
-							message = "THE STATION REQUIRES [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ioncrew1]"
+							message = "THE SHIP REQUIRES [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ioncrew1]"
 						if(3) //It requires objects
-							message = "THE STATION REQUIRES [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ionobjects]"
+							message = "THE SHIP REQUIRES [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ionobjects]"
 						if(4) //It requires an abstract
-							message = "THE STATION REQUIRES [ionabstract]"
+							message = "THE SHIP REQUIRES [ionabstract]"
 						if(5) //It requires generic/silly requirements
-							message = "THE STATION REQUIRES [ionrequire]"
+							message = "THE SHIP REQUIRES [ionrequire]"
 
 				if(4) //X is the entire crew
 					switch(rand(1,5)) //What does it require?

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -105,11 +105,11 @@
 		if(4 to 6) //You can't call the shuttle because X is on the station
 			switch(rand(1,3)) //What is X?
 				if(1) //X is a threat
-					message = "THE SHUTTLE CANNOT BE FUELED BECAUSE OF [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ionthreats] ON THE SHIP"
+					message = "THE SHUTTLE CANNOT BE LAUNCHED BECAUSE OF [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ionthreats] ON THE SHIP"
 				if(2) //X is a crewmember/job
-					message = "THE SHUTTLE CANNOT BE FUELED BECAUSE OF [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ioncrew1] ON THE SHIP"
+					message = "THE SHUTTLE CANNOT BE LAUNCHED BECAUSE OF [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ioncrew1] ON THE SHIP"
 				if(3) //X is an object
-					message = "THE SHUTTLE CANNOT BE FUELED BECAUSE OF [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ionobjects] ON THE SHIP"
+					message = "THE SHUTTLE CANNOT BE LAUNCHED BECAUSE OF [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ionobjects] ON THE SHIP"
 		if(7 to 8) //A crewmember is now X
 			switch(rand(1,2)) //Who is X?
 				if(1) //A specific crewmember

--- a/code/modules/events/meateor_wave.dm
+++ b/code/modules/events/meateor_wave.dm
@@ -5,7 +5,7 @@
 	max_occurrences = 1
 
 /datum/round_event/meteor_wave/meaty/announce()
-	priority_announce("Meaty ores have been detected on collision course with the station.", "Oh crap, get the mop.",'sound/AI/meteors.ogg')
+	priority_announce("Meaty ores have been detected on collision course with the ship.", "Oh crap, get the mop.",'sound/AI/meteors.ogg')
 
 /datum/round_event/meteor_wave/meaty/tick()
 	if(IsMultiple(activeFor, 3))

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -26,7 +26,7 @@
 			wave_type = meteors_catastrophic
 
 /datum/round_event/meteor_wave/announce()
-	priority_announce("Meteors have been detected on collision course with the station.", "Meteor Alert", 'sound/AI/meteors.ogg')
+	priority_announce("Meteors have been detected on collision course with the ship.", "Meteor Alert", 'sound/AI/meteors.ogg')
 
 
 /datum/round_event/meteor_wave/tick()

--- a/code/modules/events/operative.dm
+++ b/code/modules/events/operative.dm
@@ -44,7 +44,7 @@
 		else
 			nuke_code = nuke.r_code
 
-		Mind.store_memory("<B>Station Self-Destruct Device Code</B>: [nuke_code]", 0, 0)
+		Mind.store_memory("<B>Ship Self-Destruct Device Code</B>: [nuke_code]", 0, 0)
 		Mind.current << "The nuclear authorization code is: <B>[nuke_code]</B>"
 
 		var/datum/objective/nuclear/O = new()

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -13,7 +13,7 @@
 	announceWhen	= 1
 
 /datum/round_event/radiation_storm/announce()
-	priority_announce("High levels of radiation detected near the station. Maintenance is best shielded from radiation.", "Anomaly Alert", 'sound/AI/radiation.ogg')
+	priority_announce("High levels of radiation detected near the ship. Maintenance is best shielded from radiation.", "Anomaly Alert", 'sound/AI/radiation.ogg')
 	//sound not longer matches the text, but an audible warning is probably good
 
 

--- a/code/modules/events/weightless.dm
+++ b/code/modules/events/weightless.dm
@@ -13,7 +13,7 @@
 	endWhen = rand(40,80)
 
 /datum/round_event/weightless/announce()
-	command_alert("Warning: Failsafes for the station's artificial gravity arrays have been triggered. Please be aware that if this problem recurs it may result in formation of gravitational anomalies. Nanotrasen wishes to remind you that the unauthorised formation of anomalies within Nanotrasen facilities is strictly prohibited by health and safety regulation [rand(99,9999)][pick("a","b","c")]:subclause[rand(1,20)][pick("a","b","c")].")
+	command_alert("Warning: Failsafes for the ship's artificial gravity arrays have been triggered. Please be aware that if this problem recurs it may result in formation of gravitational anomalies. Nanotrasen wishes to remind you that the unauthorised formation of anomalies within Nanotrasen facilities is strictly prohibited by health and safety regulation [rand(99,9999)][pick("a","b","c")]:subclause[rand(1,20)][pick("a","b","c")].")
 
 /datum/round_event/weightless/start()
 	for(var/area/A in world)

--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -29,7 +29,7 @@
 		wormholes += new /obj/effect/portal/wormhole(T, null, null, -1)
 
 /datum/round_event/wormholes/announce()
-	priority_announce("Space-time anomalies detected on the station. There is no additional data.", "Anomaly Alert", 'sound/AI/spanomalies.ogg')
+	priority_announce("Space-time anomalies detected on the ship. There is no additional data.", "Anomaly Alert", 'sound/AI/spanomalies.ogg')
 
 /datum/round_event/wormholes/tick()
 	if(activeFor % shift_frequency == 0)

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -232,7 +232,7 @@
 	else
 		SSshuttle.emergencyLastCallLoc = null
 
-	priority_announce("The escape shuttles have been armed. [redAlert ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will launch in [timeLeft(600)] minutes.[reason][SSshuttle.emergencyLastCallLoc ? "\n\nArming signal traced. Results can be viewed on any communications console." : "" ]", null, 'sound/AI/shuttlecalled.ogg', "Priority")
+	priority_announce("The escape shuttles have been armed. [redAlert ? "General Quarters status confirmed: Emergency fueling initiated " : "" ]It will launch in [timeLeft(600)] minutes.[reason][SSshuttle.emergencyLastCallLoc ? "\n\nArming signal traced. Results can be viewed on any communications console." : "" ]", null, 'sound/AI/shuttlecalled.ogg', "Priority")
 
 /obj/docking_port/mobile/emergency/cancel(area/signalOrigin)
 	if(mode != SHUTTLE_CALL)
@@ -285,8 +285,8 @@
 					return
 				mode = SHUTTLE_DOCKED
 				timer = world.time
-				send2irc("Server", "The Emergency Shuttle has docked with the station.")
-				priority_announce("The Emergency Shuttle has docked with the station. You have [timeLeft(600)] minutes to board the Emergency Shuttle.", null, 'sound/AI/shuttledock.ogg', "Priority")
+				send2irc("Server", "The Emergency Shuttle fueling completed.")
+				priority_announce("The Emergency Shuttle has been fueled and is ready for launch. You have [timeLeft(600)] minutes to board the Emergency Shuttle.", null, 'sound/AI/shuttledock.ogg', "Priority")
 				feedback_add_details("emergency_shuttle", src.name)
 
 				// Gangs only have one attempt left if the shuttle has


### PR DESCRIPTION
:cl: We're a ship, not a station
tweak: Adjusted event announcements to use the word "ship" instead of "station".
/:cl:
