### PR TITLE
Changes Central Command to Fleet Command

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -27,7 +27,7 @@ var/command_name = null
 	if (command_name)
 		return command_name
 
-	var/name = "Central Command"
+	var/name = "Fleet Command"
 
 	command_name = name
 	return name

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -234,7 +234,7 @@ This file contains the arcane tome files.
 			if(confirm_final == "No")
 				user << "<span class='cult'>You decide to prepare further before scribing the rune.</span>"
 				return
-			priority_announce("Figments from an eldritch god are being summoned by [user] into [locname] from an unknown dimension. Disrupt the ritual at all costs!","Central Command Higher Dimensionsal Affairs", 'sound/AI/spanomalies.ogg')
+			priority_announce("Figments from an eldritch god are being summoned by [user] into [locname] from an unknown dimension. Disrupt the ritual at all costs!","Fleet Command Higher Dimensionsal Affairs", 'sound/AI/spanomalies.ogg')
 			for(var/B in spiral_range_turfs(1, user, 1))
 				var/turf/T = B
 				var/obj/machinery/shield/N = new(T)

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -254,7 +254,7 @@ var/time_last_changed_position = 0
 
 			var/accesses = ""
 			if(istype(src,/obj/machinery/computer/card/centcom))
-				accesses += "<h5>Central Command:</h5>"
+				accesses += "<h5>Fleet Command:</h5>"
 				for(var/A in get_all_centcom_access())
 					if(A in modify.access)
 						accesses += "<a href='?src=\ref[src];choice=access;access_target=[A];allowed=0'><font color=\"red\">[replacetext(get_centcom_access_desc(A), " ", "&nbsp")]</font></a> "

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -253,7 +253,7 @@
 				src.active1 = null
 				src.active2 = null
 				src.authenticated = 1
-				src.rank = "Central Command"
+				src.rank = "Fleet Command"
 				src.screen = 1
 			else if(istype(src.scan, /obj/item/weapon/card/id))
 				src.active1 = null

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -326,7 +326,7 @@ What a mess.*/
 					active1 = null
 					active2 = null
 					authenticated = usr.client.holder.admin_signature
-					rank = "Central Command"
+					rank = "Fleet Command"
 					screen = 1
 				else if(istype(scan, /obj/item/weapon/card/id))
 					active1 = null

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -252,7 +252,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 
 /obj/machinery/hologram/comms_pad
 	name = "communications holopad"
-	desc = "It's a floor-mounted device for communicating with Central Command and with other ships using holograms."
+	desc = "It's a floor-mounted device for communicating with Fleet Command and with other ships using holograms."
 	icon_state = "comms_pad0"
 	layer = LOW_OBJ_LAYER
 	var/mob/communicator/master

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -189,19 +189,19 @@ update_label("John Doe", "Clowny")
 	..()
 
 /obj/item/weapon/card/id/centcom
-	name = "\improper Centcom ID"
-	desc = "An ID straight from Cent. Com."
+	name = "\improper FleetComm ID"
+	desc = "An ID straight from Fleet Comm."
 	icon_state = "centcom"
-	registered_name = "Central Command"
-	assignment = "General"
+	registered_name = "Fleet Command"
+	assignment = "Admiral"
 
 /obj/item/weapon/card/id/centcom/New()
 	access = get_all_centcom_access()
 	..()
 
 /obj/item/weapon/card/id/ert
-	name = "\improper Centcom ID"
-	desc = "A ERT ID card"
+	name = "\improper FleetComm ID"
+	desc = "An ERT ID card"
 	icon_state = "centcom"
 	registered_name = "Emergency Response Team Commander"
 	assignment = "Emergency Response Team Commander"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -102,13 +102,13 @@
 					message_admins("[key_name(usr)] tried to create gangs. Unfortunately, there were not enough candidates available.")
 					log_admin("[key_name(usr)] failed create gangs.")
 			if("13")
-				message_admins("[key_name(usr)] is creating a Centcom response team...")
+				message_admins("[key_name(usr)] is creating a FleetComm response team...")
 				if(src.makeEmergencyresponseteam())
-					message_admins("[key_name(usr)] created a Centcom response team.")
-					log_admin("[key_name(usr)] created a Centcom response team.")
+					message_admins("[key_name(usr)] created a FleetComm response team.")
+					log_admin("[key_name(usr)] created a FleetComm response team.")
 				else
-					message_admins("[key_name_admin(usr)] tried to create a Centcom response team. Unfortunately, there were not enough candidates available.")
-					log_admin("[key_name(usr)] failed to create a Centcom response team.")
+					message_admins("[key_name_admin(usr)] tried to create a FleetComm response team. Unfortunately, there were not enough candidates available.")
+					log_admin("[key_name(usr)] failed to create a FleetComm response team.")
 			if("14")
 				message_admins("[key_name(usr)] is creating an abductor team...")
 				if(src.makeAbductorTeam())
@@ -1758,14 +1758,14 @@
 			usr << "The person you are trying to contact is not wearing a headset"
 			return
 
-		var/input = input(src.owner, "Please enter a message to reply to [key_name(H)] via their headset.","Outgoing message from Centcom", "")
+		var/input = input(src.owner, "Please enter a message to reply to [key_name(H)] via their headset.","Outgoing message from FleetComm", "")
 		if(!input)
 			return
 
 		src.owner << "You sent [input] to [H] via a secure channel."
-		log_admin("[src.owner] replied to [key_name(H)]'s Centcom message with the message [input].")
-		message_admins("[src.owner] replied to [key_name(H)]'s Centcom message with: \"[input]\"")
-		H << "You hear something crackle in your ears for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows. [input].  Message ends.\""
+		log_admin("[src.owner] replied to [key_name(H)]'s FleetComm message with the message [input].")
+		message_admins("[src.owner] replied to [key_name(H)]'s FleetComm message with: \"[input]\"")
+		H << "You hear something crackle in your ears for a moment before a voice speaks.  \"Please stand by for a message from Fleet Command.  Message as follows. [input].  Message ends.\""
 
 	else if(href_list["SyndicateReply"])
 		var/mob/living/carbon/human/H = locate(href_list["SyndicateReply"])

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -395,7 +395,7 @@
 
 /datum/admins/proc/makeOfficial()
 	var/mission = input("Assign a task for the official", "Assign Task", "Conduct a routine preformance review of [station_name()] and its Captain.")
-	var/list/mob/dead/observer/candidates = pollCandidates("Do you wish to be considered to be a Centcom Official?", "deathsquad")
+	var/list/mob/dead/observer/candidates = pollCandidates("Do you wish to be considered to be a FleetComm Official?", "deathsquad")
 
 	if(candidates.len)
 		var/mob/dead/observer/chosen_candidate = pick(candidates)
@@ -406,7 +406,7 @@
 		newmob.real_name = newmob.dna.species.random_name(newmob.gender,1)
 		newmob.dna.update_dna_identity()
 		newmob.key = chosen_candidate.key
-		newmob.mind.assigned_role = "Centcom Official"
+		newmob.mind.assigned_role = "FleetComm Official"
 		newmob.equipOutfit(/datum/outfit/centcom_official)
 
 		//Assign antag status and the mission
@@ -422,20 +422,20 @@
 			newmob.set_species(/datum/species/human)
 
 		//Greet the official
-		newmob << "<B><font size=3 color=red>You are a Centcom Official.</font></B>"
-		newmob << "<BR>Central Command is sending you to [station_name()] with the task: [mission]"
+		newmob << "<B><font size=3 color=red>You are a FleetComm Official.</font></B>"
+		newmob << "<BR>Fleet Command is sending you to [station_name()] with the task: [mission]"
 
 		//Logging and cleanup
-		message_admins("Centcom Official [key_name_admin(newmob)] has spawned with the task: [mission]")
-		log_game("[key_name(newmob)] has been selected as a Centcom Official")
+		message_admins("FleetComm Official [key_name_admin(newmob)] has spawned with the task: [mission]")
+		log_game("[key_name(newmob)] has been selected as a FleetComm Official")
 
 		return 1
 
 	return 0
 
-// CENTCOM RESPONSE TEAM
+// FleetComm RESPONSE TEAM
 /datum/admins/proc/makeEmergencyresponseteam()
-	var/alert = input("Which team should we send?", "Select Response Level") as null|anything in list("Green: Centcom Official", "Blue: Light ERT (No Armoury Access)", "Amber: Full ERT (Armoury Access)", "Red: Elite ERT (Armoury Access + Pulse Weapons)", "Delta: Deathsquad")
+	var/alert = input("Which team should we send?", "Select Response Level") as null|anything in list("Green: FleetComm Official", "Blue: Light ERT (No Armoury Access)", "Amber: Full ERT (Armoury Access)", "Red: Elite ERT (Armoury Access + Pulse Weapons)", "Delta: Deathsquad")
 	if(!alert)
 		return
 	switch(alert)
@@ -447,7 +447,7 @@
 			alert = "Amber"
 		if("Blue: Light ERT (No Armoury Access)")
 			alert = "Blue"
-		if("Green: Centcom Official")
+		if("Green: FleetComm Official")
 			return makeOfficial()
 	var/teamsize = min(7,input("Maximum size of team? (7 max)", "Select Team Size",4) as null|num)
 	var/mission = input("Assign a mission to the Emergency Response Team", "Assign Mission", "Assist the station.")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -489,12 +489,12 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!holder)
 		src << "Only administrators may use this command."
 		return
-	var/input = input(usr, "Please input a new name for Central Command.", "What?", "") as text|null
+	var/input = input(usr, "Please input a new name for Fleet Command.", "What?", "") as text|null
 	if(!input)
 		return
 	change_command_name(input)
-	message_admins("[key_name_admin(src)] has changed Central Command's name to [input]")
-	log_admin("[key_name(src)] has changed the Central Command name to: [input]")
+	message_admins("[key_name_admin(src)] has changed Fleet Command's name to [input]")
+	log_admin("[key_name(src)] has changed the Fleet Command name to: [input]")
 
 /client/proc/cmd_admin_delete(atom/O as obj|mob|turf in world)
 	set category = "Admin"

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -362,7 +362,7 @@ var/global/list/ghost_orbits = list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 /client/verb/toggle_announcement_sound()
 	set name = "Hear/Silence Announcements"
 	set category = "Preferences"
-	set desc = ".Toggles hearing Central Command, Captain, VOX, and other announcement sounds"
+	set desc = ".Toggles hearing Fleet Command, Captain, VOX, and other announcement sounds"
 	prefs.toggles ^= SOUND_ANNOUNCEMENTS
 	src << "You will now [(prefs.toggles & SOUND_ANNOUNCEMENTS) ? "hear announcement sounds" : "no longer hear announcements"]."
 	prefs.save_preferences()

--- a/code/orphaned_procs/priority_announce.dm
+++ b/code/orphaned_procs/priority_announce.dm
@@ -10,16 +10,16 @@
 			announcement += "<br><h2 class='alert'>[html_encode(title)]</h2>"
 	else if(type == "Captain")
 		announcement += "<h1 class='alert'>Captain Announces</h1>"
-		news_network.SubmitArticle(text, "Captain's Announcement", "Station Announcements", null)
+		news_network.SubmitArticle(text, "Captain's Announcement", "Ship Announcements", null)
 
 	else
 		announcement += "<h1 class='alert'>[command_name()] Update</h1>"
 		if (title && length(title) > 0)
 			announcement += "<br><h2 class='alert'>[html_encode(title)]</h2>"
 		if(title == "")
-			news_network.SubmitArticle(text, "Central Command Update", "Station Announcements", null)
+			news_network.SubmitArticle(text, "Fleet Command Update", "Station Announcements", null)
 		else
-			news_network.SubmitArticle(title + "<br><br>" + text, "Central Command", "Station Announcements", null)
+			news_network.SubmitArticle(title + "<br><br>" + text, "Fleet Command", "Ship Announcements", null)
 
 	announcement += "<br><span class='alert'>[html_encode(text)]</span><br>"
 	announcement += "<br>"


### PR DESCRIPTION
:cl: Fleeterizing
tweak: tweaked CentCom ID cards to be FleetComm ID cards
twear: Default FleetComm rank from General to Admiral
tweak: Updates a lot of flavor text and announcement instances from Central Command / CentCom to Fleet Command / FleetComm
spellcheck: fixed a grammar issue
/:cl:
