### PR TITLE
Fixes bridge officers being department head

### DIFF
--- a/code/modules/jobs/job_types/bridge.dm
+++ b/code/modules/jobs/job_types/bridge.dm
@@ -4,7 +4,7 @@ Bridge Officer
 /datum/job/bofficer
 	title = "Bridge Officer"
 	flag = BOFFICER
-	department_head = list("Captain", "Executive Officer")
+	department_head = list("Captain")
 	department_flag = ENGSEC
 	faction = "Station"
 	total_positions = 2


### PR DESCRIPTION
At least until we rename HoP to XO.
:cl: Vivalas

fix: Fixes Bridge Officers being heads.
/:cl:

