### PR TITLE
snoefleks in bridge officer headsets

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -103,6 +103,18 @@
 	icon_state = "hop_cypherkey"
 	channels = list("Supply" = 1, "Service" = 1, "Command" = 1)
 
+/obj/item/device/encryptionkey/heads/weapons
+	name ="\proper the weapons officer's encryption key"
+	desc = "An encryption key for a radio headset.  Channels are as follows: :u - supply, :c - command."
+	icon_state = "hop_cypherkey"
+	channels = list("Supply" = 1, "Command" = 1)
+
+/obj/item/device/encryptionkey/heads/helms
+	name = "\proper the helms officer's encryption key"
+	desc = "An encryption key for a radio headset.  Channels are as follows: :e - engineering, :c - command."
+	icon_state = "hop_cypherkey"
+	channels = list("Engineering" = 1, "Command" = 1)
+
 /obj/item/device/encryptionkey/headset_cargo
 	name = "supply radio encryption key"
 	desc = "An encryption key for a radio headset.  To access the supply channel, use :u."

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -166,8 +166,25 @@
 	flags = EARBANGPROTECT
 	icon_state = "com_headset_alt"
 	item_state = "com_headset_alt"
-
 	keyslot = new /obj/item/device/encryptionkey/heads/hop
+
+/obj/item/device/radio/headset/heads/weapons
+	name ="\proper the weapons officer's headset"
+	desc ="The headset of the guy who gets to press buttons and make pewpew noises. \nChannels are as follows: :u - supply, :c - command."
+	icon_state = "com_heaset"
+	flags = EARBANGPROTECT
+	icon_state = "com_headset_alt"
+	item_state = "com_headset_alt"
+	keyslot = new /obj/item/device/encryptionkey/heads/weapons
+
+/obj/item/device/radio/headset/heads/helms
+	name ="\proper the helms officer's headset"
+	desc ="The headset of the stations designated driver. \nChannels are as follows: :e - engineering, :c - command."
+	icon_state = "com_heaset"
+	flags = EARBANGPROTECT
+	icon_state = "com_headset_alt"
+	item_state = "com_headset_alt"
+	keyslot = new /obj/item/device/encryptionkey/heads/helms
 
 /obj/item/device/radio/headset/headset_cargo
 	name = "supply radio headset"

--- a/code/modules/jobs/job_types/bridge.dm
+++ b/code/modules/jobs/job_types/bridge.dm
@@ -47,9 +47,11 @@ var/list/posts = list("weapons", "helms")
       if("weapons")
         post_access = list(access_weapons_console)
         spawn_point = locate(/obj/effect/landmark/start/bo/weapons) in department_command_spawns
+        ears = /obj/item/device/radio/headset/heads/weapons
       if("helms")
         post_access = list(access_helms_console)
         spawn_point = locate(/obj/effect/landmark/start/bo/helms) in department_command_spawns
+        ears = /obj/item/device/radio/headset/heads/helms
 
 /datum/outfit/job/bofficer/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
@@ -67,6 +69,7 @@ var/list/posts = list("weapons", "helms")
 
 	if(access_weapons_console in W.access) //I'm sorry
 		H.job = "Weapons Officer"
+
 	if(access_helms_console in W.access)
 		H.job = "Helms Officer"
 


### PR DESCRIPTION
Bridge officers now get their own headsets. Yay!
Weapons officer keep supply, so them and their Munitions can coordinate with cargo to order more shells
Helms officer now gets access to engineering instead of Supply, so he can bitch about running out of plasma for his FTL drive

:cl: 
add: Due to recent successful missions, the NSV Astraeus has been allocated more funds to their officers uniform department.
add: Bridge officers now get their own versions of the command headset, to reflect their job's needs.

/:cl:
