### PR TITLE
Tweaks admin create command report and change command name

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -467,9 +467,9 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!holder)
 		src << "Only administrators may use this command."
 		return
-	var/crSender = input(usr, "Who's sending the message? Leave blank for Central Command", "What?", "") as message|null
+	var/crSender = input(usr, "Who's sending the message? Leave blank for default (Currently: [command_name()])", "What?", "") as message|null
 	if(!crSender)
-		crSender = "Central Command"
+		crSender = command_name()
 	var/crTitle = input(usr, "Title of the report (OPTIONAL):", "What?", "") as message|null
 	if(!crTitle)
 		crTitle = null
@@ -483,7 +483,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	else
 		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/AI/commandreport.ogg')
 
-	print_command_report(crBody,"[confirm=="Public" ? "" : "Classified "][command_name()] Report")
+	print_command_report(crBody,"[confirm=="Public" ? "" : "Classified "][crSender] Report")
 
 	log_admin("[key_name(src)] has created a command report: [crBody]")
 	message_admins("[key_name_admin(src)] has created a command report")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -467,19 +467,25 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!holder)
 		src << "Only administrators may use this command."
 		return
-	var/input = input(usr, "Please enter anything you want. Anything. Serious.", "What?", "") as message|null
-	if(!input)
+	var/crSender = input(usr, "Who's sending the message? Leave blank for Central Command", "What?", "") as message|null
+	if(!crSender)
+		crSender = "Central Command"
+	var/crTitle = input(usr, "Title of the report (OPTIONAL):", "What?", "") as message|null
+	if(!crTitle)
+		crTitle = null
+	var/crBody = input(usr, "Contents of the report:", "What?", "") as message|null
+	if(!crBody)
 		return
 
-	var/confirm = alert(src, "Do you want to announce the contents of the report to the crew?", "Announce", "Yes", "No")
-	if(confirm == "Yes")
-		priority_announce(input, null, 'sound/AI/commandreport.ogg')
+	var/confirm = alert(src, "Send a public report, or a classified report?", "Announce", "Public", "Classified")
+	if(confirm == "Public")
+		priority_announce(crBody, crTitle, 'sound/AI/commandreport.ogg', "Admin", crSender)
 	else
 		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/AI/commandreport.ogg')
 
-	print_command_report(input,"[confirm=="Yes" ? "" : "Classified "][command_name()] Update")
+	print_command_report(crBody,"[confirm=="Public" ? "" : "Classified "][command_name()] Report")
 
-	log_admin("[key_name(src)] has created a command report: [input]")
+	log_admin("[key_name(src)] has created a command report: [crBody]")
 	message_admins("[key_name_admin(src)] has created a command report")
 	feedback_add_details("admin_verb","CCR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/orphaned_procs/priority_announce.dm
+++ b/code/orphaned_procs/priority_announce.dm
@@ -1,4 +1,4 @@
-/proc/priority_announce(text, title = "", sound = 'sound/AI/attention.ogg', type)
+/proc/priority_announce(text, title = "", sound = 'sound/AI/attention.ogg', type, sender)
 	if(!text)
 		return
 
@@ -12,6 +12,13 @@
 		announcement += "<h1 class='alert'>Captain Announces</h1>"
 		news_network.SubmitArticle(text, "Captain's Announcement", "Station Announcements", null)
 
+	else if(type == "Admin")
+		announcement += "<h1 class='alert'>[html_encode(sender)] Update</h1>"
+		if (title && length(title) > 0)
+			announcement += "<br><h2 class='alert'>[html_encode(title)]</h2>"
+			news_network.SubmitArticle(title + "<br><br>" + text, sender + " Update", "Station Announcements", null)
+		else
+			news_network.SubmitArticle(text, sender + " Update", "Station Announcements", null)
 	else
 		announcement += "<h1 class='alert'>[command_name()] Update</h1>"
 		if (title && length(title) > 0)


### PR DESCRIPTION
Basically, this eliminates the issue of changing the command name and then auto announcements being sent from that command name. This PR distinguishes the admin create command report and change command name verbs in the following ways:

**Create command report:**

- You will be prompted to specify the command name for the specific report

- You can leave command name blank to use the currently set command name

- You can now specify a title for the report, like a sub-heading


**Change command name:**

- This very is now used to semi-permanently change the command name for any announcements that regularly display it

:cl: Tyler/BrandonSacawv
add: adds "admin" command reports
tweak: admins can now specify command name and title from create command report verb
/:cl:
