### PR TITLE
Fixes targetting spam

### DIFF
--- a/code/datums/ship.dm
+++ b/code/datums/ship.dm
@@ -300,7 +300,7 @@ var/next_ship_id
 			continue
 		if(!SSship.check_hostilities(ship.faction,O.faction))
 			possible_targets += O
-	if(ship.system == SSstarmap.current_system && !SSship.check_hostilities(ship.faction,"ship"))
+	if(ship.system && ship.system == SSstarmap.current_system && !SSship.check_hostilities(ship.faction,"ship"))
 		possible_targets += "ship"
 	if(!possible_targets.len)
 		return


### PR DESCRIPTION
No syndicate, fuck you and your slipspace weaponry.

:cl: Vivalas

fix: Fixes combat spam that occurs when a ship in transit tried to target the player ship also in transit.

/:cl:
