### PR TITLE
Compressed Matter Cartridges spelling fix.

### DIFF
--- a/code/modules/cargo/exports/tools.dm
+++ b/code/modules/cargo/exports/tools.dm
@@ -109,7 +109,7 @@
 
 /datum/export/rcd_ammo
 	cost = 15 // 1.5 metal, 1 glass -> 12.5 credits, +2.5 credits
-	unit_name = "compressed matter cardridge"
+	unit_name = "compressed matter cartridge"
 	export_types = list(/datum/design/rcd_ammo)
 
 /datum/export/rpd

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -216,7 +216,7 @@
 	maxstack = 50
 
 /datum/design/rcd_ammo
-	name = "Compressed matter cardridge"
+	name = "Compressed matter cartridge"
 	id = "rcd_ammo"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 3000, MAT_GLASS=2000)


### PR DESCRIPTION
This fixes #476 
Bye bye 'muh immersions'

:cl: Funce
fix: Compressed Matter Cartridge is now spelt correctly
/:cl:
