### PR TITLE
Changes the 'station' to 'ship' in the charter announcement and other places

### DIFF
--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "scroll2"
 	desc = "An official document entrusting the governance of the ship \
-		to the Captain."
+		and the area within its shield boundaries to the Captain."
 	var/used = FALSE
 
 	var/unlimited_uses = FALSE
@@ -87,7 +87,7 @@
 
 	name = "ship charter for [world.name]"
 	desc = "An official document entrusting the governance of \
-		[world.name] to Captain [user]."
+		[world.name] and area within its shield boundaries to Captain [user]."
 
 	if(!unlimited_uses)
 		used = TRUE

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -87,7 +87,7 @@
 
 	name = "ship charter for [world.name]"
 	desc = "An official document entrusting the governance of \
-		[world.name] and area within its shield boundaries to Captain [user]."
+		[world.name] and the area within its shield boundaries to Captain [user]."
 
 	if(!unlimited_uses)
 		used = TRUE

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -2,8 +2,8 @@
 	name = "station charter"
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "scroll2"
-	desc = "An official document entrusting the governance of the station \
-		and surrounding space to the Captain. "
+	desc = "An official document entrusting the governance of the ship \
+		to the Captain."
 	var/used = FALSE
 
 	var/unlimited_uses = FALSE
@@ -31,11 +31,11 @@
 
 /obj/item/station_charter/attack_self(mob/living/user)
 	if(used)
-		user << "This charter has already been used to name the station."
+		user << "This charter has already been used to name the ship."
 		return
 	if(!ignores_timeout && (world.time-round_start_time > CHALLENGE_TIME_LIMIT)) //5 minutes
 		user << "The crew has already settled into the shift. \
-			It probably wouldn't be good to rename the station right now."
+			It probably wouldn't be good to rename the ship right now."
 		return
 	if(response_timer_id)
 		user << "You're still waiting for approval from your employers about \
@@ -49,7 +49,7 @@
 
 	if(!new_name)
 		return
-	log_game("[key_name(user)] has proposed to name the station as \
+	log_game("[key_name(user)] has proposed to name the ship as \
 		[new_name]")
 
 	if(standard_station_regex.Find(new_name))
@@ -61,7 +61,7 @@
 	// Autoapproves after a certain time
 	response_timer_id = addtimer(src, "rename_station", approval_time, \
 		FALSE, new_name, user)
-	admins << "<span class='adminnotice'><b><font color=orange>CUSTOM STATION RENAME:</font></b>[key_name_admin(user)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) proposes to rename the station to [new_name] (will autoapprove in [approval_time / 10] seconds). (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[user]'>BSA</A>) (<A HREF='?_src_=holder;reject_custom_name=\ref[src]'>REJECT</A>)</span>"
+	admins << "<span class='adminnotice'><b><font color=orange>CUSTOM SHIP RENAME:</font></b>[key_name_admin(user)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) proposes to rename the ship to [new_name] (will autoapprove in [approval_time / 10] seconds). (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[user]'>BSA</A>) (<A HREF='?_src_=holder;reject_custom_name=\ref[src]'>REJECT</A>)</span>"
 
 /obj/item/station_charter/proc/reject_proposed(user)
 	if(!user)
@@ -71,7 +71,7 @@
 	var/turf/T = get_turf(src)
 	T.visible_message("<span class='warning'>The proposed changes disappear \
 		from [src]; it looks like they've been rejected.</span>")
-	var/m = "[key_name(user)] has rejected the proposed station name."
+	var/m = "[key_name(user)] has rejected the proposed ship name."
 
 	message_admins(m)
 	log_admin(m)
@@ -82,12 +82,12 @@
 /obj/item/station_charter/proc/rename_station(designation, mob/user)
 	world.name = designation
 	station_name = designation
-	minor_announce("[user.real_name] has designated your station as [world.name]", "Captain's Charter", 0)
-	log_game("[key_name(user)] has renamed the station as [world.name]")
+	minor_announce("[user.real_name] has designated your ship as [world.name]", "Captain's Charter", 0)
+	log_game("[key_name(user)] has renamed the ship as [world.name]")
 
-	name = "station charter for [world.name]"
+	name = "ship charter for [world.name]"
 	desc = "An official document entrusting the governance of \
-		[world.name] and surrounding space to Captain [user]."
+		[world.name] to Captain [user]."
 
 	if(!unlimited_uses)
 		used = TRUE


### PR DESCRIPTION
So I'm sure this needs to be fixed. I should probably fix the rest of the 'station' but these were the most pressing.
Make sure to check that the description changes are okay.

:cl: Funce
fix: The Charter now refers to the ship as a ship rather than a station.
/:cl:
