### PR TITLE
Fixes belts (security belts mostly) not having their item overlays before you add/remove an item to them.

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -13,6 +13,10 @@
 		add_overlay("[I.name]")
 	..()
 
+/obj/item/weapon/storage/belt/Initialize()
+	. = ..()
+	update_icon()
+
 /obj/item/weapon/storage/belt/utility
 	name = "toolbelt" //Carn: utility belt is nicer, but it bamboozles the text parsing.
 	desc = "Holds tools."

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -13,10 +13,6 @@
 		add_overlay("[I.name]")
 	..()
 
-/obj/item/weapon/storage/belt/New()
-	update_icon()
-	..()
-
 /obj/item/weapon/storage/belt/utility
 	name = "toolbelt" //Carn: utility belt is nicer, but it bamboozles the text parsing.
 	desc = "Holds tools."
@@ -47,7 +43,7 @@
 	new /obj/item/weapon/wirecutters(src)
 	new /obj/item/device/multitool(src)
 	new /obj/item/stack/cable_coil(src,30,pick("red","yellow","orange"))
-
+	update_icon()
 
 /obj/item/weapon/storage/belt/utility/atmostech/New()
 	..()
@@ -58,7 +54,7 @@
 	new /obj/item/weapon/wirecutters(src)
 	new /obj/item/device/t_scanner(src)
 	new /obj/item/weapon/extinguisher/mini(src)
-
+	update_icon()
 
 
 /obj/item/weapon/storage/belt/medical
@@ -147,7 +143,7 @@
 	new /obj/item/weapon/grenade/flashbang(src)
 	new /obj/item/device/assembly/flash/handheld(src)
 	new /obj/item/weapon/melee/baton/loaded(src)
-
+	update_icon()
 
 /obj/item/weapon/storage/belt/mining
 	name = "explorer's webbing"
@@ -221,6 +217,7 @@
 	..()
 	for(var/i in 1 to 6)
 		new /obj/item/device/soulstone(src)
+	update_icon()
 
 /obj/item/weapon/storage/belt/champion
 	name = "championship belt"
@@ -304,7 +301,8 @@
 	new /obj/item/weapon/grenade/syndieminibomb(src)
 	new /obj/item/weapon/screwdriver(src)
 	new /obj/item/device/multitool(src)
-
+	update_icon()
+	
 /obj/item/weapon/storage/belt/wands
 	name = "wand belt"
 	desc = "A belt designed to hold various rods of power. A veritable fanny pack of exotic magic."
@@ -327,7 +325,8 @@
 	for(var/obj/item/weapon/gun/magic/wand/W in contents) //All wands in this pack come in the best possible condition
 		W.max_charges = initial(W.max_charges)
 		W.charges = W.max_charges
-
+	update_icon()
+	
 /obj/item/weapon/storage/belt/janitor
 	name = "janibelt"
 	desc = "A belt used to hold most janitorial supplies."

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -13,9 +13,9 @@
 		add_overlay("[I.name]")
 	..()
 
-/obj/item/weapon/storage/belt/Initialize()
-	. = ..()
+/obj/item/weapon/storage/belt/New()
 	update_icon()
+	..()
 
 /obj/item/weapon/storage/belt/utility
 	name = "toolbelt" //Carn: utility belt is nicer, but it bamboozles the text parsing.


### PR DESCRIPTION
Title. They don't get their items correctly shown unless you take one out and put it back in to force it to update.

:cl: kevinz000
fix: Fixes belts (security belts mostly) not having their item overlays before you add/remove an item to them.
/:cl: