### PR TITLE
Detective can now go through security to get to his office

### DIFF
--- a/_maps/map_files/Trailblazer/Trailblazer.dmm
+++ b/_maps/map_files/Trailblazer/Trailblazer.dmm
@@ -14800,6 +14800,26 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
+"FgX" = (
+/obj/machinery/door/airlock/security{
+	name = "Brig";
+	req_access = null;
+	req_access_txt = "38"
+	},
+/obj/machinery/door_timer{
+	id = "Cell 1";
+	pixel_y = -32
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred,
+/area/shuttle/ftl/security/brig)
 "Fiy" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -18550,26 +18570,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
-"NKB" = (
-/obj/machinery/door/airlock/security{
-	name = "Brig";
-	req_access = null;
-	req_access_txt = "1"
-	},
-/obj/machinery/door_timer{
-	id = "Cell 1";
-	pixel_y = -32
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/darkred,
-/area/shuttle/ftl/security/brig)
 "NLh" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -52406,7 +52406,7 @@ oZB
 oyn
 NMe
 NMe
-NKB
+FgX
 NMe
 NMe
 NMe


### PR DESCRIPTION
:cl: ike709
fix: Detective can now walk through security to enter/exit his office, rather than resorting to Maintenance.
/:cl:

Now anyone with access to enter Security can walk into the cell area, too. Ability to access the cells and cell timers should™ remain the same, because all I touched was the airlock.

Fixes #561
Fixes #551 

Yay! Issue dupe!