### PR TITLE
AI Ship message temporary fix

### DIFF
--- a/code/controllers/subsystem/ships.dm
+++ b/code/controllers/subsystem/ships.dm
@@ -276,6 +276,8 @@ var/global/list/ftl_weapons_consoles = list()
 		return //don't need information about every combat sequence happening across the galaxy
 	for(var/obj/machinery/computer/ftl_weapons/C in ftl_weapons_consoles)
 		C.status_update(message,sound)
+	for (var/mob/living/silicon/aiPlayer in player_list)
+		aiPlayer << message
 
 /datum/subsystem/ship/proc/factor_damage(var/flag,var/datum/starship/S)
 	return factor_active_component(flag,S) / factor_component(flag,S)


### PR DESCRIPTION
Fix #103 No "combat text" for AI
Temporary because no custom message format, and no filtering (so floods the AI player with a lot of ships jumping around in the sector)