### PR TITLE
Built MAC guns can now be properly linked and viewed on consoles

### DIFF
--- a/code/game/machinery/computer/ftl_munitions.dm
+++ b/code/game/machinery/computer/ftl_munitions.dm
@@ -15,12 +15,13 @@
 /obj/machinery/computer/munitions_console/proc/link_ammo_racks()
 	sleep(1) //give time for the other things to load
 
+	ammo_racks = list()
+	cannons = list()
+
 	for(var/obj/machinery/ammo_rack/M in machines)
-		if(!(M in ammo_racks))
-			ammo_racks += M
+		ammo_racks += M
 	for(var/obj/machinery/mac_breech/B in machines)
-		if(!(B in cannons))
-			cannons += B
+		cannons += B
 
 /obj/machinery/computer/munitions_console/attack_hand(mob/user)
 	var/dat = "<B>Munitions Control Computer</B><HR>"

--- a/code/game/machinery/computer/ftl_munitions.dm
+++ b/code/game/machinery/computer/ftl_munitions.dm
@@ -16,9 +16,11 @@
 	sleep(1) //give time for the other things to load
 
 	for(var/obj/machinery/ammo_rack/M in machines)
-		ammo_racks += M
+		if(!(M in ammo_racks))
+			ammo_racks += M
 	for(var/obj/machinery/mac_breech/B in machines)
-		cannons += B
+		if(!(B in cannons))
+			cannons += B
 
 /obj/machinery/computer/munitions_console/attack_hand(mob/user)
 	var/dat = "<B>Munitions Control Computer</B><HR>"
@@ -57,6 +59,7 @@
 			dat += "<BR>-[S.name]"
 
 	dat += "<BR><BR><BR><HR>"
+	dat += "<center><A href=?src=\ref[src];reload=1>Reload Connections</A></center>"
 	dat += "<center><A href=?src=\ref[src];refresh=1>Refresh</A></center>"
 
 	var/datum/browser/popup = new(user, "scanner", name, 800, 660)
@@ -73,6 +76,8 @@
 		var/obj/machinery/ammo_rack/M = locate(href_list["loader"])
 		M.toggle_loader()
 		updateUsrDialog()
+	if(href_list["reload"])
+		link_ammo_racks()
 	if(href_list["refresh"])
 		updateUsrDialog()
 	attack_hand(usr)

--- a/code/game/machinery/computer/ftl_weapons.dm
+++ b/code/game/machinery/computer/ftl_weapons.dm
@@ -47,14 +47,16 @@
 	var/list/kinetics_list = list()
 	data["kinetic_weapons"] = kinetics_list
 	for(var/obj/machinery/mac_barrel/K in kinetic_weapons)
-		var/list/kinetic_list = list()
+		if(K.breech)
+			var/list/kinetic_list = list()
 
-		kinetic_list["name"] = "[K]"
-		kinetic_list["id"] = "\ref[K]"
-		kinetic_list["loaded"] = K.breech.loaded_shell
-		kinetic_list["can_fire"] = K.can_fire(TRUE)
-
-		kinetics_list[++kinetics_list.len] = kinetic_list
+			kinetic_list["name"] = "[K]"
+			kinetic_list["id"] = "\ref[K]"
+			kinetic_list["loaded"] = K.breech.loaded_shell
+			kinetic_list["can_fire"] = K.can_fire(TRUE)
+			kinetics_list[++kinetics_list.len] = kinetic_list
+		else
+			K.find_breech()
 	var/list/lasers_list = list()
 	data["laser_weapons"] = lasers_list
 	for(var/obj/machinery/power/shipweapon/L in laser_weapons)

--- a/code/game/machinery/computer/ftl_weapons.dm
+++ b/code/game/machinery/computer/ftl_weapons.dm
@@ -24,8 +24,7 @@
 	for(var/obj/machinery/mac_barrel/K in world)
 		if(!istype(get_area(K), /area/shuttle/ftl))
 			continue
-		if(copytext(K.id, 1, 7) == "weapon")
-			kinetic_weapons += K
+		kinetic_weapons += K
 	laser_weapons = list()
 	for(var/obj/machinery/power/shipweapon/L in world)
 		if(!istype(get_area(L), /area/shuttle/ftl))

--- a/code/game/machinery/mac_cannon.dm
+++ b/code/game/machinery/mac_cannon.dm
@@ -96,7 +96,7 @@
 /obj/machinery/mac_barrel/proc/toggle_hatch() //just moves the functionality of the massdriver control into the mac cannon, cleaned up a bit
 	var/list/activated_doors = list()
 	for(var/obj/machinery/door/poddoor/M in machines)
-		if(M.id == id)
+		if(M.id && M.id == id)
 			activated_doors += M
 			spawn(0) M.open()
 	sleep(50)


### PR DESCRIPTION
[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)


:cl: Skullyton
add: Munitions consoles now have a Reload Connections button, which rechecks connections and makes new ones to MAC guns and ammo racks
fix: Ship Tactical Console can now detect newly made MAC guns
/:cl:

All tested, should be fine

![munition_console](https://cloud.githubusercontent.com/assets/9110500/24077864/3fd49ffe-0c53-11e7-8768-328cebffe867.PNG)

![ship_tac_com](https://cloud.githubusercontent.com/assets/9110500/24077865/47bb6e00-0c53-11e7-95a5-f376ecb3c52a.PNG)
