### PR TITLE
Ports latejoin job priortization from /tg/ who ported it from Yog

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -10,6 +10,8 @@ var/datum/subsystem/job/SSjob
 	var/list/job_debug = list()			//Debug info
 	var/initial_players_to_assign = 0 	//used for checking against population caps
 
+	var/list/prioritized_jobs = list()
+
 /datum/subsystem/job/New()
 	NEW_SS_GLOBAL(SSjob)
 

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -493,7 +493,7 @@ var/time_last_changed_position = 0
 				else
 					SSjob.prioritized_jobs += j
 					prioritycount++
-					usr << "<span class='notice'>[j.title] has been successfully [priority ?  "prioritized" : "unprioritized"]. Potential employees will notice your request.</span>"
+				usr << "<span class='notice'>[j.title] has been successfully [priority ?  "prioritized" : "unprioritized"]. Potential employees will notice your request.</span>"
 
 		if ("print")
 			if (!( printing ))

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -19,6 +19,7 @@ var/time_last_changed_position = 0
 	var/list/region_access = null
 	var/list/head_subordinates = null
 	var/target_dept = 0 //Which department this computer has access to. 0=all departments
+	var/prioritycount = 0 // we don't want 500 prioritized jobs
 
 	//Cooldown for closing positions in seconds
 	//if set to -1: No cooldown... probably a bad idea
@@ -122,7 +123,7 @@ var/time_last_changed_position = 0
 			S = "--------"
 		dat += "<a href='?src=\ref[src];choice=scan'>[S]</a>"
 		dat += "<table>"
-		dat += "<tr><td style='width:25%'><b>Job</b></td><td style='width:25%'><b>Slots</b></td><td style='width:25%'><b>Open job</b></td><td style='width:25%'><b>Close job</b></td></tr>"
+		dat += "<tr><td style='width:25%'><b>Job</b></td><td style='width:25%'><b>Slots</b></td><td style='width:25%'><b>Open job</b></td><td style='width:25%'><b>Close job</b><td style='width:25%'><b>Prioritize</b></td></td></tr>"
 		var/ID
 		if(scan && (access_change_ids in scan.access) && !target_dept)
 			ID = 1
@@ -166,6 +167,22 @@ var/time_last_changed_position = 0
 					dat += "Cooldown ongoing: [mins]:[(seconds < 10) ? "0[seconds]" : "[seconds]"]"
 				if(0)
 					dat += "Denied"
+			dat += "</td><td>"
+			switch(job.total_positions)
+				if(0)
+					dat += "Denied"
+				else
+					if(ID)
+						if(job in SSjob.prioritized_jobs)
+							dat += "<a href='?src=\ref[src];choice=prioritize_job;job=[job.title]'>Deprioritize</a>"
+						else
+							if(prioritycount < 5)
+								dat += "<a href='?src=\ref[src];choice=prioritize_job;job=[job.title]'>Prioritize</a>"
+							else
+								dat += "Denied"
+					else
+						dat += "Prioritize"
+
 			dat += "</td></tr>"
 		dat += "</table>"
 	else
@@ -201,7 +218,7 @@ var/time_last_changed_position = 0
 			header += "<div align='center'><br>"
 			header += "<a href='?src=\ref[src];choice=modify'>Remove [target_name]</a> || "
 			header += "<a href='?src=\ref[src];choice=scan'>Remove [scan_name]</a> <br> "
-			header += "<a href='?src=\ref[src];choice=mode;mode_target=1'>Access Crew Manifest</a> || "
+			header += "<a href='?src=\ref[src];choice=mode;mode_target=1'>Access Crew Manifest</a> <br> "
 			header += "<a href='?src=\ref[src];choice=logout'>Log Out</a></div>"
 
 		header += "<hr>"
@@ -460,6 +477,23 @@ var/time_last_changed_position = 0
 					time_last_changed_position = world.time / 10
 				j.total_positions--
 				opened_positions[edit_job_target]--
+
+		if ("prioritize_job")
+			// TOGGLE WHETHER JOB APPEARS AS PRIORITIZED IN THE LOBBY
+			if(scan && (access_change_ids in scan.access) && !target_dept)
+				var/priority_target = href_list["job"]
+				var/datum/job/j = SSjob.GetJob(priority_target)
+				if(!j)
+					return 0
+				var/priority = TRUE
+				if(j in SSjob.prioritized_jobs)
+					SSjob.prioritized_jobs -= j
+					prioritycount--
+					priority = FALSE
+				else
+					SSjob.prioritized_jobs += j
+					prioritycount++
+					usr << "<span class='notice'>[j.title] has been successfully [priority ?  "prioritized" : "unprioritized"]. Potential employees will notice your request.</span>"
 
 		if ("print")
 			if (!( printing ))

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -392,6 +392,17 @@
 		if(job && IsJobAvailable(job.title))
 			available_job_count++;
 
+	if(length(SSjob.prioritized_jobs))
+		dat += "<div class='notice red'>The station has flagged these jobs as high priority:<br>"
+		var/amt = length(SSjob.prioritized_jobs)
+		var/amt_count
+		for(var/datum/job/a in SSjob.prioritized_jobs)
+			amt_count++
+			if(amt_count != amt) // checks for the last job added.
+				dat += " [a.title], "
+			else
+				dat += " [a.title]. </div>"
+
 	dat += "<div class='clearBoth'>Choose from the following open positions:</div><br>"
 	dat += "<div class='jobs'><div class='jobsColumn'>"
 	var/job_count = 0


### PR DESCRIPTION
:cl: ike709
add: The HoP can now prioritize latejoin roles in the Job Management screen of their ID console.
/:cl:

Credit to the following people for creating it, trying to port it to /tg/, and successfully porting it to /tg/; respectively:
Super3222
bgobandit
Cyberboss

Merged /tg/ PR: https://github.com/tgstation/tgstation/pull/24901
Original /tg/ PR: https://github.com/tgstation/tgstation/pull/24495

Extra credit to bgobandit for the description I shamelessly stole:

This PR adds the ability for HoPs to specify certain jobs as prioritized via the Job Management section of the ID console. Up to five jobs can be prioritized at a time. Typos not ported from the /tg/ PR because I'm lazy. Message ability not ported from Yog because meta.

![image](https://cloud.githubusercontent.com/assets/5714543/24087704/6d480122-0cf0-11e7-832e-ca99ff02e45c.png)

If any prioritized jobs exist, they will be shown to players in the Join Game screen.

![image](https://cloud.githubusercontent.com/assets/5714543/24087707/7507d0ea-0cf0-11e7-82e0-a38c43e66260.png)
