### PR TITLE
Bridge Officers get their own PDAs

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -93,6 +93,11 @@
 	default_cartridge = /obj/item/weapon/cartridge/hop
 	icon_state = "pda-hop"
 
+/obj/item/device/pda/heads/bo
+	name = "bridge officer PDA"
+	default_cartridge = /obj/item/weapon/cartridge/head
+	icon_state = "pda-hop"
+
 /obj/item/device/pda/heads/hos
 	name = "head of security PDA"
 	default_cartridge = /obj/item/weapon/cartridge/hos

--- a/code/modules/jobs/job_types/bridge.dm
+++ b/code/modules/jobs/job_types/bridge.dm
@@ -24,7 +24,7 @@ var/list/posts = list("weapons", "helms")
 /datum/outfit/job/bofficer //utilizes HoP headset for now
 	name = "Bridge Officer"
 
-	belt = /obj/item/device/pda //if you ever change this, remove the part that references it below
+	belt = /obj/item/device/pda/heads/bo //if you ever change this, remove the part that references it below
 	glasses = /obj/item/clothing/glasses/sunglasses
 	ears = /obj/item/device/radio/headset/heads/hop
 	uniform =  /obj/item/clothing/under/rank/bofficer
@@ -77,7 +77,7 @@ var/list/posts = list("weapons", "helms")
 	W.update_label(newjob=W.assignment)
 	data_core.manifest_modify(W.registered_name, W.assignment)
 
-	var/obj/item/device/pda/P = H.belt
+	var/obj/item/device/pda/heads/bo/P = H.belt
 	if(istype(P))
 		P.ownjob = W.assignment
 		P.update_label() //grrr


### PR DESCRIPTION
:cl: ike709
add: Bridge Officers get their own PDA. Includes a crew manifest.
/:cl:

My second and final April Fools PR. This adds custom PDAs for the Bridge Officers, with the HoP paintjob and the cartridge with the crew manifest. Looking at Messenger every round to see the crew was annoying.