### PR TITLE
Makes MAC cannon slightly more likely to decalibrate when fired.

### DIFF
--- a/code/game/machinery/mac_cannon.dm
+++ b/code/game/machinery/mac_cannon.dm
@@ -78,7 +78,7 @@
 		qdel(breech.loaded_shell)
 		breech.loaded_objects -= breech.loaded_shell
 		breech.loaded_shell = null
-		if(prob(10))
+		if(prob(20))
 			breech.alignment = max(0,breech.alignment - 0.1) //20% chance the barrel becomes 10% more inaccurate
 
 	else //otherwise shoot whatever is in the barrel


### PR DESCRIPTION


:cl: Vivalas

tweak: Changed mac cannon decalibration chance from 10% to 20%.

/:cl:
