### PR TITLE
MO gets an age restriction

### DIFF
--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -40,6 +40,7 @@ Munitions Officer
 	spawn_positions = 1
 	supervisors = "the weapons officer, the head of personnel"
 	selection_color = "#e49f58"
+	minimal_player_age = 10
 
 	outfit = /datum/outfit/job/munitions_officer
 


### PR DESCRIPTION
:cl: ike709
tweak: Munitions Officer now has a 10 day age restriction. Same as Bridge Officer.
/:cl:

While the number of days is debatable, I think an age restriction of some amount is definitely justified.

Common mistakes Munitions Officers make that the majority of FTL13 players should hopefully know to avoid:
- Not arming shells before loading them.
- Ejecting armed shells.
- Not knowing oil is the necessary lubricant. I've seen people put in water and welding fuel.
- Spamming the breech open and closed and wasting all the oil
- Not knowing how to replace the actuator / Not knowing the actuator is a thing.
- Not closing the breech.
- Not loading what the WO says to load.

I could go into a much longer list about best practices, but that's full of opinions.