### PR TITLE
Speeds up world init, hopefully

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -163,3 +163,9 @@
 #define TANK_MAX_RELEASE_PRESSURE (ONE_ATMOSPHERE*3)
 #define TANK_MIN_RELEASE_PRESSURE 0
 #define TANK_DEFAULT_RELEASE_PRESSURE 16
+
+#define ATMOS_PASS_YES 1
+#define ATMOS_PASS_NO 0
+#define ATMOS_PASS_PROC -1 //ask CanAtmosPass()
+#define ATMOS_PASS_DENSITY -2 //just check density
+#define CANATMOSPASS(A, O) ( A.CanAtmosPass == ATMOS_PASS_PROC ? A.CanAtmosPass(O) : ( A.CanAtmosPass == ATMOS_PASS_DENSITY ? !A.density : A.CanAtmosPass ) )

--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -39,7 +39,7 @@
 #define SMOOTH_DIAGONAL	4	//if atom should smooth diagonally, this should be present in 'smooth' var
 #define SMOOTH_BORDER	8	//atom will smooth with the borders of the map
 #define SMOOTH_QUEUED	16	//atom is currently queued to smooth.
-#define SMOOTH_CUSTOM	32 //use custom smoothing proc, for... custom... smoothing
+#define SMOOTH_CUSTOM	32 //use custom smoothing proc, for... custom... smoothing, obviously...
 
 #define NULLTURF_BORDER 123456789
 

--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -33,12 +33,13 @@
 #define N_SOUTHEAST	64
 #define N_SOUTHWEST	1024
 
-#define SMOOTH_FALSE	0 //not smooth
-#define SMOOTH_TRUE		1 //smooths with exact specified types or just itself
-#define SMOOTH_MORE		2 //smooths with all subtypes of specified types or just itself (this value can replace SMOOTH_TRUE)
-#define SMOOTH_DIAGONAL	4 //if atom should smooth diagonally, this should be present in 'smooth' var
-#define SMOOTH_BORDER	8 //atom will smooth with the borders of the map
-#define SMOOTH_CUSTOM	16//use custom smoothing proc, for... custom... smoothing
+#define SMOOTH_FALSE	0	//not smooth
+#define SMOOTH_TRUE		1	//smooths with exact specified types or just itself
+#define SMOOTH_MORE		2	//smooths with all subtypes of specified types or just itself (this value can replace SMOOTH_TRUE)
+#define SMOOTH_DIAGONAL	4	//if atom should smooth diagonally, this should be present in 'smooth' var
+#define SMOOTH_BORDER	8	//atom will smooth with the borders of the map
+#define SMOOTH_QUEUED	16	//atom is currently queued to smooth.
+#define SMOOTH_CUSTOM	32 //use custom smoothing proc, for... custom... smoothing
 
 #define NULLTURF_BORDER 123456789
 
@@ -109,21 +110,22 @@
 
 	return adjacencies
 
+//do not use, use queue_smooth(atom)
 /proc/smooth_icon(atom/A)
-	if(qdeleted(A))
-		return
 	if(!A || !A.smooth)
 		return
-	spawn(0)
-		if((A.smooth & SMOOTH_TRUE) || (A.smooth & SMOOTH_MORE))
-			var/adjacencies = calculate_adjacencies(A)
+	A.smooth &= ~SMOOTH_QUEUED
+	if (!A.z)
+		return
+	if(qdeleted(A))
+		return
+	if((A.smooth & SMOOTH_TRUE) || (A.smooth & SMOOTH_MORE))
+		var/adjacencies = calculate_adjacencies(A)
 
-			if(A.smooth & SMOOTH_DIAGONAL)
-				A.diagonal_smooth(adjacencies)
-			else if(A.smooth & SMOOTH_CUSTOM)
-				A.custom_smooth(adjacencies)
-			else
-				cardinal_smooth(A, adjacencies)
+		if(A.smooth & SMOOTH_DIAGONAL)
+			A.diagonal_smooth(adjacencies)
+		else
+			cardinal_smooth(A, adjacencies)
 
 /atom/proc/custom_smooth(adjacencies)
 	return
@@ -159,12 +161,12 @@
 /turf/closed/wall/diagonal_smooth(adjacencies)
 	adjacencies = reverse_ndir(..())
 	if(adjacencies)
-		underlays.Cut()
+		var/list/U = list()
 		if(fixed_underlay)
 			if(fixed_underlay["space"])
-				underlays += image('icons/turf/space.dmi', SPACE_ICON_STATE, layer=src.layer)
+				U += image('icons/turf/space.dmi', SPACE_ICON_STATE, layer=src.layer)
 			else
-				underlays += image(fixed_underlay["icon"], fixed_underlay["icon_state"], layer=src.layer)
+				U += image(fixed_underlay["icon"], fixed_underlay["icon_state"], layer=src.layer)
 		else
 			var/turf/T = get_step(src, turn(adjacencies, 180))
 			if(T && T.density)
@@ -173,11 +175,11 @@
 					T = get_step(src, turn(adjacencies, 225))
 
 			if(istype(T, /turf/open/space))
-				underlays += image('icons/turf/space.dmi', SPACE_ICON_STATE, layer=src.layer)
+				U += image('icons/turf/space.dmi', SPACE_ICON_STATE, layer=src.layer)
 			else if(T && !T.density && !T.smooth)
-				underlays += T
+				U += T
 			else
-				underlays += DEFAULT_UNDERLAY_IMAGE
+				U += DEFAULT_UNDERLAY_IMAGE
 
 /proc/cardinal_smooth(atom/A, adjacencies)
 	//NW CORNER
@@ -232,25 +234,30 @@
 		else if(adjacencies & N_EAST)
 			se = "4-e"
 
+	var/list/New = list()
+
 	if(A.top_left_corner != nw)
 		A.overlays -= A.top_left_corner
 		A.top_left_corner = nw
-		A.add_overlay(nw)
+		New += nw
 
 	if(A.top_right_corner != ne)
 		A.overlays -= A.top_right_corner
 		A.top_right_corner = ne
-		A.add_overlay(ne)
+		New += ne
 
 	if(A.bottom_right_corner != sw)
 		A.overlays -= A.bottom_right_corner
 		A.bottom_right_corner = sw
-		A.add_overlay(sw)
+		New += sw
 
 	if(A.bottom_left_corner != se)
 		A.overlays -= A.bottom_left_corner
 		A.bottom_left_corner = se
-		A.add_overlay(se)
+		New += se
+
+	if(New.len)
+		A.add_overlay(New)
 
 /proc/find_type_in_direction(atom/source, direction)
 	var/turf/target_turf = get_step(source, direction)
@@ -313,14 +320,16 @@
 
 /atom/proc/replace_smooth_overlays(nw, ne, sw, se)
 	clear_smooth_overlays()
+	var/list/O = list()
 	top_left_corner = nw
-	add_overlay(nw)
+	O += nw
 	top_right_corner = ne
-	add_overlay(ne)
+	O += ne
 	bottom_left_corner = sw
-	add_overlay(sw)
+	O += sw
 	bottom_right_corner = se
-	add_overlay(se)
+	O += se
+	add_overlay(O)
 
 /proc/reverse_ndir(ndir)
 	switch(ndir)
@@ -360,21 +369,6 @@
 			return 0
 
 //SSicon_smooth
-/proc/ss_smooth_icon(atom/A)
-	if(qdeleted(A))
-		return
-	if(!istype(A) || (A && !A.smooth))
-		return
-	if((A.smooth & SMOOTH_TRUE) || (A.smooth & SMOOTH_MORE))
-		var/adjacencies = calculate_adjacencies(A)
-		if(A.smooth & SMOOTH_DIAGONAL)
-			A.diagonal_smooth(adjacencies)
-		else if(A.smooth & SMOOTH_CUSTOM)
-			A.custom_smooth(adjacencies)
-		else
-			cardinal_smooth(A, adjacencies)
-
-//SSicon_smooth
 /proc/queue_smooth_neighbors(atom/A)
 	for(var/V in orange(1,A))
 		var/atom/T = V
@@ -383,11 +377,12 @@
 
 //SSicon_smooth
 /proc/queue_smooth(atom/A)
-	if(SSicon_smooth)
-		SSicon_smooth.smooth_queue[A] = A
-		SSicon_smooth.can_fire = 1
-	else
-		smooth_icon(A)
+	if(!A.smooth || A.smooth & SMOOTH_QUEUED)
+		return
+
+	SSicon_smooth.smooth_queue += A
+	SSicon_smooth.can_fire = 1
+	A.smooth |= SMOOTH_QUEUED
 
 //Example smooth wall
 /turf/closed/wall/smooth

--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -32,5 +32,5 @@ var/datum/subsystem/icon_smooth/SSicon_smooth
 		if(!A || A.z <= 2)
 			continue
 		smooth_icon(A)
-		
+		CHECK_TICK
 	..()

--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -16,7 +16,7 @@ var/datum/subsystem/icon_smooth/SSicon_smooth
 	while(smooth_queue.len)
 		var/atom/A = smooth_queue[smooth_queue.len]
 		smooth_queue.len--
-		ss_smooth_icon(A)
+		smooth_icon(A)
 		if (MC_TICK_CHECK)
 			return
 	if (!smooth_queue.len)
@@ -25,8 +25,12 @@ var/datum/subsystem/icon_smooth/SSicon_smooth
 /datum/subsystem/icon_smooth/Initialize()
 	smooth_zlevel(1,TRUE)
 	smooth_zlevel(2,TRUE)
-	for(var/V in smooth_queue)
+	var/queue = smooth_queue
+	smooth_queue = list()
+	for(var/V in queue)
 		var/atom/A = V
-		if(A.z == 1 || A.z == 2)
-			smooth_queue -= A
+		if(!A || A.z <= 2)
+			continue
+		smooth_icon(A)
+		
 	..()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -22,6 +22,20 @@
 	var/list/priority_overlays
 	var/dont_save = 0
 
+/atom/New()
+	//atom creation method that preloads variables at creation
+	if(use_preloader && (src.type == _preloader.target_path))//in case the instanciated atom is creating other atoms in New()
+		_preloader.load(src)
+
+	//lighting stuff
+	if(opacity && isturf(loc))
+		loc.UpdateAffectingLights()
+
+	if(luminosity)
+		light = new(src)
+
+	//. = ..() //uncomment if you are dumb enough to add a /datum/New() proc
+
 /atom/Destroy()
 	if(alternate_appearances)
 		for(var/aakey in alternate_appearances)
@@ -31,6 +45,8 @@
 
 	return ..()
 
+/atom/proc/CanPass(atom/movable/mover, turf/target, height=1.5)
+	return (!density || !height)
 
 /atom/proc/onCentcom()
 	var/turf/T = get_turf(src)

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -29,6 +29,7 @@
 	..(loc)
 	ConsumeTile()
 	if(atmosblock)
+		CanAtmosPass = ATMOS_PASS_NO
 		air_update_turf(1)
 	return
 
@@ -58,9 +59,6 @@
 					if(C)
 						result++
 		. -= result - 1
-
-/obj/effect/blob/CanAtmosPass(turf/T)
-	return !atmosblock
 
 /obj/effect/blob/BlockSuperconductivity()
 	return atmosblock

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -734,6 +734,7 @@ var/list/teleport_runes = list()
 	invocation = "Khari'd! Eske'te tannin!"
 	icon_state = "1"
 	color = rgb(255, 0, 0)
+	CanAtmosPass = ATMOS_PASS_DENSITY
 
 /obj/effect/rune/wall/examine(mob/user)
 	..()

--- a/code/game/gamemodes/miniantags/abduction/machinery/dispenser.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/dispenser.dm
@@ -14,6 +14,7 @@
 	return rgb(rand(0,255),rand(0,255),rand(0,255))
 
 /obj/machinery/abductor/gland_dispenser/New()
+	..()
 	gland_types = subtypesof(/obj/item/organ/gland)
 	gland_types = shuffle(gland_types)
 	gland_colors = new/list(gland_types.len)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -9,6 +9,8 @@
 	layer = OPEN_DOOR_LAYER
 	power_channel = ENVIRON
 
+	CanAtmosPass = ATMOS_PASS_DENSITY
+
 	var/secondsElectrified = 0
 	var/shockedby = list()
 	var/visible = 1
@@ -76,9 +78,6 @@
 /obj/machinery/door/CanPass(atom/movable/mover, turf/target, height=0)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return !opacity
-	return !density
-
-/obj/machinery/door/CanAtmosPass()
 	return !density
 
 /obj/machinery/door/proc/bumpopen(mob/user)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -21,6 +21,8 @@
 	closingLayer = CLOSED_FIREDOOR_LAYER
 	assemblytype = /obj/structure/firelock_frame
 
+	CanAtmosPass = ATMOS_PASS_PROC
+
 /obj/machinery/door/firedoor/Bumped(atom/AM)
 	if(panel_open || operating)
 		return

--- a/code/game/machinery/doors/spacepod.dm
+++ b/code/game/machinery/doors/spacepod.dm
@@ -5,6 +5,7 @@
 	icon_state = "n_beam"
 	density = 0
 	anchored = 1
+	CanAtmosPass = ATMOS_PASS_PROC
 
 /obj/structure/spacepoddoor/initialize()
 	..()

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -8,6 +8,7 @@
 	visible = 0
 	flags = ON_BORDER
 	opacity = 0
+	CanAtmosPass = ATMOS_PASS_PROC
 	var/obj/item/weapon/electronics/airlock/electronics = null
 	var/reinf = 0
 	var/shards = 2

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -9,6 +9,7 @@
 		unacidable = 1
 		var/const/max_health = 200
 		var/health = max_health //The shield can only take so much beating (prevents perma-prisons)
+		CanAtmosPass = ATMOS_PASS_DENSITY
 
 /obj/machinery/shield/New()
 	src.setDir(pick(1,2,3,4))
@@ -29,9 +30,6 @@
 /obj/machinery/shield/CanPass(atom/movable/mover, turf/target, height)
 	if(!height) return 0
 	else return ..()
-
-/obj/machinery/shield/CanAtmosPass(turf/T)
-	return !density
 
 /obj/machinery/shield/bullet_act(obj/item/projectile/P)
 	. = ..()

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -200,6 +200,7 @@
 	desc = "A lightweight foamed metal wall."
 	gender = PLURAL
 	var/metal = 1		// 1=aluminium, 2=iron
+	CanAtmosPass = ATMOS_PASS_DENSITY
 
 /obj/structure/foamedmetal/New()
 	..()
@@ -299,8 +300,4 @@
 		user << "<span class='warning'>You hit the metal foam to no effect!</span>"
 
 /obj/structure/foamedmetal/CanPass(atom/movable/mover, turf/target, height=1.5)
-	return !density
-
-
-/obj/structure/foamedmetal/CanAtmosPass()
 	return !density

--- a/code/game/objects/effects/forcefields.dm
+++ b/code/game/objects/effects/forcefields.dm
@@ -6,9 +6,7 @@
 	opacity = 0
 	density = 1
 	unacidable = 1
-
-/obj/effect/forcefield/CanAtmosPass(turf/T)
-	return !density
+	CanAtmosPass = ATMOS_PASS_DENSITY
 
 /obj/effect/forcefield/cult
 	desc = "An unholy shield that blocks all attacks."

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -33,8 +33,8 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	var/max_heat_protection_temperature //Set this variable to determine up to which temperature (IN KELVIN) the item protects against heat damage. Keep at null to disable protection. Only protects areas set by heat_protection flags
 	var/min_cold_protection_temperature //Set this variable to determine down to which temperature (IN KELVIN) the item protects against cold damage. 0 is NOT an acceptable number due to if(varname) tests!! Keep at null to disable protection. Only protects areas set by cold_protection flags
 
-	var/list/actions = list() //list of /datum/action's that this item has.
-	var/list/actions_types = list() //list of paths of action datums to give to the item on New().
+	var/list/actions //list of /datum/action's that this item has.
+	var/list/actions_types //list of paths of action datums to give to the item on New().
 
 	//Since any item can now be a piece of clothing, this has to be put here so all items share it.
 	var/flags_inv //This flag is used to determine when items in someone's inventory cover others. IE helmets making it so you can't see glasses, etc.
@@ -54,11 +54,11 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	var/strip_delay = 40
 	var/put_on_delay = 20
 	var/breakouttime = 0
-	var/list/materials = list()
+	var/list/materials
 	var/origin_tech = null	//Used by R&D to determine what research bonuses it grants.
 	var/needs_permit = 0			//Used by security bots to determine if this item is safe for public use.
 
-	var/list/attack_verb = list() //Used in attackby() to say how something was attacked "[x] has been [z.attack_verb] by [y] with [z]"
+	var/list/attack_verb //Used in attackby() to say how something was attacked "[x] has been [z.attack_verb] by [y] with [z]"
 	var/list/species_exception = null	// list() of species types, if a species cannot put items in a certain slot, but species type is in list, it will be able to wear that item
 
 	var/suittoggled = 0
@@ -94,20 +94,13 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	// non-clothing items
 	var/datum/dog_fashion/dog_fashion = null
 
-
-/obj/item/proc/check_allowed_items(atom/target, not_inside, target_self)
-	if(((src in target) && !target_self) || (!istype(target.loc, /turf) && !istype(target, /turf) && not_inside))
-		return 0
-	else
-		return 1
-
-/obj/item/device
-	icon = 'icons/obj/device.dmi'
-
 /obj/item/New()
+	if(!materials)
+		materials = list()
 	..()
 	for(var/path in actions_types)
 		new path(src)
+	actions_types = null
 
 /obj/item/Destroy()
 	if(ismob(loc))
@@ -116,6 +109,15 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	for(var/X in actions)
 		qdel(X)
 	return ..()
+
+/obj/item/device
+	icon = 'icons/obj/device.dmi'
+
+/obj/item/proc/check_allowed_items(atom/target, not_inside, target_self)
+	if(((src in target) && !target_self) || (!isturf(target.loc) && !isturf(target) && not_inside))
+		return 0
+	else
+		return 1
 
 /obj/item/blob_act(obj/effect/blob/B)
 	qdel(src)

--- a/code/game/objects/items/devices/instruments.dm
+++ b/code/game/objects/items/devices/instruments.dm
@@ -10,6 +10,7 @@
 /obj/item/device/instrument/New()
 	song = new(instrumentId, src)
 	song.instrumentExt = instrumentExt
+	..()
 
 /obj/item/device/instrument/Destroy()
 	qdel(song)

--- a/code/game/objects/items/devices/pipe_painter.dm
+++ b/code/game/objects/items/devices/pipe_painter.dm
@@ -29,7 +29,6 @@
 	var/obj/machinery/atmospherics/pipe/P = A
 	P.color = modes[mode]
 	P.pipe_color = modes[mode]
-	P.stored.color = modes[mode]
 	user.visible_message("<span class='notice'>[user] paints \the [P] [mode].</span>","<span class='notice'>You paint \the [P] [mode].</span>")
 	P.update_node_icon() //updates the neighbors
 

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -22,6 +22,7 @@
 /obj/item/device/taperecorder/New()
 	mytape = new /obj/item/device/tape/random(src)
 	update_icon()
+	..()
 
 
 /obj/item/device/taperecorder/examine(mob/user)
@@ -278,3 +279,4 @@
 //Random colour tapes
 /obj/item/device/tape/random/New()
 	icon_state = "tape_[pick("white", "blue", "red", "yellow", "purple")]"
+	..()

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -43,6 +43,7 @@
 
 /obj/item/toy/balloon/New()
 	create_reagents(10)
+	..()
 
 /obj/item/toy/balloon/attack(mob/living/carbon/human/M, mob/user)
 	return
@@ -654,9 +655,6 @@
 	var/card_throw_range = 7
 	var/list/card_attack_verb = list("attacked")
 
-/obj/item/toy/cards/New()
-	..()
-
 /obj/item/toy/cards/proc/apply_card_vars(obj/item/toy/cards/newobj, obj/item/toy/cards/sourceobj) // Applies variables for supporting multiple types of card deck
 	if(!istype(sourceobj))
 		return
@@ -1187,7 +1185,8 @@
 	var/toysound = 'sound/machines/click.ogg'
 
 /obj/item/toy/figure/New()
-    desc = "A \"Space Life\" brand [src]."
+	desc = "A \"Space Life\" brand [src]."
+	..()
 
 /obj/item/toy/figure/attack_self(mob/user as mob)
 	if(cooldown <= world.time)

--- a/code/game/objects/items/weapons/RPD.dm
+++ b/code/game/objects/items/weapons/RPD.dm
@@ -542,7 +542,6 @@ var/global/list/RPD_recipes=list(
 			playsound(get_turf(src), 'sound/machines/click.ogg', 50, 1)
 			P.color = paint_colors[paint_color]
 			P.pipe_color = paint_colors[paint_color]
-			P.stored.color = paint_colors[paint_color]
 			user.visible_message("<span class='notice'>[user] paints \the [P] [paint_color].</span>","<span class='notice'>You paint \the [P] [paint_color].</span>")
 			//P.update_icon()
 			P.update_node_icon()

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -27,6 +27,7 @@
 	name = "lipstick"
 
 /obj/item/weapon/lipstick/random/New()
+	..()
 	colour = pick("red","purple","lime","black","green","blue","white")
 	name = "[colour] lipstick"
 

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -37,6 +37,7 @@
 /obj/item/weapon/dice/New()
 	result = rand(1, sides)
 	update_icon()
+	..()
 
 /obj/item/weapon/dice/d1
 	name = "d1"

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -188,7 +188,7 @@
 	for(var/turf/T in turflist)
 		if(T == previousturf)
 			continue	//so we don't burn the tile we be standin on
-		if(!T.CanAtmosPass(previousturf))
+		if(!T.atmos_adjacent_turfs || !T.atmos_adjacent_turfs[previousturf])
 			break
 		ignite_turf(T)
 		sleep(1)

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -21,12 +21,11 @@
 /obj/item/weapon/grenade/chem_grenade/New()
 	create_reagents(1000)
 	stage_change() // If no argument is set, it will change the stage to the current stage, useful for stock grenades that start READY.
-
+	..()
 
 /obj/item/weapon/grenade/chem_grenade/examine(mob/user)
 	display_timer = (stage == READY && !nadeassembly)	//show/hide the timer based on assembly state
 	..()
-
 
 /obj/item/weapon/grenade/chem_grenade/attack_self(mob/user)
 	if(stage == READY &&  !active)

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -231,12 +231,12 @@
 	var/nanofrost_cooldown = 0
 
 /obj/item/weapon/extinguisher/mini/nozzle/New(parent_tank)
+	..()
 	if(check_tank_exists(parent_tank, src))
 		tank = parent_tank
 		reagents = tank.reagents
 		max_water = tank.volume
 		loc = tank
-	return
 
 /obj/item/weapon/extinguisher/mini/nozzle/Move()
 	..()

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -59,8 +59,7 @@
 	health = 200
 	smooth = SMOOTH_TRUE
 	var/resintype = null
-
-
+	CanAtmosPass = ATMOS_PASS_DENSITY
 
 /obj/structure/alien/resin/New(location)
 	..()
@@ -71,9 +70,6 @@
 	var/turf/T = loc
 	..()
 	move_update_air(T)
-
-/obj/structure/alien/resin/CanAtmosPass()
-	return !density
 
 /obj/structure/alien/resin/wall
 	name = "resin wall"

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -18,6 +18,7 @@
 
 /obj/structure/door_assembly/New()
 	update_icon()
+	..()
 
 /obj/structure/door_assembly/door_assembly_0
 	name = "airlock assembly"

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -22,6 +22,7 @@
 	/turf/closed/wall/r_wall/rust)
 	smooth = SMOOTH_TRUE
 	can_be_unanchored = 0
+	CanAtmosPass = ATMOS_PASS_DENSITY
 
 /obj/structure/falsewall/New(loc)
 	..()
@@ -31,9 +32,6 @@
 	density = 0
 	air_update_turf(1)
 	return ..()
-
-/obj/structure/falsewall/CanAtmosPass(turf/T)
-	return !density
 
 /obj/structure/falsewall/attack_hand(mob/user)
 	if(opening)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -18,6 +18,7 @@
 
 /obj/structure/janitorialcart/New()
 	create_reagents(100)
+	..()
 
 
 /obj/structure/janitorialcart/proc/wet_mop(obj/item/weapon/mop, mob/user)
@@ -160,4 +161,3 @@
 		add_overlay("cart_replacer")
 	if(signs)
 		add_overlay("cart_sign[signs]")
-

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -18,6 +18,7 @@
 	var/oreAmount = 7
 	var/openSound = 'sound/effects/stonedoor_openclose.ogg'
 	var/closeSound = 'sound/effects/stonedoor_openclose.ogg'
+	CanAtmosPass = ATMOS_PASS_DENSITY
 
 /obj/structure/mineral_door/New(location)
 	..()
@@ -58,9 +59,6 @@
 /obj/structure/mineral_door/CanPass(atom/movable/mover, turf/target, height=0)
 	if(istype(mover, /obj/effect/beam))
 		return !opacity
-	return !density
-
-/obj/structure/mineral_door/CanAtmosPass()
 	return !density
 
 /obj/structure/mineral_door/proc/TryToSwitchState(atom/user)

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -10,6 +10,7 @@
 
 /obj/structure/mopbucket/New()
 	create_reagents(100)
+	..()
 
 /obj/structure/mopbucket/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/mop))

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -308,6 +308,7 @@
 
 
 /obj/structure/piano/New()
+	..()
 	song = new("piano", src)
 
 	if(prob(50))

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -56,13 +56,11 @@
 /obj/structure/plasticflaps/mining //A specific type for mining that doesn't allow airflow because of them damn crates
 	name = "airtight plastic flaps"
 	desc = "Heavy duty, airtight, plastic flaps."
+	CanAtmosPass = ATMOS_PASS_NO
 
 /obj/structure/plasticflaps/mining/New()
 	air_update_turf(1)
 	..()
-
-/obj/structure/plasticflaps/mining/CanAtmosPass()
-	return 0
 
 /obj/structure/plasticflaps/mining/Destroy()
 	air_update_turf(1)

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -23,6 +23,7 @@ FLOOR SAFES
 
 
 /obj/structure/safe/New()
+	..()
 	tumbler_1_pos = rand(0, 71)
 	tumbler_1_open = rand(0, 71)
 

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -11,6 +11,8 @@
 	var/health = 100
 	var/oreAmount = 7
 	var/mineralType = "metal"
+	CanAtmosPass = ATMOS_PASS_DENSITY
+
 
 /obj/structure/statue/Destroy()
 	density = 0
@@ -87,9 +89,6 @@
 	add_fingerprint(user)
 	user.visible_message("[user] rubs some dust off from the [name]'s surface.", \
 						 "<span class='notice'>You rub some dust off from the [name]'s surface.</span>")
-
-/obj/structure/statue/CanAtmosPass()
-	return !density
 
 /obj/structure/statue/bullet_act(obj/item/projectile/P)
 	. = ..()

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -22,6 +22,7 @@
 	for(var/i in 1 to plasmatanks)
 		new /obj/item/weapon/tank/internals/plasma(src)
 	update_icon()
+	..()
 
 /obj/structure/tank_dispenser/update_icon()
 	cut_overlays()

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -14,6 +14,7 @@
 /obj/structure/toilet/New()
 	open = round(rand(0, 1))
 	update_icon()
+	..()
 
 
 /obj/structure/toilet/attack_hand(mob/living/user)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -26,6 +26,7 @@
 	var/facing = "l"	//Does the windoor open to the left or right?
 	var/secure = 0		//Whether or not this creates a secure windoor
 	var/state = "01"	//How far the door assembly has progressed
+	CanAtmosPass = ATMOS_PASS_PROC
 
 /obj/structure/windoor_assembly/examine(mob/user)
 	..()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -20,6 +20,7 @@
 	var/image/crack_overlay
 	var/list/debris = list()
 	can_be_unanchored = 1
+	CanAtmosPass = ATMOS_PASS_PROC
 
 /obj/structure/window/examine(mob/user)
 	..()

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -37,7 +37,7 @@
 
 		//only check this turf, if it didn't check us when it was initalized
 		if(enemy_tile.current_cycle < times_fired)
-			if(CanAtmosPass(enemy_tile))
+			if(CANATMOSPASS(src, enemy_tile))
 				atmos_adjacent_turfs |= enemy_tile
 				enemy_tile.atmos_adjacent_turfs |= src
 			else
@@ -175,4 +175,3 @@
 		wet_time = 0
 	if(wet)
 		addtimer(src, "HandleWet", 15)
-

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -32,10 +32,14 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 	var/burnt = 0
 	var/floor_tile = null //tile that this floor drops
 	var/obj/item/stack/tile/builtin_tile = null //needed for performance reasons when the singularity rips off floor tiles
-	var/list/broken_states = list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
-	var/list/burnt_states = list()
+	var/list/broken_states
+	var/list/burnt_states
 
 /turf/open/floor/New()
+	if(!broken_states)
+		broken_states = list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
+	if(!burnt_states)
+		burnt_states = list()
 	..()
 	if(icon_state in icons_to_ignore_at_floor_init) //so damaged/burned tiles or plating icons aren't saved as the default
 		icon_regular_floor = "floor"

--- a/code/game/turfs/simulated/floor/mineral_floor.dm
+++ b/code/game/turfs/simulated/floor/mineral_floor.dm
@@ -11,13 +11,15 @@
 /turf/open/floor/mineral
 	name = "mineral floor"
 	icon_state = ""
-	var/list/icons = list()
+	var/list/icons
 
 
 
 /turf/open/floor/mineral/New()
-	..()
 	broken_states = list("[initial(icon_state)]_dam")
+	..()
+	if(!icons)
+		icons = list()
 
 /turf/open/floor/mineral/update_icon()
 	if(!..())

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -13,10 +13,12 @@
 	name = "plating"
 	icon_state = "plating"
 	intact = 0
-	broken_states = list("platingdmg1", "platingdmg2", "platingdmg3")
-	burnt_states = list("panelscorched")
 
 /turf/open/floor/plating/New()
+	if(!broken_states)
+		broken_states = list("platingdmg1", "platingdmg2", "platingdmg3")
+	if(!burnt_states)
+		burnt_states = list("panelscorched")
 	..()
 	icon_plating = icon_state
 

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -13,7 +13,6 @@
 	var/hardness = 40 //lower numbers are harder. Used to determine the probability of a hulk smashing through.
 	var/slicing_duration = 100  //default time taken to slice the wall
 	var/sheet_type = /obj/item/stack/sheet/metal
-	var/obj/item/stack/sheet/builtin_sheet = null
 
 	canSmoothWith = list(
 	/turf/closed/wall,
@@ -23,10 +22,6 @@
 	/turf/closed/wall/rust,
 	/turf/closed/wall/r_wall/rust)
 	smooth = SMOOTH_TRUE
-
-/turf/closed/wall/New()
-	..()
-	builtin_sheet = new sheet_type
 
 /turf/closed/wall/attack_tk()
 	return
@@ -49,13 +44,13 @@
 	ChangeTurf(/turf/open/floor/plating)
 
 /turf/closed/wall/proc/break_wall()
+	var/obj/item/stack/sheet/builtin_sheet = new sheet_type(src)
 	builtin_sheet.amount = 2
-	builtin_sheet.loc = src
 	return (new /obj/structure/girder(src))
 
 /turf/closed/wall/proc/devastate_wall()
+	var/obj/item/stack/sheet/builtin_sheet = new sheet_type(src)
 	builtin_sheet.amount = 2
-	builtin_sheet.loc = src
 	new /obj/item/stack/sheet/metal(src)
 
 /turf/closed/wall/ex_act(severity, target)

--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/turf/walls/cult_wall.dmi'
 	icon_state = "cult"
 	walltype = "cult"
-	builtin_sheet = null
 	canSmoothWith = null
 
 /turf/closed/wall/mineral/cult/New()

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -14,11 +14,11 @@
 	explosion_block = 2
 
 /turf/closed/wall/r_wall/break_wall()
-	builtin_sheet.loc = src
+	new sheet_type(src)
 	return (new /obj/structure/girder/reinforced(src))
 
 /turf/closed/wall/r_wall/devastate_wall()
-	builtin_sheet.loc = src
+	new sheet_type(src)
 	new /obj/item/stack/sheet/metal(src, 2)
 
 /turf/closed/wall/r_wall/attack_animal(mob/living/simple_animal/M)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -17,7 +17,7 @@
 
 
 /turf/open/space/New()
-	update_icon()
+	icon_state = SPACE_ICON_STATE
 	air = space_gas
 
 /turf/open/space/Destroy(force)
@@ -174,9 +174,6 @@
 	if(locate(/obj/structure/lattice/catwalk, src))
 		return 1
 	return 0
-
-/turf/open/space/proc/update_icon()
-	icon_state = SPACE_ICON_STATE
 
 /turf/open/space/proc/set_transition_north(dest_z)
 	destination_x = x

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -73,10 +73,10 @@
 		return
 
 /turf/open/space/transit/New()
-	update_icon()
 	..()
+	update_icon()
 
-/turf/open/space/transit/update_icon()
+/turf/open/space/transit/proc/update_icon()
 	var/p = 9
 	var/angle = 0
 	var/state = 1

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -28,7 +28,7 @@
 
 	levelupdate()
 	if(smooth)
-		smooth_icon(src)
+		queue_smooth(src)
 	visibilityChanged()
 
 	for(var/atom/movable/AM in src)
@@ -56,6 +56,25 @@
 		return 1
 
 	return 0
+
+/turf/CanPass(atom/movable/mover, turf/target, height=1.5)
+	if(!target) return 0
+
+	if(istype(mover)) // turf/Enter(...) will perform more advanced checks
+		return !density
+
+	else // Now, doing more detailed checks for air movement and air group formation
+		if(target.blocks_air||blocks_air)
+			return 0
+
+		for(var/obj/obstacle in src)
+			if(!obstacle.CanPass(mover, target, height))
+				return 0
+		for(var/obj/obstacle in target)
+			if(!obstacle.CanPass(mover, src, height))
+				return 0
+
+		return 1
 
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
 	if (!mover)

--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -1,8 +1,16 @@
-/turf/proc/CanAtmosPass(turf/T)
+/atom/var/CanAtmosPass = ATMOS_PASS_YES
+/atom/proc/CanAtmosPass(turf/T)
+	switch(CanAtmosPass)
+		if(ATMOS_PASS_PROC)
+			return ATMOS_PASS_YES
+		if(ATMOS_PASS_DENSITY)
+			return !density
+		else
+			return CanAtmosPass
 
-/turf/closed/CanAtmosPass(turf/T)
-	return 0
+/turf/closed/CanAtmosPass = ATMOS_PASS_NO
 
+/turf/open/CanAtmosPass = ATMOS_PASS_PROC
 /turf/open/CanAtmosPass(turf/T)
 	var/R
 	if(blocks_air || T.blocks_air)
@@ -10,7 +18,7 @@
 
 	for(var/obj/O in contents+T.contents)
 		var/turf/other = (O.loc == src ? T : src)
-		if(!O.CanAtmosPass(other))
+		if(!CANATMOSPASS(O, other))
 			R = 1
 			if(O.BlockSuperconductivity()) 	//the direction and open/closed are already checked on CanAtmosPass() so there are no arguments
 				var/D = get_dir(src, T)
@@ -24,53 +32,38 @@
 
 	return !R
 
-/atom/movable/proc/CanAtmosPass()
-	return 1
-
-/atom/proc/CanPass(atom/movable/mover, turf/target, height=1.5)
-	return (!density || !height)
-
-/turf/CanPass(atom/movable/mover, turf/target, height=1.5)
-	if(!target) return 0
-
-	if(istype(mover)) // turf/Enter(...) will perform more advanced checks
-		return !density
-
-	else // Now, doing more detailed checks for air movement and air group formation
-		if(target.blocks_air||blocks_air)
-			return 0
-
-		for(var/obj/obstacle in src)
-			if(!obstacle.CanPass(mover, target, height))
-				return 0
-		for(var/obj/obstacle in target)
-			if(!obstacle.CanPass(mover, src, height))
-				return 0
-
-		return 1
-
 /atom/movable/proc/BlockSuperconductivity() // objects that block air and don't let superconductivity act. Only firelocks atm.
 	return 0
 
 /turf/proc/CalculateAdjacentTurfs()
+	var/list/atmos_adjacent_turfs = src.atmos_adjacent_turfs
 	for(var/direction in cardinal)
-		var/turf/open/T = get_step(src, direction)
-		if(!istype(T))
+		var/turf/T = get_step(src, direction)
+		if(!T)
 			continue
-		if(CanAtmosPass(T))
-			atmos_adjacent_turfs |= T
-			T.atmos_adjacent_turfs |= src
+		if(CANATMOSPASS(T, src))
+			atmos_adjacent_turfs[T] = TRUE
+			T.atmos_adjacent_turfs[src] = TRUE
 		else
-			atmos_adjacent_turfs -= T
-			T.atmos_adjacent_turfs -= src
+			if(atmos_adjacent_turfs)
+				atmos_adjacent_turfs -= T
+			if(T.atmos_adjacent_turfs)
+				T.atmos_adjacent_turfs -= src
+	src.atmos_adjacent_turfs = atmos_adjacent_turfs
 
 //returns a list of adjacent turfs that can share air with this one.
 //alldir includes adjacent diagonal tiles that can share
 //	air with both of the related adjacent cardinal tiles
 /turf/proc/GetAtmosAdjacentTurfs(alldir = 0)
-	var/adjacent_turfs = atmos_adjacent_turfs.Copy()
+	var/adjacent_turfs
+	if(atmos_adjacent_turfs)
+		adjacent_turfs = atmos_adjacent_turfs.Copy()
+	else
+		adjacent_turfs = list()
+
 	if (!alldir)
 		return adjacent_turfs
+
 	var/turf/curloc = src
 
 	for (var/direction in diagonals)
@@ -79,10 +72,10 @@
 
 		for (var/checkDirection in cardinal)
 			var/turf/checkTurf = get_step(S, checkDirection)
-			if(!(checkTurf in S.atmos_adjacent_turfs))
+			if(!S.atmos_adjacent_turfs || !S.atmos_adjacent_turfs[checkTurf])
 				continue
 
-			if (checkTurf in adjacent_turfs)
+			if (adjacent_turfs[checkTurf])
 				matchingDirections++
 
 			if (matchingDirections >= 2)

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -20,32 +20,27 @@ Pipelines + Other Objects -> Pipe network
 	var/can_unwrench = 0
 	var/initialize_directions = 0
 	var/pipe_color
-	var/obj/item/pipe/stored
+
 	var/global/list/iconsetids = list()
 	var/global/list/pipeimages = list()
 
 	var/image/pipe_vision_img = null
 
 	var/device_type = 0
-	var/list/obj/machinery/atmospherics/nodes = list()
+	var/list/obj/machinery/atmospherics/nodes
 
 /obj/machinery/atmospherics/New(loc, process = TRUE)
-	nodes.len = device_type
+	nodes = new(device_type)
 	..()
 	if(process)
 		SSair.atmos_machinery += src
 	SetInitDirections()
-	if(can_unwrench)
-		stored = new(src, make_from=src)
 
 /obj/machinery/atmospherics/Destroy()
 	for(DEVICE_TYPE_LOOP)
 		nullifyNode(I)
 
 	SSair.atmos_machinery -= src
-	if(stored)
-		qdel(stored)
-		stored = null
 
 	dropContents()
 	if(pipe_vision_img)
@@ -181,11 +176,9 @@ Pipelines + Other Objects -> Pipe network
 
 /obj/machinery/atmospherics/Deconstruct()
 	if(can_unwrench)
-		stored.loc = src.loc
+		var/obj/item/pipe/stored = new(loc, make_from=src)
 		transfer_fingerprints_to(stored)
-		stored = null
-
-	qdel(src)
+	..()
 
 /obj/machinery/atmospherics/proc/getpipeimage(iconset, iconstate, direction, col=rgb(255,255,255))
 
@@ -212,9 +205,6 @@ Pipelines + Other Objects -> Pipe network
 	if(can_unwrench)
 		color = obj_color
 		pipe_color = obj_color
-		stored.setDir(src.dir		  )//need to define them here, because the obj directions...
-		stored.pipe_type = pipe_type  //... were not set at the time the stored pipe was created
-		stored.color = obj_color
 	var/turf/T = loc
 	level = T.intact ? 2 : 1
 	atmosinit()

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -7,12 +7,12 @@ On top of that, now people can add component-speciic procs/vars if they want!
 	var/welded = 0 //Used on pumps and scrubbers
 	var/showpipe = 0
 
-	var/list/datum/pipeline/parents = list()
-	var/list/datum/gas_mixture/airs = list()
+	var/list/datum/pipeline/parents
+	var/list/datum/gas_mixture/airs
 
 /obj/machinery/atmospherics/components/New()
-	parents.len = device_type
-	airs.len = device_type
+	parents = new(device_type)
+	airs = new(device_type)
 	..()
 
 	for(DEVICE_TYPE_LOOP)
@@ -169,4 +169,3 @@ UI Stuff
 		return ..()
 	user << "<span class='danger'>Access denied.</span>"
 	return UI_CLOSE
-

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -1,13 +1,16 @@
 /datum/pipeline
 	var/datum/gas_mixture/air
-	var/list/datum/gas_mixture/other_airs = list()
+	var/list/datum/gas_mixture/other_airs
 
-	var/list/obj/machinery/atmospherics/pipe/members = list()
-	var/list/obj/machinery/atmospherics/components/other_atmosmch = list()
+	var/list/obj/machinery/atmospherics/pipe/members
+	var/list/obj/machinery/atmospherics/components/other_atmosmch
 
 	var/update = 1
 
 /datum/pipeline/New()
+	other_airs = list()
+	members = list()
+	other_atmosmch = list()
 	SSair.networks += src
 
 /datum/pipeline/Destroy()
@@ -233,4 +236,3 @@ var/pipenetwarnings = 10
 			var/list/G_gases = G.gases
 			for(var/id in G_gases)
 				G_gases[id][MOLES] *= G.volume/total_gas_mixture.volume
-

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -26,6 +26,7 @@
 	var/reset_path = /obj/effect/ctf/flag_reset
 
 /obj/item/weapon/twohanded/required/ctf/New()
+	..()
 	if(!reset)
 		reset = new reset_path(get_turf(src))
 

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -26,6 +26,7 @@
 	create_reagents(100)
 	var/obj/item/weapon/circuitboard/machine/B = new /obj/item/weapon/circuitboard/machine/microwave(null)
 	B.apply_default_parts(src)
+	..()
 
 /obj/item/weapon/circuitboard/machine/microwave
 	name = "circuit board (Microwave)"

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -33,6 +33,7 @@
 /obj/item/weapon/circuitboard/machine/smartfridge/New(loc, new_type)
 	if(new_type)
 		build_path = new_type
+	..()
 
 /obj/item/weapon/circuitboard/machine/smartfridge/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/screwdriver))

--- a/code/modules/food_and_drinks/pizzabox.dm
+++ b/code/modules/food_and_drinks/pizzabox.dm
@@ -28,6 +28,7 @@
 
 /obj/item/pizzabox/New()
 	update_icon()
+	..()
 
 /obj/item/pizzabox/Destroy()
 	unprocess()

--- a/code/modules/games/cas.dm
+++ b/code/modules/games/cas.dm
@@ -29,6 +29,7 @@ var/global/list/cards_against_space
 	card_text_file = "strings/cas_black.txt"
 
 /obj/item/toy/cards/deck/cas/New()
+	..()
 	if(!cards_against_space)  //saves loading from the files every single time a new deck is created, but still lets each deck have a random assortment, it's purely an optimisation
 		cards_against_space = list("cas_white" = file2list("strings/cas_white.txt"),"cas_black" = file2list("strings/cas_black.txt"))
 	allcards = cards_against_space[card_face]

--- a/code/modules/holodeck/items.dm
+++ b/code/modules/holodeck/items.dm
@@ -24,9 +24,11 @@
 	var/active = 0
 
 /obj/item/weapon/holo/esword/green/New()
+	..()
 	item_color = "green"
 
 /obj/item/weapon/holo/esword/red/New()
+	..()
 	item_color = "red"
 
 /obj/item/weapon/holo/esword/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
@@ -38,6 +40,7 @@
 	..()
 
 /obj/item/weapon/holo/esword/New()
+	..()
 	item_color = pick("red","blue","green","purple")
 
 /obj/item/weapon/holo/esword/attack_self(mob/living/user as mob)

--- a/code/modules/lighting/lighting_system.dm
+++ b/code/modules/lighting/lighting_system.dm
@@ -162,23 +162,6 @@
 /atom
 	var/datum/light_source/light
 
-
-//Turfs with opacity when they are constructed will trigger nearby lights to update
-//Turfs and atoms with luminosity when they are constructed will create a light_source automatically
-/turf/New()
-	..()
-	if(luminosity)
-		light = new(src)
-
-//Movable atoms with opacity when they are constructed will trigger nearby lights to update
-//Movable atoms with luminosity when they are constructed will create a light_source automatically
-/atom/movable/New()
-	..()
-	if(opacity && isturf(loc))
-		loc.UpdateAffectingLights()
-	if(luminosity)
-		light = new(src)
-
 //Objects with opacity will trigger nearby lights to update at next SSlighting fire
 /atom/movable/Destroy()
 	qdel(light)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -436,6 +436,7 @@
 	var/arbitraryatmosblockingvar = TRUE
 	var/buildstacktype = /obj/item/stack/sheet/metal
 	var/buildstackamount = 5
+	CanAtmosPass = ATMOS_PASS_NO
 
 /obj/structure/fans/deconstruct()
 	if(buildstacktype)
@@ -464,12 +465,9 @@
 	air_update_turf(1)
 
 /obj/structure/fans/Destroy()
-	arbitraryatmosblockingvar = FALSE
-	air_update_turf(1)
-	return ..()
-
-/obj/structure/fans/CanAtmosPass(turf/T)
-	return !arbitraryatmosblockingvar
+	var/turf/T = loc
+	. = ..()
+	T.air_update_turf(1)
 
 //Signs
 /obj/structure/sign/mining

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -6,7 +6,7 @@
 	icon_state = "rock"
 	var/smooth_icon = 'icons/turf/smoothrocks.dmi'
 	smooth = SMOOTH_MORE|SMOOTH_BORDER
-	canSmoothWith = list (/turf/closed/mineral, /turf/closed/wall)
+	canSmoothWith
 	baseturf = /turf/open/floor/plating/asteroid/airless
 	no_shuttle_move = 1
 	initial_gas_mix = "TEMP=2.7"
@@ -26,6 +26,8 @@
 	var/defer_change = 0
 
 /turf/closed/mineral/New()
+	if(!canSmoothWith)
+		canSmoothWith = list(/turf/closed/mineral, /turf/closed/wall)
 	pixel_y = -4
 	pixel_x = -4
 	icon = smooth_icon
@@ -60,14 +62,19 @@
 	new src.type(T)
 
 /turf/closed/mineral/random
-	var/mineralSpawnChanceList = list(
-		/turf/closed/mineral/uranium = 5, /turf/closed/mineral/diamond = 1, /turf/closed/mineral/gold = 10,
-		/turf/closed/mineral/silver = 12, /turf/closed/mineral/plasma = 20, /turf/closed/mineral/iron = 40,
-		/turf/closed/mineral/gibtonite = 4, /turf/open/floor/plating/asteroid/airless/cave = 2, /turf/closed/mineral/bscrystal = 1)
+	var/mineralSpawnChanceList
 		//Currently, Adamantine won't spawn as it has no uses. -Durandan
 	var/mineralChance = 13
+	var/display_icon_state = "rock"
 
 /turf/closed/mineral/random/New()
+	if(!mineralSpawnChanceList)
+		mineralSpawnChanceList = list(
+			/turf/closed/mineral/uranium = 5, /turf/closed/mineral/diamond = 1, /turf/closed/mineral/gold = 10,
+			/turf/closed/mineral/silver = 12, /turf/closed/mineral/plasma = 20, /turf/closed/mineral/iron = 40,
+			/turf/closed/mineral/gibtonite = 4, /turf/open/floor/plating/asteroid/airless/cave = 2, /turf/closed/mineral/bscrystal = 1)
+	if(display_icon_state)
+		icon_state = display_icon_state
 	..()
 
 	if (prob(mineralChance))
@@ -94,10 +101,6 @@
 		/turf/closed/mineral/uranium = 35, /turf/closed/mineral/diamond = 30, /turf/closed/mineral/gold = 45,
 		/turf/closed/mineral/silver = 50, /turf/closed/mineral/plasma = 50, /turf/closed/mineral/bscrystal = 20)
 
-/turf/closed/mineral/random/high_chance/New()
-	icon_state = "rock"
-	..()
-
 /turf/closed/mineral/random/low_chance
 	icon_state = "rock_lowchance"
 	mineralChance = 6
@@ -105,10 +108,6 @@
 		/turf/closed/mineral/uranium = 2, /turf/closed/mineral/diamond = 1, /turf/closed/mineral/gold = 4,
 		/turf/closed/mineral/silver = 6, /turf/closed/mineral/plasma = 15, /turf/closed/mineral/iron = 40,
 		/turf/closed/mineral/gibtonite = 2, /turf/closed/mineral/bscrystal = 1)
-
-/turf/closed/mineral/random/low_chance/New()
-	icon_state = "rock"
-	..()
 
 /turf/closed/mineral/iron
 	mineralType = /obj/item/weapon/ore/iron

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -298,6 +298,7 @@ var/global/chicken_count = 0
 	reagents = new(50)
 	reagents.my_atom = src
 	reagents.add_reagent("milk", 20)
+	..()
 
 /obj/item/udder/proc/generateMilk()
 	if(prob(5))

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -14,6 +14,7 @@
 
 /obj/item/weapon/clipboard/New()
 	update_icon()
+	..()
 
 
 /obj/item/weapon/clipboard/update_icon()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -47,7 +47,7 @@
 	icon_state = "apc0"
 	anchored = 1
 	use_power = 0
-	req_access = list(access_engine_equip)
+	req_access = null
 	var/area/area
 	var/areastring = null
 	var/opened = 0 //0=closed, 1=opened, 2=cover removed
@@ -79,7 +79,6 @@
 	var/update_state = -1
 	var/update_overlay = -1
 	var/global/status_overlays = 0
-	var/updating_icon = 0
 	var/global/list/status_overlays_lock
 	var/global/list/status_overlays_charging
 	var/global/list/status_overlays_equipment
@@ -103,6 +102,8 @@
 		terminal.connect_to_network()
 
 /obj/machinery/power/apc/New(turf/loc, var/ndir, var/building=0)
+	if(!req_access)
+		req_access = list(access_engine_equip)
 	..()
 	apcs_list += src
 
@@ -119,17 +120,14 @@
 
 	pixel_x = (src.tdir & 3)? 0 : (src.tdir == 4 ? 24 : -24)
 	pixel_y = (src.tdir & 3)? (src.tdir ==1 ? 24 : -24) : 0
-	if (building==0)
-		init()
-	else
+	if(building)
 		area = src.loc.loc:master
 		opened = 1
 		operating = 0
 		name = "[area.name] APC"
 		stat |= MAINT
 		src.update_icon()
-		spawn(5)
-			src.update()
+		addtimer(src, "update", 5)
 
 /obj/machinery/power/apc/Destroy()
 	apcs_list -= src
@@ -158,7 +156,7 @@
 	terminal.master = src
 	terminal.set_power_group(is_priority ? POWER_GROUP_APC_PRIORITY : POWER_GROUP_APC)
 
-/obj/machinery/power/apc/proc/init()
+/obj/machinery/power/apc/initialize()
 	has_electronics = 2 //installed and secured
 
 	var/area/A = src.loc.loc
@@ -172,8 +170,7 @@
 
 	make_terminal()
 
-	spawn(5)
-		src.update()
+	addtimer(src, "update", 5)
 
 /obj/machinery/power/apc/examine(mob/user)
 	..()
@@ -201,25 +198,20 @@
 /obj/machinery/power/apc/update_icon()
 	if (!status_overlays)
 		status_overlays = 1
-		status_overlays_lock = new
-		status_overlays_equipment = new
-		status_overlays_lighting = new
-		status_overlays_environ = new
-		status_overlays_charging = new
+		status_overlays_lock = new(2)
+		status_overlays_charging = new(3)
+		status_overlays_equipment = new(4)
+		status_overlays_lighting = new(4)
+		status_overlays_environ = new(4)
 
-		status_overlays_lock.len = 2
-		status_overlays_equipment.len = 4
-		status_overlays_lighting.len = 4
-		status_overlays_environ.len = 4
-		status_overlays_charging.len = 3
 
 		status_overlays_lock[1] = image(icon, "apcox-0")    // 0=blue 1=red
 		status_overlays_lock[2] = image(icon, "apcox-1")
-		
+
 		status_overlays_charging[1] = image(icon, "apco3-0")
 		status_overlays_charging[2] = image(icon, "apco3-1")
 		status_overlays_charging[3] = image(icon, "apco3-2")
-		
+
 		status_overlays_equipment[1] = image(icon, "apco0-0")
 		status_overlays_equipment[2] = image(icon, "apco0-1")
 		status_overlays_equipment[3] = image(icon, "apco0-2")
@@ -271,12 +263,14 @@
 		if(overlays.len)
 			overlays.len = 0
 		if(!(stat & (BROKEN|MAINT)) && update_state & UPSTATE_ALLGOOD)
-			add_overlay(status_overlays_lock[locked+1])
-			add_overlay(status_overlays_charging[last_power_received ? 3 : 1])
+			var/list/O = list(
+				status_overlays_lock[locked+1],
+				status_overlays_charging[last_power_received ? 3 : 1])
 			if(operating)
-				add_overlay(status_overlays_equipment[equipment+1])
-				add_overlay(status_overlays_lighting[lighting+1])
-				add_overlay(status_overlays_environ[environ+1])
+				O += status_overlays_equipment[equipment+1]
+				O += status_overlays_lighting[lighting+1]
+				O += status_overlays_environ[environ+1]
+			add_overlay(O)
 
 
 /obj/machinery/power/apc/proc/check_updates()
@@ -308,13 +302,13 @@
 	if(update_state & UPSTATE_ALLGOOD)
 		if(locked)
 			update_overlay |= APC_UPOVERLAY_LOCKED
-		
+
 		if(!last_power_received)
 			update_overlay |= APC_UPOVERLAY_CHARGEING0
 		else
 			update_overlay |= APC_UPOVERLAY_CHARGEING2
 
-		
+
 		if (!equipment)
 			update_overlay |= APC_UPOVERLAY_EQUIPMENT0
 		else if(equipment == 1)
@@ -348,13 +342,7 @@
 
 // Used in process so it doesn't update the icon too much
 /obj/machinery/power/apc/proc/queue_icon_update()
-
-	if(!updating_icon)
-		updating_icon = 1
-		// Start the update
-		spawn(APC_UPDATE_ICON_COOLDOWN)
-			update_icon()
-			updating_icon = 0
+	addtimer(src, "update_icon", APC_UPDATE_ICON_COOLDOWN)
 
 //attack with an item - open/close cover, insert cell, or (un)lock interface
 

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -29,6 +29,7 @@
 	icon_state = "compressor"
 	anchored = 1
 	density = 1
+	CanAtmosPass = ATMOS_PASS_DENSITY
 	var/obj/machinery/power/turbine/turbine
 	var/datum/gas_mixture/gas_contained
 	var/turf/inturf
@@ -47,6 +48,7 @@
 	icon_state = "turbine"
 	anchored = 1
 	density = 1
+	CanAtmosPass = ATMOS_PASS_DENSITY
 	var/opened = 0
 	var/obj/machinery/power/compressor/compressor
 	var/turf/outturf
@@ -130,9 +132,6 @@
 		return
 
 	default_deconstruction_crowbar(I)
-
-/obj/machinery/power/compressor/CanAtmosPass(turf/T)
-	return !density
 
 /obj/machinery/power/compressor/process()
 	if(!turbine)
@@ -218,9 +217,6 @@
 	compressor = locate() in get_step(src, get_dir(outturf, src))
 	if(compressor)
 		compressor.locate_machinery()
-
-/obj/machinery/power/turbine/CanAtmosPass(turf/T)
-	return !density
 
 /obj/machinery/power/turbine/process()
 

--- a/code/modules/reagents/chem_splash.dm
+++ b/code/modules/reagents/chem_splash.dm
@@ -46,12 +46,12 @@ proc/chem_splash(turf/epicenter, affected_range = 3, list/datum/reagents/reactan
 					turflist.Remove(T)
 					turflist.Add(T) // we move the purely diagonal turfs to the end of the list.
 			for(var/turf/T in turflist)
-				if(T in accessible) continue
-				for(var/turf/NT in orange(1, T))
+				if(accessible[T]) continue
+				for(var/thing in T.GetAtmosAdjacentTurfs(alldir = TRUE))
+					var/turf/NT = thing
 					if(!(NT in accessible)) continue
 					if(!(get_dir(T,NT) in cardinal)) continue
-					if(!NT.CanAtmosPass(T)) continue
-					accessible |= T
+					accessible[T] = 1
 					break
 		var/list/reactable = accessible
 		for(var/turf/T in accessible)
@@ -63,10 +63,9 @@ proc/chem_splash(turf/epicenter, affected_range = 3, list/datum/reagents/reactan
 		if(!reactable.len) //Nothing to react with. Probably means we're in nullspace.
 			return
 		var/fraction = 0.5/accessible.len // In a 100u mix. A small grenade spreads ~1.5u units per affected tile. A large grenade spreads ~0.75u, and a bomb spreads ~0.4u
-		for(var/atom/A in reactable)
+		for(var/thing in reactable)
+			var/atom/A = thing
 			splash_holder.reaction(A, TOUCH, fraction)
 
 	qdel(splash_holder)
 	return 1
-
-

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -20,6 +20,7 @@
 	add_overlay("waitlight")
 	var/obj/item/weapon/circuitboard/machine/B = new /obj/item/weapon/circuitboard/machine/chem_master(null)
 	B.apply_default_parts(src)
+	..()
 
 /obj/item/weapon/circuitboard/machine/chem_master
 	name = "circuit board (ChemMaster 3000)"

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -52,6 +52,7 @@ other types of metals and chemistry for reagents).
 	var/datum/design/blueprint
 
 /obj/item/weapon/disk/design_disk/New()
+	..()
 	src.pixel_x = rand(-5, 5)
 	src.pixel_y = rand(-5, 5)
 

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -280,5 +280,6 @@ research holder datum.
 	var/datum/tech/stored
 
 /obj/item/weapon/disk/tech_disk/New()
+	..()
 	src.pixel_x = rand(-5, 5)
 	src.pixel_y = rand(-5, 5)


### PR DESCRIPTION
:cl: ike709
tweak: World init should hopefully be faster.
/:cl:

For a full list of changes, see the original PR: https://github.com/tgstation/tgstation/pull/21992
Credit to the glorious MSO.

Other PRs included:
https://github.com/tgstation/tgstation/pull/22073
https://github.com/tgstation/tgstation/pull/23689

This does not include any changes involving armor, because we don't have armor. Should anyone ever happen to port the obj damaging refactor, this needs to be addressed.

This also doesn't include anything involving lazyinit/unsetempty, because we saw how well that went last time.

Files I think this is most likely to break:
- atmosmachinery.dm
- apc.dm
- atoms.dm
(Hopefully it doesn't actually break any, though)

As a result of porting this, I also learned that /tg/ had an addtimer refactor that made addtimer way faster. I'll be porting that soon™