### PR TITLE
Gibber no longer produces an absurd amount of meat.

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -61,6 +61,7 @@
 
 /obj/machinery/gibber/RefreshParts()
 	var/gib_time = 40
+	meat_produced = 0
 	for(var/obj/item/weapon/stock_parts/matter_bin/B in component_parts)
 		meat_produced += 3 * B.rating
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)


### PR DESCRIPTION
This fixes #575 

I crashed my test server whilst testing this. I managed to get the gibber to produce over 600 pieces of meat. NOT GOOD FRIENDS.

@monster860 

:cl: Funce
fix: The kitchen's Gibber no longer produces an absurd amount of meat. (Enough to break the server)
/:cl:
