### PR TITLE
Crafted stunprods can now actually be used

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -171,7 +171,7 @@
 	force = 3
 	throwforce = 5
 	stunforce = 5
-	hitcost = 2500
+	hitcost = 500
 	slot_flags = null
 	var/obj/item/device/assembly/igniter/sparkler = 0
 


### PR DESCRIPTION
This fixes #578 

Another which I thought was infinitesimally hard. But turned out not so much.

Also Balancing is needed for the number.

:cl: Funce
fix: Crafted stunprods can now actually be used. Don't know why you'd use them though...
/:cl:
