### PR TITLE
Drying rack is not invisible when screwdrivered

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -79,8 +79,6 @@
 
 /obj/machinery/smartfridge/attackby(obj/item/O, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "smartfridge_open", "smartfridge", O))
-		if(istype(src, /obj/machinery/smartfridge/drying_rack)) //See if it's a drying rack because the screwdrivers screw it up hehe geddit
-			update_icon() //and also there's no drying_rack_open soooo we gotta revert back peeps
 		return
 
 	if(exchange_parts(user, O))
@@ -248,6 +246,10 @@
 	icon_on = "drying_rack_on"
 	icon_off = "drying_rack"
 	var/drying = 0
+
+/obj/machinery/smartfridge/drying_rack/attackby(obj/item/O, mob/user, params)
+	..()
+	update_icon() //Screw drivers mess the icon up.
 
 /obj/machinery/smartfridge/drying_rack/interact(mob/user)
 	var/dat = ..()

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -79,6 +79,8 @@
 
 /obj/machinery/smartfridge/attackby(obj/item/O, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "smartfridge_open", "smartfridge", O))
+		if(istype(src, /obj/machinery/smartfridge/drying_rack)) //See if it's a drying rack because the screwdrivers screw it up hehe geddit
+			update_icon() //and also there's no drying_rack_open soooo we gotta revert back peeps
 		return
 
 	if(exchange_parts(user, O))


### PR DESCRIPTION
This fixes #495 
And it was exclusive to screwdrivering.

Most enjoyable fixing this one.

:cl: Funce
fix: Drying racks are no longer invisible due to being screwed by the screwdrivers
/:cl:
