### PR TITLE
Updates Satchel to Automatically Collect Ore

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -298,30 +298,25 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 		var/obj/item/weapon/storage/S = W
 		if(S.use_to_pickup)
 			if(S.collection_mode) //Mode is set to collect multiple items on a tile and we clicked on a valid one.
-				if(isturf(src.loc))
+				if(isturf(loc))
 					var/list/rejections = list()
-					var/success = 0
-					var/failure = 0
 
-					for(var/obj/item/I in src.loc)
-						if(S.collection_mode == 2 && !istype(I,src.type)) // We're only picking up items of the target type
-							failure = 1
-							continue
-						if(I.type in rejections) // To limit bag spamming: any given type only complains once
-							continue
-						if(!S.can_be_inserted(I))	// Note can_be_inserted still makes noise when the answer is no
-							rejections += I.type	// therefore full bags are still a little spammy
-							failure = 1
-							continue
+					var/list/things = loc.contents.Copy()
+					if (S.collection_mode == 2)
+						things = typecache_filter_list(things, typecacheof(type))
 
-						success = 1
-						S.handle_item_insertion(I, 1)	//The 1 stops the "You put the [src] into [S]" insertion message from being displayed.
-					if(success && !failure)
-						user << "<span class='notice'>You put everything [S.preposition] [S].</span>"
-					else if(success)
-						user << "<span class='notice'>You put some things [S.preposition] [S].</span>"
-					else
-						user << "<span class='warning'>You fail to pick anything up with [S]!</span>"
+					var/len = things.len
+					if(!len)
+						to_chat(user, "<span class='notice'>You failed to pick up anything with [S].</span>")
+						return
+					var/datum/progressbar/progress = new(user, len, loc)
+
+					while (do_after(user, 10, TRUE, S, FALSE, CALLBACK(src, .proc/handle_mass_pickup, S, things, loc, rejections, progress)))
+						sleep(1)
+
+					qdel(progress)
+
+					to_chat(user, "<span class='notice'>You put everything you could [S.preposition] [S].</span>")
 
 			else if(S.can_be_inserted(src))
 				S.handle_item_insertion(src)


### PR DESCRIPTION
This changes the satchel to /tg/ code where the satchel will automatically collect ore and add it to the ore box being pulled (if there is one).

:cl: Satchel QoL
add: Satchel automatically collects ores off of the ground.
add: Ore is automatically transferred from the satchel to the ore box.
del: Deletes redundant code.
experiment: I may be an idiot.
/:cl:
