### PR TITLE
Satchel QoL patch - ores picked up automatically

### DIFF
--- a/code/__DEFINES/callbacks.dm
+++ b/code/__DEFINES/callbacks.dm
@@ -1,0 +1,4 @@
+#define GLOBAL_PROC	"some_magic_bullshit"
+2	
+3	#define CALLBACK new /datum/callback
+4	#define INVOKE_ASYNC ImmediateInvokeAsync

--- a/code/_globalvars/typecache.dm
+++ b/code/_globalvars/typecache.dm
@@ -1,0 +1,8 @@
+//please store common type caches here.
+//type caches should only be stored here if used in mutiple places or likely to be used in mutiple places.
+
+//Note: typecache can only replace istype if you know for sure the thing is at least a datum.
+
+GLOBAL_LIST_INIT(typecache_mob, typecacheof(list(/mob)))
+
+

--- a/code/controllers/subsystem/assets.dm
+++ b/code/controllers/subsystem/assets.dm
@@ -14,8 +14,6 @@ var/datum/subsystem/assets/SSasset
 		var/datum/asset/A = new type()
 		A.register()
 
-	for(var/client/C in clients)
-		// Doing this to a client too soon after they've connected can cause issues, also the proc we call sleeps.
-		spawn(10)
-			getFilesSlow(C, cache, FALSE)
+for(var/client/C in GLOB.clients)
+		addtimer(CALLBACK(GLOBAL_PROC, .proc/getFilesSlow, C, cache, FALSE), 10)
 	..()

--- a/code/datums/callback.dm
+++ b/code/datums/callback.dm
@@ -1,0 +1,85 @@
+/*
+	USAGE:
+		var/datum/callback/C = new(object|null, /proc/type/path|"procstring", arg1, arg2, ... argn)
+		var/timerid = addtimer(C, time, timertype)
+		OR
+		var/timerid = addtimer(CALLBACK(object|null, /proc/type/path|procstring, arg1, arg2, ... argn), time, timertype)
+		Note: proc strings can only be given for datum proc calls, global procs must be proc paths
+		Also proc strings are strongly advised against because they don't compile error if the proc stops existing
+		See the note on proc typepath shortcuts
+	INVOKING THE CALLBACK:
+		var/result = C.Invoke(args, to, add) //additional args are added after the ones given when the callback was created
+		OR
+		var/result = C.InvokeAsync(args, to, add) //Sleeps will not block, returns . on the first sleep (then continues on in the "background" after the sleep/block ends), otherwise operates normally.
+		OR
+		INVOKE_ASYNC(<CALLBACK args>) to immediately create and call InvokeAsync
+	PROC TYPEPATH SHORTCUTS (these operate on paths, not types, so to these shortcuts, datum is NOT a parent of atom, etc...)
+		global proc while in another global proc:
+			.procname
+			Example:
+				CALLBACK(GLOBAL_PROC, .some_proc_here)
+		proc defined on current(src) object (when in a /proc/ and not an override) OR overridden at src or any of it's parents:
+			.procname
+			Example:
+				CALLBACK(src, .some_proc_here)
+		when the above doesn't apply:
+			.proc/procname
+			Example:
+				CALLBACK(src, .proc/some_proc_here)
+		proc defined on a parent of a some type:
+			/some/type/.proc/some_proc_here
+		Other wise you will have to do the full typepath of the proc (/type/of/thing/proc/procname)
+*/
+
+/datum/callback
+	var/datum/object = GLOBAL_PROC
+	var/delegate
+	var/list/arguments
+
+/datum/callback/New(thingtocall, proctocall, ...)
+	if (thingtocall)
+		object = thingtocall
+	delegate = proctocall
+	if (length(args) > 2)
+		arguments = args.Copy(3)
+
+/proc/ImmediateInvokeAsync(thingtocall, proctocall, ...)
+	set waitfor = FALSE
+
+	if (!thingtocall)
+		return
+
+	var/list/calling_arguments = length(args) > 2 ? args.Copy(3) : null
+
+	if (thingtocall == GLOBAL_PROC)
+		call(proctocall)(arglist(calling_arguments))
+	else
+		call(thingtocall, proctocall)(arglist(calling_arguments))
+
+/datum/callback/proc/Invoke(...)
+	if (!object)
+		return
+	var/list/calling_arguments = arguments
+	if (length(args))
+		if (length(arguments))
+			calling_arguments = calling_arguments + args //not += so that it creates a new list so the arguments list stays clean
+		else
+			calling_arguments = args
+	if (object == GLOBAL_PROC)
+		return call(delegate)(arglist(calling_arguments))
+	return call(object, delegate)(arglist(calling_arguments))
+
+//copy and pasted because fuck proc overhead
+/datum/callback/proc/InvokeAsync(...)
+	set waitfor = FALSE
+	if (!object)
+		return
+	var/list/calling_arguments = arguments
+	if (length(args))
+		if (length(arguments))
+			calling_arguments = calling_arguments + args //not += so that it creates a new list so the arguments list stays clean
+		else
+			calling_arguments = args
+	if (object == GLOBAL_PROC)
+		return call(delegate)(arglist(calling_arguments))
+	return call(object, delegate)(arglist(calling_arguments))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -308,7 +308,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 
 					var/len = things.len
 					if(!len)
-						to_chat(user, "<span class='notice'>You failed to pick up anything with [S].</span>")
+						user << "<span class='notice'>You failed to pick up anything with [S].</span>")
 						return
 					var/datum/progressbar/progress = new(user, len, loc)
 
@@ -317,7 +317,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 
 					qdel(progress)
 
-					to_chat(user, "<span class='notice'>You put everything you could [S.preposition] [S].</span>")
+					user << "<span class='notice'>You put everything you could [S.preposition] [S].</span>")
 
 			else if(S.can_be_inserted(src))
 				S.handle_item_insertion(src)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -293,39 +293,56 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 
 // Due to storage type consolidation this should get used more now.
 // I have cleaned it up a little, but it could probably use more.  -Sayu
+// The lack of ..() is intentional, do not add one
 /obj/item/attackby(obj/item/weapon/W, mob/user, params)
 	if(istype(W,/obj/item/weapon/storage))
 		var/obj/item/weapon/storage/S = W
 		if(S.use_to_pickup)
 			if(S.collection_mode) //Mode is set to collect multiple items on a tile and we clicked on a valid one.
-				if(isturf(src.loc))
+				if(isturf(loc))
 					var/list/rejections = list()
-					var/success = 0
-					var/failure = 0
 
-					for(var/obj/item/I in src.loc)
-						if(S.collection_mode == 2 && !istype(I,src.type)) // We're only picking up items of the target type
-							failure = 1
-							continue
-						if(I.type in rejections) // To limit bag spamming: any given type only complains once
-							continue
-						if(!S.can_be_inserted(I))	// Note can_be_inserted still makes noise when the answer is no
-							rejections += I.type	// therefore full bags are still a little spammy
-							failure = 1
-							continue
+					var/list/things = loc.contents.Copy()
+					if (S.collection_mode == 2)
+						things = typecache_filter_list(things, typecacheof(type))
 
-						success = 1
-						S.handle_item_insertion(I, 1)	//The 1 stops the "You put the [src] into [S]" insertion message from being displayed.
-					if(success && !failure)
-						user << "<span class='notice'>You put everything [S.preposition] [S].</span>"
-					else if(success)
-						user << "<span class='notice'>You put some things [S.preposition] [S].</span>"
-					else
-						user << "<span class='warning'>You fail to pick anything up with [S]!</span>"
+					var/len = things.len
+					if(!len)
+						to_chat(user, "<span class='notice'>You failed to pick up anything with [S].</span>")
+						return
+					var/datum/progressbar/progress = new(user, len, loc)
+
+					while (do_after(user, 10, TRUE, S, FALSE, CALLBACK(src, .proc/handle_mass_pickup, S, things, loc, rejections, progress)))
+						sleep(1)
+
+					qdel(progress)
+
+					to_chat(user, "<span class='notice'>You put everything you could [S.preposition] [S].</span>")
 
 			else if(S.can_be_inserted(src))
 				S.handle_item_insertion(src)
 
+/obj/item/proc/handle_mass_pickup(obj/item/weapon/storage/S, list/things, atom/thing_loc, list/rejections, datum/progressbar/progress)
+	for(var/obj/item/I in things)
+		things -= I
+		if(I.loc != thing_loc)
+			continue
+		if(I.type in rejections) // To limit bag spamming: any given type only complains once
+			continue
+		if(!S.can_be_inserted(I, stop_messages = TRUE))	// Note can_be_inserted still makes noise when the answer is no
+			if(S.contents.len >= S.storage_slots)
+				break
+			rejections += I.type	// therefore full bags are still a little spammy
+			continue
+
+		S.handle_item_insertion(I, TRUE)	//The 1 stops the "You put the [src] into [S]" insertion message from being displayed.
+
+		if (TICK_CHECK)
+			progress.update(progress.goal - things.len)
+			return TRUE
+
+	progress.update(progress.goal - things.len)
+	return FALSE
 
 // afterattack() and attack() prototypes moved to _onclick/item_attack.dm for consistency
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -308,7 +308,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 
 					var/len = things.len
 					if(!len)
-						user << "<span class='notice'>You failed to pick up anything with [S].</span>")
+						user << "<span class='notice'>You failed to pick up anything with [S].</span>"
 						return
 					var/datum/progressbar/progress = new(user, len, loc)
 
@@ -317,7 +317,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 
 					qdel(progress)
 
-					user << "<span class='notice'>You put everything you could [S.preposition] [S].</span>")
+					user << "<span class='notice'>You put everything you could [S.preposition] [S].</span>"
 
 			else if(S.can_be_inserted(src))
 				S.handle_item_insertion(src)


### PR DESCRIPTION
:cl: Satchel QoL
add: Satchels automatically pick up ores when held in hand or in belt, so long as the holder is standing above the ore. Collects all of one ore type at a time, then moves on to the other.
add: Ores in satchel will automatically be transferred to ore box, so long as one is being pulled by the user.
add: New global variable compatible with new /tg/ ports, required for this patch to function.
add: Relevant _defines variable for callbacks.
del: Older satchel code.
fix: Fixes ported /tg/ user-messages to not throw errors.
/:cl:
