### PR TITLE
Temporarily removes "Kill pirates" objective

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -904,10 +904,7 @@ var/global/list/possible_items_special = list()
 
 /datum/objective/ftl/killships/find_target()
 	ship_count = rand(5,10)
-	if(prob(25))
-		faction = "pirate"
-	else
-		faction = "syndicate"
+	faction = "syndicate" //TODO: Fix and readd Kill Pirate objective. Pirates seem to have spawning issues, or just don't spawn frequently enough
 	..()
 
 /datum/objective/ftl/killships/update_explanation_text()


### PR DESCRIPTION
:cl: ike709
tweak: You'll no longer have an objective to kill pirates. For now.
/:cl:

Something is wrong with the objective to kill a certain number of pirates. They're fucking damn near impossible to find even in the white systems, and rounds with this objective will spend literally hours just trying to _find_ pirates. I don't know if pirates are somewhat broken, need to spawn more frequently, or what.

This is one of the primary sources for hella long rounds that I've seen.