### PR TITLE
Replaces prize pulse rifle in stations with a pulse destroyer

### DIFF
--- a/_maps/ship_encounters/station.dmm
+++ b/_maps/ship_encounters/station.dmm
@@ -709,7 +709,7 @@
 	})
 "bI" = (
 /obj/structure/table/reinforced,
-/obj/item/weapon/gun/energy/pulse/prize,
+/obj/item/weapon/gun/energy/pulse/destroyer,
 /turf/open/floor/plasteel/darkblue,
 /area/no_entry{
 	has_gravity = 1;

--- a/_maps/ship_encounters/station2.dmm
+++ b/_maps/ship_encounters/station2.dmm
@@ -1987,7 +1987,7 @@
 	})
 "dQ" = (
 /obj/structure/table/reinforced,
-/obj/item/weapon/gun/energy/pulse/prize,
+/obj/item/weapon/gun/energy/pulse/destroyer,
 /turf/open/floor/noslip,
 /area/no_entry{
 	has_gravity = 1;


### PR DESCRIPTION
Fixes ghosts seeing the "someone won a pulse rifle" message when actually it just was spawned on the station.