### PR TITLE
Fixes runtime with SMES charged past capacity

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -247,7 +247,7 @@
 
 
 /obj/machinery/power/smes/proc/chargedisplay()
-	return round(5.5*charge/capacity)
+	return Clamp(round(5.5*charge/capacity),0,5)
 
 /obj/machinery/power/smes/process()
 	if(terminal)


### PR DESCRIPTION
Clamps the values for the display to prevent going out of range in the array.