### PR TITLE
Makes pirates spawn in neutral sectors other than in fleets

### DIFF
--- a/code/controllers/subsystem/starmap.dm
+++ b/code/controllers/subsystem/starmap.dm
@@ -109,6 +109,7 @@ var/datum/subsystem/starmap/SSstarmap
 		if(system.alignment == "unaligned")
 			var/datum/star_faction/pirate = SSship.cname2faction("pirate")
 			pirate.systems += system
+			system.danger_level = 2
 
 
 


### PR DESCRIPTION
@monster860 @CrAzYPiLoT-SS13 

:cl: Vivalas

fix: Pirate ships will now spawn in neutral sectors other than in fleets

/:cl:
