### PR TITLE
Reduces electrical storm and vent clog weight so they happen less

### DIFF
--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -3,7 +3,8 @@
 	typepath = /datum/round_event/electrical_storm
 	earliest_start = 6000
 	min_players = 5
-	weight = 40
+	weight = 25
+	max_occurrences = 3
 	alertadmins = 0
 
 /datum/round_event/electrical_storm

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/vent_clog
 	name = "Clogged Vents"
 	typepath = /datum/round_event/vent_clog
-	weight = 35
+	weight = 30
 
 /datum/round_event/vent_clog
 	announceWhen	= 1


### PR DESCRIPTION
:cl: ike709
tweak: Electrical Storm event weight reduced to 25 from 40
tweak: Electrical Storm cannot happen more than 3 times
tweak: Clogged Vents weight reduced to 30 from 35
/:cl:

Electrical storms happen too damn often, and they offer nothing more than a minor annoyance.

Clogged vents aren't _quite_ as bad but still a bit silly.