### PR TITLE
Ports compile option to visualize active turfs

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -50,6 +50,9 @@
 #warn compiling in TESTING mode. testing() debug messages will be visible.
 #endif
 
+//Highlights atmos active turfs in green
+//#define VISUALIZE_ACTIVE_TURFS
+
 //Update this whenever you need to take advantage of more recent byond features
 #define MIN_COMPILER_VERSION 510
 #if DM_VERSION < MIN_COMPILER_VERSION

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -237,6 +237,9 @@ var/datum/subsystem/air/SSair
 
 /datum/subsystem/air/proc/remove_from_active(turf/open/T)
 	active_turfs -= T
+	#ifdef VISUALIZE_ACTIVE_TURFS
+	T.color = null
+	#endif
 	if(istype(T))
 		T.excited = 0
 		if(T.excited_group)
@@ -245,6 +248,9 @@ var/datum/subsystem/air/SSair
 
 /datum/subsystem/air/proc/add_to_active(turf/open/T, blockchanges = 1)
 	if(istype(T) && T.air)
+		#ifdef VISUALIZE_ACTIVE_TURFS
+		T.color = "#00ff00"
+		#endif
 		T.excited = 1
 		active_turfs |= T
 		if(blockchanges && T.excited_group)


### PR DESCRIPTION
:cl: ike709
add: There is now a compile option to visualize active turfs. They will appear green.
/:cl:

Credit to Cyberboss.
Original PR: https://github.com/tgstation/tgstation/pull/25594
NOTE: We do not have add_atom_colour and remove_atom_colour. This is the best alternative I could come up with.

NOTE 2: I have absolutely no idea if this works at all. It turns a bunch of turfs green, but I have no clue if they're actually active turfs or not because I don't really know how to deal with active turfs.