### PR TITLE
[READY FOR REVIEW] Alternate Job Titles

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -60,6 +60,9 @@ var/datum/subsystem/job/SSjob
 			return J
 	return null
 
+/datum/subsystem/job/proc/GetPlayerAltTitle(mob/new_player/player, rank)
+	return player.client.prefs.GetPlayerAltTitle(GetJob(rank))
+
 /datum/subsystem/job/proc/AssignRole(mob/new_player/player, rank, latejoin=0)
 	Debug("Running AR, Player: [player], Rank: [rank], LJ: [latejoin]")
 	if(player && player.mind && rank)
@@ -75,6 +78,7 @@ var/datum/subsystem/job/SSjob
 			position_limit = job.spawn_positions
 		Debug("Player: [player] is now Rank: [rank], JCP:[job.current_positions], JPL:[position_limit]")
 		player.mind.assigned_role = rank
+		player.mind.role_alt_title = GetPlayerAltTitle(player, rank)
 		unassigned -= player
 		job.current_positions++
 		return 1
@@ -354,7 +358,6 @@ var/datum/subsystem/job/SSjob
 //Gives the player the stuff he should have with his rank
 /datum/subsystem/job/proc/EquipRank(mob/living/H, rank, joined_late=0)
 	var/datum/job/job = GetJob(rank)
-
 	H.job = rank
 
 	//If we joined at roundstart we should be positioned at our workstation
@@ -386,17 +389,18 @@ var/datum/subsystem/job/SSjob
 		if(istype(S, /obj/effect/landmark) && istype(S.loc, /turf))
 			H.loc = S.loc
 
+	var/alt_title = null
 	if(H.mind)
 		H.mind.assigned_role = rank
-
+		alt_title = H.mind.role_alt_title
 	if(job)
 		var/new_mob = job.equip(H)
 		if(ismob(new_mob))
 			H = new_mob
 		job.apply_fingerprints(H)
 
-	H << "<b>You are the [rank].</b>"
-	H << "<b>As the [rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>"
+	H << "<b>You are the [alt_title ? alt_title : rank].</b>"
+	H << "<b>As the [alt_title ? alt_title : rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>"
 	H << "<b>To speak on your departments radio, use the :h button. To see others, look closely at your headset.</b>"
 	if(job.req_admin_notify)
 		H << "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>"

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -70,9 +70,28 @@
 		manifest_inject(H)
 
 /datum/datacore/proc/manifest_modify(name, assignment)
-	var/datum/data/record/foundrecord = find_record("name", name, data_core.general)
+
+	var/datum/data/record/foundrecord
+	var/real_title = assignment
+
+	for(var/datum/data/record/t in data_core.general)
+		if(t)
+			if(t.fields["name"] == name)
+				foundrecord = t
+				break
+
+	var/list/all_jobs = get_job_datums()
+
+	for(var/datum/job/J in all_jobs)
+		var/list/alttitles = get_alternate_titles(J.title)
+		if(!J)	continue
+		if(assignment in alttitles)
+			real_title = J.title
+			break
+
 	if(foundrecord)
 		foundrecord.fields["rank"] = assignment
+		foundrecord.fields["real_rank"] = real_title
 
 /datum/datacore/proc/get_manifest(monochrome, OOC)
 	var/list/heads = list()
@@ -101,29 +120,30 @@
 	for(var/datum/data/record/t in data_core.general)
 		var/name = t.fields["name"]
 		var/rank = t.fields["rank"]
+		var/real_rank = t.fields["real_rank"]
 		var/department = 0
-		if(rank in command_positions)
+		if(real_rank in command_positions)
 			heads[name] = rank
 			department = 1
-		if(rank in security_positions)
+		if(real_rank in security_positions)
 			sec[name] = rank
 			department = 1
-		if(rank in engineering_positions)
+		if(real_rank in engineering_positions)
 			eng[name] = rank
 			department = 1
-		if(rank in medical_positions)
+		if(real_rank in medical_positions)
 			med[name] = rank
 			department = 1
-		if(rank in science_positions)
+		if(real_rank in science_positions)
 			sci[name] = rank
 			department = 1
-		if(rank in supply_positions)
+		if(real_rank in supply_positions)
 			sup[name] = rank
 			department = 1
-		if(rank in civilian_positions)
+		if(real_rank in civilian_positions)
 			civ[name] = rank
 			department = 1
-		if(rank in nonhuman_positions)
+		if(real_rank in nonhuman_positions)
 			bot[name] = rank
 			department = 1
 		if(!department && !(name in heads))
@@ -186,7 +206,9 @@ var/record_id_num = 1001
 /datum/datacore/proc/manifest_inject(mob/living/carbon/human/H)
 	if(H.mind && (H.mind.assigned_role != H.mind.special_role))
 		var/assignment
-		if(H.mind.assigned_role)
+		if(H.mind.role_alt_title)
+			assignment = H.mind.role_alt_title
+		else if(H.mind.assigned_role)
 			assignment = H.mind.assigned_role
 		else if(H.job)
 			assignment = H.job
@@ -205,6 +227,7 @@ var/record_id_num = 1001
 		var/datum/data/record/G = new()
 		G.fields["id"]			= id
 		G.fields["name"]		= H.real_name
+		G.fields["real_rank"]	= H.mind.assigned_role
 		G.fields["rank"]		= assignment
 		G.fields["age"]			= H.age
 		if(config.mutant_races)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -43,6 +43,7 @@
 	var/list/restricted_roles = list()
 
 	var/datum/job/assigned_job
+	var/role_alt_title
 
 	var/list/datum/objective/objectives = list()
 	var/list/datum/objective/special_verbs = list()

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -54,7 +54,7 @@
 	if(id)
 		var/obj/item/weapon/card/id/newid = new id(H)
 		H.equip_to_slot_or_del(newid,slot_wear_id)
-		newid.update_label(H.real_name, H.job)
+		newid.update_label(H.real_name, SSjob.GetPlayerAltTitle(H, H.job))
 	if(l_pocket)
 		H.equip_to_slot_or_del(new l_pocket(H),slot_l_store)
 	if(r_pocket)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -509,6 +509,7 @@ What a mess.*/
 				G.fields["name"] = "New Record"
 				G.fields["id"] = "[num2hex(rand(1, 1.6777215E7), 6)]"
 				G.fields["rank"] = "Unassigned"
+				G.fields["real_rank"] = "Unassigned"
 				G.fields["sex"] = "Male"
 				G.fields["age"] = "Unknown"
 				if(config.mutant_races)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -81,7 +81,6 @@
 	var/list/access = list()
 	var/registered_name = null // The name registered_name on the card
 	var/assignment = null
-
 	var/dorm = 0		// determines if this ID has claimed a dorm already
 
 /obj/item/weapon/card/id/attack_self(mob/user)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -81,6 +81,7 @@
 	var/list/access = list()
 	var/registered_name = null // The name registered_name on the card
 	var/assignment = null
+
 	var/dorm = 0		// determines if this ID has claimed a dorm already
 
 /obj/item/weapon/card/id/attack_self(mob/user)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -446,7 +446,7 @@ var/list/preferences_datums = list()
 	popup.set_content(dat)
 	popup.open(0)
 
-/datum/preferences/proc/SetChoices(mob/user, limit = 10, list/splitJobs = list("Bartender","Chief Engineer","Research Director"), widthPerColumn = 360, height = 600)
+/datum/preferences/proc/SetChoices(mob/user, limit = 17, list/splitJobs = list("Chief Engineer"), widthPerColumn = 295, height = 620)
 	if(!SSjob)
 		return
 
@@ -504,7 +504,10 @@ var/list/preferences_datums = list()
 		if((rank in command_positions) || (rank == "AI"))//Bold head jobs
 			HTML += "<b><span class='dark'>[rank]</span></b>"
 		else
-			HTML += "<span class='dark'>[rank]</span>"
+			if(job.alt_titles)
+				HTML += "<span class='dark'><a href=\"byond://?src=\ref[user];preference=job;task=alt_title;job=\ref[job]\">[GetPlayerAltTitle(job)]</a></span>"
+			else
+				HTML += "<span class='dark'>[rank]</span>"
 
 		HTML += "</td><td width='40%'>"
 
@@ -546,9 +549,6 @@ var/list/preferences_datums = list()
 			continue
 
 		HTML += "<font color=[prefLevelColor]>[prefLevelLabel]</font></a>"
-
-		if(job.alt_titles)
-			HTML += "<br><b><a class='white' href=\"?_src_=prefs;preference=job;task=alt_title;job=\ref[job]\">\[[GetPlayerAltTitle(job)]\]</a></b></td></tr>"
 
 		HTML += "</td></tr>"
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -446,7 +446,7 @@ var/list/preferences_datums = list()
 	popup.set_content(dat)
 	popup.open(0)
 
-/datum/preferences/proc/SetChoices(mob/user, limit = 17, list/splitJobs = list("Chief Engineer"), widthPerColumn = 354, height = 620)
+/datum/preferences/proc/SetChoices(mob/user, limit = 10, list/splitJobs = list("Bartender","Chief Engineer","Research Director"), widthPerColumn = 360, height = 600)
 	if(!SSjob)
 		return
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -657,9 +657,7 @@ var/list/preferences_datums = list()
 	return 1
 
 /datum/preferences/proc/GetPlayerAltTitle(datum/job/job)
-	return player_alt_titles.Find(job.title) > 0 \
-		? player_alt_titles[job.title] \
-		: job.title
+	return player_alt_titles.Find(job.title) > 0 ? player_alt_titles[job.title] : job.title
 
 /datum/preferences/proc/SetPlayerAltTitle(datum/job/job, new_title)
 	// remove existing entry

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -357,6 +357,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["job_engsec_med"]		>> job_engsec_med
 	S["job_engsec_low"]		>> job_engsec_low
 
+	//Alternate job titles
+	S["player_alt_titles"]	>> player_alt_titles
+
 	//try to fix any outdated data if necessary
 	if(needs_update >= 0)
 		update_character(needs_update)		//needs_update == savefile_version if we need an update (positive integer)
@@ -408,6 +411,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	job_engsec_high = sanitize_integer(job_engsec_high, 0, 65535, initial(job_engsec_high))
 	job_engsec_med = sanitize_integer(job_engsec_med, 0, 65535, initial(job_engsec_med))
 	job_engsec_low = sanitize_integer(job_engsec_low, 0, 65535, initial(job_engsec_low))
+
+	if(!player_alt_titles) player_alt_titles = new()
 
 	return 1
 
@@ -466,6 +471,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["job_engsec_high"]	<< job_engsec_high
 	S["job_engsec_med"]		<< job_engsec_med
 	S["job_engsec_low"]		<< job_engsec_low
+
+	//Alternate job titles
+	S["player_alt_titles"]	<< player_alt_titles
 
 	return 1
 

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -2,7 +2,7 @@
 Assistant
 */
 /datum/job/assistant
-	title = "Assistant"
+	title = "Assistant" //Assistants cannot have alt titles
 	flag = ASSISTANT
 	department_flag = CIVILIAN
 	faction = "Station"

--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -69,6 +69,7 @@ Cargo Technician
 	spawn_positions = 2
 	supervisors = "the quartermaster and the executive officer"
 	selection_color = "#dcba97"
+	alt_titles = list("Supply Technician","Production Officer")
 
 	outfit = /datum/outfit/job/cargo_tech
 
@@ -96,6 +97,7 @@ Shaft Miner
 	spawn_positions = 3
 	supervisors = "the quartermaster and the executive officer"
 	selection_color = "#dcba97"
+	alt_titles = list("Salvager", "Explorer")
 
 	outfit = /datum/outfit/job/miner
 
@@ -166,6 +168,7 @@ Cook
 	spawn_positions = 1
 	supervisors = "the executive officer"
 	selection_color = "#bbe291"
+	alt_titles = list("Chef","Sous-chef")
 	var/cooks = 0 //Counts cooks amount
 
 	outfit = /datum/outfit/job/cook
@@ -244,6 +247,7 @@ Janitor
 	spawn_positions = 1
 	supervisors = "the executive officer"
 	selection_color = "#bbe291"
+	alt_titles = list("Sanitation Technician", "Maid")
 	var/global/janitors = 0
 
 	outfit = /datum/outfit/job/janitor

--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -69,7 +69,7 @@ Cargo Technician
 	spawn_positions = 2
 	supervisors = "the quartermaster and the executive officer"
 	selection_color = "#dcba97"
-	alt_titles = list("Supply Technician","Production Officer")
+	alt_titles = list("Supply Technician","Production Technician")
 
 	outfit = /datum/outfit/job/cargo_tech
 

--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -13,6 +13,7 @@ Strip out?
 	spawn_positions = 1
 	supervisors = "the executive officer"
 	selection_color = "#dddddd"
+	alt_titles = list("Morale Officer")
 
 	outfit = /datum/outfit/job/clown
 
@@ -125,6 +126,7 @@ Strip out?
 	spawn_positions = 1
 	supervisors = "the executive officer"
 	selection_color = "#dddddd"
+	alt_titles = list("Reporter","Journalist")
 
 	outfit = /datum/outfit/job/librarian
 
@@ -154,6 +156,7 @@ Strip out?
 	spawn_positions = 2
 	supervisors = "the executive officer"
 	selection_color = "#dddddd"
+	alt_titles = list("Public Defender","Magistrate","Judge")
 	var/lawyers = 0 //Counts lawyer amount
 
 	outfit = /datum/outfit/job/lawyer

--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -13,7 +13,7 @@ Strip out?
 	spawn_positions = 1
 	supervisors = "the executive officer"
 	selection_color = "#dddddd"
-	alt_titles = list("Morale Officer")
+	alt_titles = list("Morale Technician")
 
 	outfit = /datum/outfit/job/clown
 
@@ -156,7 +156,7 @@ Strip out?
 	spawn_positions = 2
 	supervisors = "the executive officer"
 	selection_color = "#dddddd"
-	alt_titles = list("Public Defender","Magistrate","Judge")
+	alt_titles = list("Public Defender")
 	var/lawyers = 0 //Counts lawyer amount
 
 	outfit = /datum/outfit/job/lawyer

--- a/code/modules/jobs/job_types/civilian_chaplain.dm
+++ b/code/modules/jobs/job_types/civilian_chaplain.dm
@@ -13,6 +13,7 @@ Strip out?
 	spawn_positions = 1
 	supervisors = "the executive officer"
 	selection_color = "#dddddd"
+	alt_titles = list("Priest","Pastor","Minister")
 
 	outfit = /datum/outfit/job/chaplain
 

--- a/code/modules/jobs/job_types/engineering.dm
+++ b/code/modules/jobs/job_types/engineering.dm
@@ -60,7 +60,7 @@ Station Engineer
 	total_positions = 5
 	spawn_positions = 5
 	supervisors = "the chief engineer"
-	alt_titles = list("Maintenance Technician","Engine Technician","Electrician")
+	alt_titles = list("Maintenance Technician","Engine Technician","Electrician","Repair Specialist", "Architect", "Propulsion Engineer")
 	selection_color = "#fff5cc"
 
 	outfit = /datum/outfit/job/engineer
@@ -98,6 +98,7 @@ Atmospheric Technician
 	spawn_positions = 1
 	supervisors = "the chief engineer"
 	selection_color = "#fff5cc"
+	alt_titles = list("Firefighter", "Plumber")
 
 	outfit = /datum/outfit/job/atmos
 

--- a/code/modules/jobs/job_types/engineering.dm
+++ b/code/modules/jobs/job_types/engineering.dm
@@ -60,6 +60,7 @@ Station Engineer
 	total_positions = 5
 	spawn_positions = 5
 	supervisors = "the chief engineer"
+	alt_titles = list("Maintenance Technician","Engine Technician","Electrician")
 	selection_color = "#fff5cc"
 
 	outfit = /datum/outfit/job/engineer

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -194,7 +194,7 @@
 	var/obj/item/device/pda/PDA = H.get_item_by_slot(pda_slot)
 	if(istype(PDA))
 		PDA.owner = H.real_name
-		PDA.ownjob = H.job
+		PDA.ownjob = SSjob.GetPlayerAltTitle(H, H.job)
 		PDA.update_label()
 
 /datum/outfit/job/proc/announce_head(var/mob/living/carbon/human/H, var/channels) //tells the given channel that the given mob is the new department head. See communications.dm for valid channels.

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -29,9 +29,11 @@
 	//Supervisors, who this person answers to directly
 	var/supervisors = ""
 
-	//Sellection screen color
+	//Selection screen color
 	var/selection_color = "#ffffff"
 
+	//List of alternate titles, if any
+	var/list/alt_titles
 
 	//If this is set to 1, a text is printed to the player when jobs are assigned, telling him that he should let admins know that he has to disconnect.
 	var/req_admin_notify
@@ -176,11 +178,16 @@
 		return
 
 	var/obj/item/weapon/card/id/C = H.wear_id
+
+	var/alt_title
+	if(H.mind)
+		alt_title = H.mind.role_alt_title
+
 	if(istype(C))
 		var/datum/job/J = SSjob.GetJob(H.job) // Not sure the best idea
 		C.access = J.get_access()
 		C.registered_name = H.real_name
-		C.assignment = H.job
+		C.assignment = alt_title ? alt_title : J.title
 		C.update_label()
 		H.sec_hud_set_ID()
 

--- a/code/modules/jobs/job_types/medical.dm
+++ b/code/modules/jobs/job_types/medical.dm
@@ -59,6 +59,7 @@ Medical Doctor
 	spawn_positions = 3
 	supervisors = "the chief medical officer"
 	selection_color = "#ffeef0"
+	alt_titles = list("EMT","Paramedic","Surgeon")
 
 	outfit = /datum/outfit/job/doctor
 
@@ -93,6 +94,7 @@ Chemist
 	spawn_positions = 2
 	supervisors = "the chief medical officer"
 	selection_color = "#ffeef0"
+	alt_titles = list("Pharmacist")
 
 	outfit = /datum/outfit/job/chemist
 

--- a/code/modules/jobs/job_types/science.dm
+++ b/code/modules/jobs/job_types/science.dm
@@ -58,6 +58,7 @@ Scientist
 	spawn_positions = 3
 	supervisors = "the research director"
 	selection_color = "#ffeeff"
+	alt_titles = list("Xenobiologist", "Researcher")
 
 	outfit = /datum/outfit/job/scientist
 
@@ -89,6 +90,7 @@ Roboticist
 	spawn_positions = 2
 	supervisors = "research director"
 	selection_color = "#ffeeff"
+	alt_titles = list("Mechanic")
 
 	outfit = /datum/outfit/job/roboticist
 

--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -192,7 +192,6 @@ Security Officer
 	supervisors = "the head of security, and the head of your assigned department (if applicable)"
 	selection_color = "#ffeeee"
 	minimal_player_age = 7
-	alt_titles = list("Security Guard", "Marine")
 
 	outfit = /datum/outfit/job/security
 

--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -140,6 +140,7 @@ Detective
 	supervisors = "the head of security"
 	selection_color = "#ffeeee"
 	minimal_player_age = 7
+	alt_titles = list("Forensic Technician", "Private Investigator", "Inspector")
 
 	outfit = /datum/outfit/job/detective
 
@@ -191,6 +192,7 @@ Security Officer
 	supervisors = "the head of security, and the head of your assigned department (if applicable)"
 	selection_color = "#ffeeee"
 	minimal_player_age = 7
+	alt_titles = list("Security Guard", "Marine")
 
 	outfit = /datum/outfit/job/security
 

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -130,7 +130,27 @@ var/list/nonhuman_positions = list(
 /proc/guest_jobbans(job)
 	return ((job in command_positions) || (job in nonhuman_positions) || (job in security_positions))
 
+/proc/get_job_datums()
+	var/list/occupations = list()
+	var/list/all_jobs = typesof(/datum/job)
 
+	for(var/A in all_jobs)
+		var/datum/job/job = new A()
+		if(!job)	continue
+		occupations += job
+
+	return occupations
+
+/proc/get_alternate_titles(var/job)
+	var/list/jobs = get_job_datums()
+	var/list/titles = list()
+
+	for(var/datum/job/J in jobs)
+		if(!J)	continue
+		if(J.title == job)
+			titles = J.alt_titles
+
+	return titles
 
 //this is necessary because antags happen before job datums are handed out, but NOT before they come into existence
 //so I can't simply use job datum.department_head straight from the mind datum, laaaaame.

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -350,8 +350,13 @@
 	if(ticker.current_state != GAME_STATE_PLAYING)
 		return
 	var/area/A = get_area(character)
+	var/arrivaljob
+	if(character.mind.role_alt_title)
+		arrivaljob = character.mind.role_alt_title
+	else
+		arrivaljob = character.job
 	var/message = "<span class='game deadsay'><span class='name'>\
-		[character.real_name]</span> ([character.job]) has arrived at the station at \
+		[character.real_name]</span> ([arrivaljob]) has arrived at the station at \
 		<span class='name'>[A.name]</span>.</span>"
 	deadchat_broadcast(message, follow_target = character, message_type=DEADCHAT_ARRIVALRATTLE)
 	if((!announcement_systems.len) || (!character.mind))

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -366,7 +366,7 @@
 
 	spawn(4) //so we can actually see the post_equip bullshit
 		var/obj/machinery/announcement_system/announcer = pick(announcement_systems)
-		announcer.announce("ARRIVAL", character.real_name, character.job, list()) //make the list empty to make it announce it in common
+		announcer.announce("ARRIVAL", character.real_name, arrivaljob, list()) //make the list empty to make it announce it in common
 
 /mob/new_player/proc/AddEmploymentContract(mob/living/carbon/human/employee)
 	//TODO:  figure out a way to exclude wizards/nukeops/demons from this.


### PR DESCRIPTION
:cl: ike709
add: Jobs can now have alternate titles. You can choose them in Occupation Preferences. These currently have no gameplay impact, and are just for fluff.
/:cl:

You can now choose an alternate name for your job from a predefined list, configurable in Occupation Preferences. I'm pretty sure this one works correctly, actually.

I ported this from paradise, but couldn't find a PR for it.

Everything seems to work as intended.

Does not support alternate titles for assistants, heads of staff, or Bridge Officers.

Title-based outfits will be coming in a future PR.

LIST OF CURRENT ALT JOB TITLES:
Cargo Tech: "Supply Technician","Production Technician"
Shaft Miner: "Salvager", "Explorer"
Cook: "Chef","Sous-chef"
Janitor: "Sanitation Technician", "Maid"
Clown: "Morale Technician"
Librarian: "Journalist", "Reporter"
Lawyer: "Public Defender"
Chaplain: "Priest","Pastor","Minister"
Engineer: "Maintenance Technician","Engine Technician","Electrician","Repair Specialist", "Architect", "Propulsion Engineer"
Atmos Tech: "Firefighter", "Plumber"
Medical Doctor: "EMT","Paramedic","Surgeon"
Chemist: "Pharmacist"
Scientist: "Xenobiologist", "Researcher"
Roboticist: "Mechanic"
Detective: "Forensic Technician", "Private Investigator", "Inspector"

New Occupation Preferences window. Same size as the original one.
![image](https://cloud.githubusercontent.com/assets/5714543/25054374/696ec086-2122-11e7-9009-d368036afa69.png)
