### PR TITLE
Improves testing QoL by shortening default lobby and roundend time

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -5,9 +5,11 @@
 STATIONNAME Space Station 13
 
 # Lobby time: This is the amount of time between rounds that players have to setup their characters and be ready.
+## NOTE: This is a testing value. Please change it to 120 on an actual server.
 LOBBY_COUNTDOWN 20
 
 # Round End Time: This is the amount of time after the round ends that players have to murder death kill each other.
+## NOTE: This is a testing value. Please change it to 90 on an actual server.
 ROUND_END_COUNTDOWN 20
 
 ## Add a # infront of this if you want to use the SQL based admin system, the legacy system uses admins.txt. You need to set up your database to use the SQL based system.

--- a/config/config.txt
+++ b/config/config.txt
@@ -5,10 +5,10 @@
 STATIONNAME Space Station 13
 
 # Lobby time: This is the amount of time between rounds that players have to setup their characters and be ready.
-LOBBY_COUNTDOWN 120
+LOBBY_COUNTDOWN 20
 
 # Round End Time: This is the amount of time after the round ends that players have to murder death kill each other.
-ROUND_END_COUNTDOWN 90
+ROUND_END_COUNTDOWN 20
 
 ## Add a # infront of this if you want to use the SQL based admin system, the legacy system uses admins.txt. You need to set up your database to use the SQL based system.
 ADMIN_LEGACY_SYSTEM


### PR DESCRIPTION
:cl: ike709
tweak: The default time for the lobby and roundend countdowns are much shorter. THESE ARE VALUES FOR TESTING. DO NOT USE THEM ON ACTUAL SERVERS.
/:cl:

## NOTE: DO NOT UPDATE THE CONFIG TO THESE VALUES. THESE ARE FOR TESTING PURPOSES ONLY.

I'm tired of having to reduce these manually all the time, and the config already contains at least one testing default value that would fuck up an actual server.