### PR TITLE
Xenobiology ports

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -379,5 +379,5 @@
 	max_combined_w_class = 200
 	w_class = 1
 	preposition = "in"
-	can_hold = list(/obj/item/slime_extract, /obj/item/weapon/reagent_containers/syringe, /obj/item/weapon/reagent_containers/glass/beaker, /obj/item/weapon/reagent_containers/glass/bottle, /obj/item/weapon/reagent_containers/blood, /obj/item/weapon/reagent_containers/hypospray/medipen, /obj/item/trash/deadmouse)
+	can_hold = list(/obj/item/slime_extract, /obj/item/weapon/reagent_containers/syringe, /obj/item/weapon/reagent_containers/glass/beaker, /obj/item/weapon/reagent_containers/glass/bottle, /obj/item/weapon/reagent_containers/blood, /obj/item/weapon/reagent_containers/hypospray/medipen, /obj/item/trash/deadmouse, /obj/item/weapon/reagent_containers/food/snacks/monkeycube)
 	burn_state = FLAMMABLE

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -90,6 +90,24 @@
 	P.amount = 5
 	P.loc = get_turf(holder.my_atom)
 
+/datum/chemical_reaction/slimeglass
+	name = "Slime Glass"
+	id = "m_glass"
+	result = null
+	required_reagents = list("water" = 1)
+	required_container = /obj/item/slime_extract/metal
+	required_other = 1
+
+/datum/chemical_reaction/slimeglass/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/obj/item/stack/sheet/glass/M = new /obj/item/stack/sheet/glass
+	M.amount = 15
+	M.loc = get_turf(holder.my_atom)
+	var/obj/item/stack/sheet/rglass/P = new /obj/item/stack/sheet/rglass
+	P.amount = 5
+	P.loc = get_turf(holder.my_atom)
+
+
 //Gold
 /datum/chemical_reaction/slimecrit
 	name = "Slime Crit"
@@ -245,6 +263,21 @@
 	P.loc = get_turf(holder.my_atom)
 
 
+/datum/chemical_reaction/slimefoam
+	name = "Slime Foam"
+	id = "m_foam"
+	result = null
+	required_reagents = list("water" = 5)
+	required_container = /obj/item/slime_extract/blue
+	required_other = 1
+
+
+
+datum/chemical_reaction/slimefoam/on_reaction(datum/reagents/holder)
+
+	holder.add_reagent("water", 20)
+	holder.add_reagent("fluorosurfactant", 20)
+
 
 //Dark Blue
 /datum/chemical_reaction/slimefreeze
@@ -318,6 +351,21 @@
 		var/turf/open/T = get_turf(holder.my_atom)
 		if(istype(T))
 			T.atmos_spawn_air("plasma=50;TEMP=1000")
+
+/datum/chemical_reaction/slimesmoke
+	name = "Slime Smoke"
+	id = "m_smoke"
+	result=null
+	required_reagents = list("water"=5)
+	required_container = /obj/item/slime_extract/orange
+	required_other = 1
+
+/datum/chemical_reaction/slimesmoke/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	holder.add_reagent("phosphorus", 10)
+	holder.add_reagent("sugar", 10)
+	holder.add_reagent("potassium", 10)
+
 
 //Yellow
 
@@ -472,6 +520,8 @@
 	var/obj/item/slimepotion/docility/P = new /obj/item/slimepotion/docility
 	P.loc = get_turf(holder.my_atom)
 
+
+
 //Black
 /datum/chemical_reaction/slimemutate2
 	name = "Advanced Mutation Toxin"
@@ -511,6 +561,15 @@
 /datum/chemical_reaction/slimeexplosion/proc/boom(datum/reagents/holder)
 	if(holder && holder.my_atom)
 		explosion(get_turf(holder.my_atom), 1 ,3, 6)
+
+/datum/chemical_reaction/slime/slimecornoil
+	name = "Slime Corn Oil"
+	id = "m_cornoil"
+	result = "cornoil"
+	required_reagents = list("blood" =1)
+	required_container = /obj/item/slime_extract/oil
+	required_other = 1
+	result_amount = 5
 
 //Light Pink
 /datum/chemical_reaction/slimepotion2
@@ -677,6 +736,19 @@
 	if(P)
 		P.loc = get_turf(holder.my_atom)
 
+/datum/chemical_reaction/slimecrayon
+	name = "Slime Crayon"
+	id = "s_crayon"
+	required_reagents = list("blood" = 1)
+	required_container = /obj/item/slime_extract/pyrite
+	required_other = 1
+
+/datum/chemical_reaction/slimecrayon/on_reaction(datum/reagents/holder)
+	var/chosen = pick(difflist(subtypesof(/obj/item/toy/crayon),typesof(/obj/item/toy/crayon/spraycan)))
+	new chosen(get_turf(holder.my_atom))
+	..()
+
+
 //Rainbow :o)
 /datum/chemical_reaction/slimeRNG
 	name = "Random Core"
@@ -708,4 +780,16 @@
 	feedback_add_details("slime_cores_used","[type]")
 	var/obj/item/slimepotion/transference/P = new /obj/item/slimepotion/transference
 	P.loc = get_turf(holder.my_atom)
+
+datum/chemical_reaction/flight_potion
+	name = "Flight Potion"
+	id = "flight potion"
+	required_reagents = list("holywater" = 5, "uranium" = 5)
+	required_other = 1
+	required_container = /obj/item/slime_extract/rainbow
+
+/datum/chemical_reaction/flight_potion/on_reaction(datum/reagents/holder)
+	 var/obj/item/weapon/reagent_containers/glass/bottle/potion/flight/M  = new /obj/item/weapon/reagent_containers/glass/bottle/potion/flight
+	 M.loc = get_turf(holder.my_atom)
+
 

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -29,7 +29,7 @@
 
 	icon_screen = "slime_comp"
 	icon_keyboard = "rd_key"
-	
+
 /obj/machinery/computer/camera_advanced/xenobio/New()
 	..()
 
@@ -72,6 +72,17 @@
 		user << "<span class='notice'>You feed [O] to the [src]. It now has [monkeys] monkey cubes stored.</span>"
 		user.drop_item()
 		qdel(O)
+		return
+	else if(istype(O, /obj/item/weapon/storage/bag))
+		var/obj/item/weapon/storage/P = O
+		var/loaded = 0
+		for(var/obj/G in P.contents)
+			if(istype(G, /obj/item/weapon/reagent_containers/food/snacks/monkeycube))
+				loaded = 1
+				monkeys++
+				qdel(G)
+		if (loaded)
+			user << "<span class='notice'>You fill the [src] with the monkey cubes stored in [O]. The [src] now has [monkeys] monkey cubes stored.</span>"
 		return
 	..()
 


### PR DESCRIPTION
Ports the reactions listed in the changelog and the ability for the bio bags to pick up monkey cubes. 
Unadded in this push are the gender potion reaction and the customizable golem shell reactions.



:cl: optional name here
add: bio bags updated, can now pick up cubes and put them in machine( Credit: XDTM)
add:ported a decent amount of /tg/ slime reactions we didn't have from forking:
Metal slimes can now make glass and reinforced glass panes from water(Credit: XDTM)
Blue slimes now cause a foam reaction when injected with water(Credit: XDTM)
Orange slimes now cause a smoke reaction when injected with water(Credit: XDTM)
Oil slimes now create corn oil when injected with blood(Credit: XDTM)
Pyrite slimes can create a random crayon or spraycan when injected with blood(Credit: XDTM)
Rainbow slimes can now create flight potions when injected with uranium and holy water (Credit: CaptainChloroform)
/:cl:
