### PR TITLE
LAZY list stuff

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -386,3 +386,12 @@
 
 //Picks from the list, with some safeties, and returns the "default" arg if it fails
 #define DEFAULTPICK(L, default) ((istype(L, /list) && L:len) ? pick(L) : default)
+
+#define LAZYINITLIST(L) if (!L) L = list()
+
+#define UNSETEMPTY(L) if (L && !L.len) L = null
+#define LAZYREMOVE(L, I) if(L) { L -= I; if(!L.len) { L = null; } }
+#define LAZYADD(L, I) if(!L) { L = list(); } L += I;
+#define LAZYACCESS(L, I) (L ? (isnum(I) ? (I > 0 && I <= L.len ? L[I] : null) : L[I]) : null)
+#define LAZYLEN(L) length(L)
+#define LAZYCLEARLIST(L) if(L) L.Cut()


### PR DESCRIPTION
:cl: ike709
add: Ported LAZYINITLIST, UNSETEMPTY, LAZYLEN, LAZYADD, LAZYREMOVE, and LAZYACCESS to make future ports easier.
/:cl:

I added these in a PR that did a bunch of other stuff and got reverted. So now I'm just including this, and not replacing anything in the code with it yet. It's the latest from /tg/ _lists file.

What the fuck is CRLF even?