### PR TITLE
Small runtime purge

### DIFF
--- a/code/controllers/subsystem/ships.dm
+++ b/code/controllers/subsystem/ships.dm
@@ -410,6 +410,8 @@ var/global/list/ftl_weapons_consoles = list()
 		if(!C.active) return 1
 
 /datum/subsystem/ship/proc/faction2prefix(var/datum/starship/S)
+	if(!S) //Runtimes are bad
+		return "Unknown"
 	switch(check_hostilities(S.faction,"ship"))
 		if(1)
 			return "Allied"

--- a/code/datums/ship.dm
+++ b/code/datums/ship.dm
@@ -419,6 +419,7 @@ var/next_ship_id
 
 	if(!ship.flagship)
 		ship.mission_ai = new /datum/ship_ai/flee //the flagship is dead, panic!!! (or coders are dumb, in which case, panic!!!)
+		return
 
 	if(ship.flagship == "ship")
 		if(SSstarmap.in_transit && ship.target_system != SSstarmap.to_system)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -56,11 +56,11 @@
 		if(stat & BROKEN)
 			icon_state = "firex"
 			return
-
-		if(SSshuttle.emergency.mode in list(SHUTTLE_DOCKED,SHUTTLE_CALL,SHUTTLE_ENDGAME,SHUTTLE_ESCAPE))
-			add_overlay("overlay_e")
-		else
-			add_overlay("overlay_[security_level]")
+		if(SSshuttle.emergency) //Runtimes are bad
+			if(SSshuttle.emergency.mode in list(SHUTTLE_DOCKED,SHUTTLE_CALL,SHUTTLE_ENDGAME,SHUTTLE_ESCAPE))
+				add_overlay("overlay_e")
+			else
+				add_overlay("overlay_[security_level]")
 		if(detecting)
 			add_overlay("overlay_[A.fire ? "fire" : "clear"]")
 		else


### PR DESCRIPTION
Kinda brute force fixed some runtimes from the combat update.

Cannot read null.mode (firealarm.dm: 60) **//Dealt with**

Cannot read null.faction (ships.dm: 413) **//Dealt with**

Cannot read null.ftl_time (ship.dm: 429) **//Dealt with**