### PR TITLE
Changelog now opens automatically when a user hasn't seen the latest

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -230,7 +230,7 @@ NOTIFY_NEW_PLAYER_AGE 0
 #PANIC_BUNKER
 
 ## Uncomment to have the changelog file automatically open when a user connects and hasn't seen the latest changelog
-#AGGRESSIVE_CHANGELOG
+AGGRESSIVE_CHANGELOG
 
 ## Uncomment to have the game log runtimes to the log folder. (Note: this disables normal output in dd/ds, so it should be left off for testing.
 #LOG_RUNTIMES


### PR DESCRIPTION
:cl: ike709
tweak: The changelog now opens automatically when you haven't seen the latest changes. Read the damn changelog.
/:cl:

I'm tired of people saying "That's a thing now?" when I mention a feature or "Has _____ been fixed?". If they read the changelog, they'd know.

@monster860 Config change.