### PR TITLE
Moves TEG to SSair

### DIFF
--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -68,9 +68,9 @@
 		cut_overlays()
 	else
 		cut_overlays()
-
-		if(lastgenlev != 0)
-			add_overlay(image('icons/obj/power.dmi', "teg-op[lastgenlev]"))
+		var/L = min(round(lastgenlev/100000),11)
+		if(L != 0)
+			add_overlay(image('icons/obj/power.dmi', "teg-op[L]"))
 
 		add_overlay(image('icons/obj/power.dmi', "teg-oc[lastcirc]"))
 
@@ -81,8 +81,6 @@
 
 	if(!cold_circ || !hot_circ)
 		return
-
-	lastgen = 0
 
 	if(powernet)
 		//world << "cold_circ and hot_circ pass"
@@ -129,19 +127,18 @@
 		if(cold_air)
 			var/datum/gas_mixture/cold_circ_air1 = cold_circ.AIR1
 			cold_circ_air1.merge(cold_air)
+		update_icon()
 
 	var/circ = "[cold_circ && cold_circ.last_pressure_delta > 0 ? "1" : "0"][hot_circ && hot_circ.last_pressure_delta > 0 ? "1" : "0"]"
 	if(circ != lastcirc)
 		lastcirc = circ
-		update_icon()
 
 	src.updateDialog()
 	
 /obj/machinery/power/generator/process()
-	var/power_output = lastgen / 1000 //Setting this number higher just makes the change in power output slower or faster, it doesnt actualy reduce power output cause **math**
+	var/power_output = round(lastgen / 10) //Setting this number higher just makes the change in power output slower, it doesnt actualy reduce power output cause **math**
 	send_power(power_output)
-	var/genlev = max(0, min( round(11*power_output / 100000), 11))
-	lastgenlev = genlev
+	lastgenlev = power_output
 	lastgen -= power_output
 	..()
 
@@ -162,12 +159,13 @@
 		var/datum/gas_mixture/hot_circ_air2 = hot_circ.AIR2
 
 		t += "<div class='statusDisplay'>"
-		if(lastgen < 1000000) //less than a MW
-			lastgen /= 1000
-			t += "Output: [round(lastgen,0.01)] kW"
+		var/displaygen = lastgenlev
+		if(displaygen < 1000000) //less than a MW
+			displaygen /= 1000
+			t += "Output: [round(displaygen,0.01)] kW"
 		else
-			lastgen /= 1000000
-			t += "Output: [round(lastgen,0.01)] MW"
+			displaygen /= 1000000
+			t += "Output: [round(displaygen,0.01)] MW"
 
 		t += "<BR>"
 


### PR DESCRIPTION
Apparently the TEG ran on process() too. I had to do a bit more work for this one but it's tested and working.

Since power output would have issues if only run on SSair I kept just the power generation part in process. process_atmos stores power to be output by process in a delayed fashion.

:cl: ninjanomnom
tweak: TEG displays power in kw or MW now
tweak: TEG power bar only maxes over 1MW now
experiment: Moves TEG to SSair
/:cl:
