### PR TITLE
[Aetherwhisp] Atmos + bugfixes take 2

### DIFF
--- a/_maps/map_files/Aetherwhisp/Aetherwhisp.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp.dmm
@@ -2528,23 +2528,6 @@
 "fgN" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/armory)
-"fhl" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "8;22"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/secondary/exit)
 "fhN" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -3122,6 +3105,17 @@
 /area/shuttle/ftl/crew_quarters/theatre{
 	name = "Library"
 	})
+"ggN" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/bridge{
+	name = "Bridge";
+	req_one_access_txt = "42"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge)
 "ghm" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -13075,6 +13069,16 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine/plasma,
 /area/shuttle/ftl/atmos)
+"vKA" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance";
+	req_access_txt = "0";
+	req_one_access_txt = "8;22;16"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Library"
+	})
 "vLt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -16886,16 +16890,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engineering)
-"CJN" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "8;22"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Library"
-	})
 "CKi" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/glass_external{
@@ -18950,20 +18944,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/brig)
-"Gdz" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/bridge,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/bridge)
 "Ggj" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/mechanical,
@@ -20050,38 +20030,6 @@
 /obj/item/device/flashlight/lamp,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/secondary/construction)
-"HOA" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 2
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 2
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/bridge{
-	name = "Battle-Bridge"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/bridge{
-	mouse_over_pointer = 0;
-	name = "Battle Bridge"
-	})
 "HOT" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -21059,14 +21007,6 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/shuttle/ftl/atmos)
-"JRc" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/bridge,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/bridge)
 "JRz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
@@ -28395,6 +28335,23 @@
 /obj/structure/cryofeed,
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/crew_quarters/sleep)
+"VMo" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/bridge{
+	name = "Bridge";
+	req_one_access_txt = "42"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge)
 "VNv" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -28822,6 +28779,39 @@
 "WAt" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
+"WAy" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 2
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 2
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/bridge{
+	name = "Battle-Bridge";
+	req_one_access_txt = "42"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge{
+	mouse_over_pointer = 0;
+	name = "Battle Bridge"
+	})
 "WBb" = (
 /obj/machinery/airalarm{
 	pixel_y = 22
@@ -29527,6 +29517,23 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
+"XPV" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance";
+	req_access_txt = "0";
+	req_one_access_txt = "8;22;16"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/secondary/exit)
 "XRw" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -64638,9 +64645,9 @@ tHS
 tHS
 tHS
 tHS
-Gdz
+VMo
 iHA
-JRc
+ggN
 bWM
 tHS
 tHS
@@ -68515,7 +68522,7 @@ HfP
 Aky
 hZm
 tET
-HOA
+WAy
 JnI
 zZi
 Umf
@@ -72384,7 +72391,7 @@ aon
 iUz
 DxK
 cno
-fhl
+XPV
 EiW
 NDh
 PQF
@@ -73926,7 +73933,7 @@ xnd
 mrD
 vkC
 Dnn
-CJN
+vKA
 eel
 oQX
 toK

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp.dmm
@@ -13250,6 +13250,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
+"vUb" = (
+/obj/machinery/camera{
+	c_tag = "Hydroponics";
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/obj/structure/table,
+/obj/item/weapon/watertank,
+/obj/item/weapon/reagent_containers/spray/plantbgone{
+	pixel_x = 13;
+	pixel_y = 5
+	},
+/obj/item/weapon/reagent_containers/spray/plantbgone{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/item/weapon/reagent_containers/spray/plantbgone{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/green/side{
+	dir = 2
+	},
+/area/shuttle/ftl/hydroponics)
 "vUP" = (
 /obj/structure/closet/crate/engineering,
 /obj/item/stack/spacecash/c10,
@@ -14119,15 +14145,6 @@
 	},
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/ftl/medical/cmo)
-"xJN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/assembly/chargebay)
 "xKh" = (
 /obj/structure/table,
 /obj/item/weapon/folder/yellow,
@@ -14596,6 +14613,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
+"yIP" = (
+/obj/item/weapon/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/robotics)
 "yJI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -17952,10 +17973,6 @@
 "ECt" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/hallway/secondary/entry)
-"ECL" = (
-/obj/machinery/droneDispenser,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/assembly/robotics)
 "EDx" = (
 /obj/structure/chair{
 	dir = 1
@@ -19635,19 +19652,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/janitor)
-"Hom" = (
-/obj/machinery/camera{
-	c_tag = "Hydroponics";
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/obj/structure/table,
-/turf/open/floor/plasteel/green/side{
-	dir = 2
-	},
-/area/shuttle/ftl/hydroponics)
 "Hqa" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -23204,6 +23208,15 @@
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engineering)
+"NvX" = (
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/chargebay)
 "NwY" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -24138,16 +24151,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"OUC" = (
-/obj/item/weapon/twohanded/required/kirbyplants/random,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/assembly/chargebay)
 "OVU" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -28819,6 +28822,13 @@
 "WAt" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
+"WBb" = (
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
+/obj/machinery/droneDispenser,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/chargebay)
 "WBG" = (
 /obj/structure/shuttle/engine/propulsion/burst{
 	tag = "icon-propulsion (NORTH)";
@@ -70318,7 +70328,7 @@ YMY
 TSn
 QWi
 ixD
-Hom
+vUb
 Eab
 VVJ
 PQF
@@ -72064,7 +72074,7 @@ jUs
 Zjw
 sFy
 sTd
-ECL
+yIP
 lgd
 ADL
 sBi
@@ -75146,7 +75156,7 @@ toK
 NVL
 igH
 igH
-xJN
+NvX
 Lfb
 Lfb
 Lfb
@@ -75403,7 +75413,7 @@ toK
 toK
 toK
 igH
-OUC
+WBb
 Bww
 ciA
 LQJ

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp.dmm
@@ -6,24 +6,19 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"acx" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	device_type = null;
-	id = "shuttle1";
-	name = "ORM Shutter Control";
-	pixel_x = -24;
-	pixel_y = 6
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/obj/machinery/light_switch{
-	pixel_x = -22;
-	pixel_y = -10
+"adh" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6;
+	icon_state = "intact"
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
+/area/shuttle/ftl/atmos)
+"aeg" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "aeQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -131,20 +126,6 @@
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"aoB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "apk" = (
 /obj/structure/table,
 /obj/item/weapon/paper_bin{
@@ -161,6 +142,26 @@
 /obj/item/weapon/pen,
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
+"apU" = (
+/obj/structure/closet/secure_closet/security,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 0;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig{
+	name = "Departures Checkpoint"
+	})
 "aqE" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/structure/extinguisher_cabinet{
@@ -208,25 +209,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"axe" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/research{
-	name = "Science Department";
-	req_access_txt = "18;26";
-	req_one_access_txt = "0"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/lab)
 "axr" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -239,13 +221,6 @@
 /obj/machinery/computer/station_alert,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/chiefs_office)
-"azp" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 1
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "aAN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -320,6 +295,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
+"aBj" = (
+/obj/machinery/camera{
+	c_tag = "Teleporter Room";
+	dir = 4
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/structure/frame/computer,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge/meeting_room{
+	name = "Teleporter"
+	})
 "aCy" = (
 /obj/structure/table/wood,
 /obj/item/device/radio/intercom,
@@ -327,43 +318,21 @@
 /area/shuttle/ftl/crew_quarters/theatre{
 	name = "Library"
 	})
-"aDl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 8
+"aDx" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"aEe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/cargo)
-"aED" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
-	},
-/turf/closed/wall,
-/area/shuttle/ftl/hallway/secondary/exit)
-"aIf" = (
 /obj/structure/cable{
 	crit_fail = 0;
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/closed/wall,
-/area/shuttle/ftl/maintenance/engineering)
-"aKT" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/engineering)
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "aLF" = (
 /obj/machinery/light{
 	dir = 2
@@ -380,6 +349,16 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/chiefs_office)
+"aNq" = (
+/obj/machinery/computer/robotics,
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/hor)
 "aOe" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_medical{
@@ -433,30 +412,10 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/telecomms/computer)
-"aUg" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8;
-	initialize_directions = 11
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "aUC" = (
 /obj/machinery/computer/upload/ai,
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
-"aVU" = (
-/obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
-/obj/machinery/meter,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"aWV" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/clothing/shoes/magboots,
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/engineering)
 "aWW" = (
 /obj/structure/table,
 /obj/item/weapon/paper_bin{
@@ -470,19 +429,6 @@
 /obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
-"aXt" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 2;
-	icon_state = "manifold";
-	tag = "icon-manifold (EAST)"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "aZM" = (
 /obj/machinery/ammo_rack/full/shield_piercing,
 /turf/open/floor/plasteel/darkwarning/side{
@@ -569,32 +515,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/surgery)
-"bfB" = (
-/obj/structure/table,
-/obj/item/weapon/tank/internals/emergency_oxygen{
-	pixel_x = -8;
-	pixel_y = 0
-	},
-/obj/item/weapon/tank/internals/emergency_oxygen{
-	pixel_x = -8;
-	pixel_y = 0
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = 4;
-	pixel_y = 0
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = 4;
-	pixel_y = 0
-	},
-/obj/item/weapon/electronics/airlock{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/weapon/electronics/airlock,
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "bgM" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -635,6 +555,26 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
+"bir" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/cargo/office)
+"biM" = (
+/obj/machinery/camera{
+	c_tag = "R&D Server Room";
+	name = "security camera";
+	network = list("SS13","RD")
+	},
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/research/server)
 "biT" = (
 /obj/structure/sign/securearea{
 	pixel_x = -32
@@ -647,19 +587,14 @@
 /obj/machinery/hologram/holopad,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
-"bkf" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+"bnY" = (
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/weapon/crowbar/large,
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
+/area/shuttle/ftl/engine/tool_storage)
 "bpf" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/heads)
@@ -679,18 +614,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
-"bqu" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "bqI" = (
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/office)
@@ -715,21 +638,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/tool_storage)
-"buf" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/chair/office{
-	dir = 2
-	},
-/obj/effect/landmark/start{
-	name = "Ship Engineer";
-	shuttle_abstract_movable = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engineering)
 "bup" = (
 /obj/machinery/power/smes{
 	charge = 500000
@@ -748,12 +656,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"bux" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 8
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "buB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -770,16 +672,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
-"bzT" = (
-/obj/machinery/space_heater,
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
-	},
+"bvN" = (
 /turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
+/area/shuttle/ftl/maintenance/medbay)
 "bAk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
@@ -801,6 +696,16 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/chiefs_office)
+"bBi" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Atmospheric Technician";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "bBp" = (
 /obj/item/weapon/storage/pod{
 	pixel_x = 32
@@ -854,6 +759,14 @@
 /obj/machinery/computer/station_alert,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"bHR" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/ai_status_display{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "bIb" = (
 /obj/machinery/computer/telecomms/server{
 	network = "tcommsat"
@@ -887,10 +800,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"bMe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
+"bLV" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"bNf" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/medical/medbay)
 "bNN" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -961,13 +883,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"bXN" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/hologram/holopad,
-/turf/open/floor/plasteel/bar,
-/area/shuttle/ftl/crew_quarters/bar)
 "bYj" = (
 /obj/machinery/computer/munitions_console,
 /obj/machinery/firealarm{
@@ -990,15 +905,6 @@
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
-"bZp" = (
-/obj/machinery/camera/motion{
-	c_tag = "AI Chamber External";
-	dir = 2;
-	network = list("SS13","MiniSat");
-	pixel_y = 0
-	},
-/turf/open/space,
-/area/shuttle/ftl/space)
 "can" = (
 /obj/structure/chair/comfy{
 	dir = 1
@@ -1022,6 +928,38 @@
 /obj/structure/filingcabinet/chestdrawer/wheeled,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
+"cco" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = 22
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
+"cdg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Starboard Airlock"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
 "chS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -1124,11 +1062,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/exit)
-"ctE" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "cuj" = (
 /obj/structure/filingcabinet,
 /obj/machinery/camera{
@@ -1149,13 +1082,6 @@
 /obj/machinery/computer/pandemic,
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/virology)
-"czb" = (
-/turf/open/floor/plating/warnplate/side{
-	tag = "icon-plating_warn_side (EAST)";
-	icon_state = "plating_warn_side";
-	dir = 4
-	},
-/area/shuttle/ftl/munitions)
 "cAz" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1203,27 +1129,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/nuke_storage)
-"cGO" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/bar)
-"cIw" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/secondary/exit)
 "cKD" = (
 /obj/machinery/light{
 	dir = 4
@@ -1241,6 +1146,12 @@
 	dir = 4
 	},
 /area/shuttle/ftl/hydroponics)
+"cLA" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "cOi" = (
 /turf/closed/wall/shuttle{
 	icon_state = "swall8";
@@ -1274,6 +1185,16 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/cargo/mining)
+"cTP" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 1;
+	filter_type = "plasma";
+	icon_state = "filter_off";
+	on = 1;
+	tag = "icon-filter_off (WEST)"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "cUX" = (
 /obj/structure/chair{
 	dir = 1
@@ -1293,6 +1214,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"cVL" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Engine North";
+	dir = 6;
+	network = list("SS13","Supermatter")
+	},
+/obj/structure/table,
+/obj/item/weapon/storage/firstaid/fire,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8;
+	icon_state = "intact";
+	tag = "icon-intact (NORTH)"
+	},
+/obj/item/device/multitool,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
 "cWs" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2
@@ -1364,30 +1304,11 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
-"cXQ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	tag = "icon-pump_map (NORTH)";
-	icon_state = "pump_map";
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "cZg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"cZz" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/escape{
-	dir = 9
-	},
-/area/shuttle/ftl/atmos)
 "daz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 2
@@ -1403,13 +1324,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"dbN" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip{
-	density = 0
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "dcv" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/emergency,
@@ -1467,6 +1381,11 @@
 	dir = 4
 	},
 /area/shuttle/ftl/hydroponics)
+"diw" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/medbay)
 "dix" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/bar,
@@ -1529,32 +1448,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"dqL" = (
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/obj/structure/table,
-/obj/item/weapon/folder/blue,
-/obj/item/weapon/pen,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/break_room)
 "drw" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
@@ -1579,31 +1472,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"dsn" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "dtp" = (
 /turf/closed/wall/shuttle{
 	dir = 2;
@@ -1735,28 +1603,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/entry)
-"dBf" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
+"dzE" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/item/weapon/restraints/handcuffs,
+/obj/item/device/taperecorder{
+	pixel_x = 4;
 	pixel_y = 0
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "engineering security door"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 25
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access_txt = "15"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig{
+	name = "Departures Checkpoint"
+	})
+"dEa" = (
+/obj/structure/table/wood,
+/obj/item/device/flashlight/lamp,
+/obj/item/weapon/gun/projectile/revolver/russian,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "dFN" = (
 /obj/effect/landmark/start{
 	name = "Janitor";
@@ -1767,10 +1636,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/janitor)
-"dHu" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "dJZ" = (
 /obj/machinery/button/door{
 	id = "brig_enter_shutters";
@@ -1793,6 +1658,25 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
+"dML" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/research{
+	name = "Science Department";
+	req_access_txt = "0";
+	req_one_access_txt = "18;26"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/lab)
 "dNN" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 4
@@ -1822,6 +1706,20 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
+"dPj" = (
+/obj/machinery/light_switch{
+	pixel_x = -8;
+	pixel_y = -22
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"dRi" = (
+/obj/machinery/hologram/holopad,
+/turf/open/floor/plasteel/bar,
+/area/shuttle/ftl/crew_quarters/bar)
 "dRq" = (
 /obj/machinery/door/airlock{
 	name = "Unit 2"
@@ -1924,21 +1822,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/toilet)
-"dYW" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/engineering)
 "dZA" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -1965,16 +1848,15 @@
 "eaI" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/telecomms/server)
-"eaT" = (
-/obj/structure/chair/office{
+"eaR" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 2
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/bar,
-/area/shuttle/ftl/crew_quarters/bar)
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "ebR" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -1999,6 +1881,18 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
+"eee" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/device/radio/intercom{
+	pixel_x = -32
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Monitoring";
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/scrubber/huge,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "eel" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
@@ -2013,37 +1907,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"egI" = (
-/obj/structure/table,
-/obj/item/weapon/book/manual/wiki/security_space_law{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/item/weapon/storage/toolbox/emergency,
-/obj/item/device/radio/intercom{
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "egP" = (
 /turf/open/floor/plasteel/bot,
 /area/shuttle/ftl/assembly/robotics)
-"ehJ" = (
-/obj/structure/chair/office{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/bar)
 "eio" = (
 /obj/machinery/requests_console{
 	department = "Virology";
@@ -2062,17 +1928,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"eje" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start{
-	name = "Atmospheric Technician";
-	shuttle_abstract_movable = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "elB" = (
 /obj/structure/toilet{
 	dir = 4
@@ -2197,6 +2052,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
+"erH" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/ai_status_display{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
 "eto" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2308,6 +2174,35 @@
 "exG" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/bridge/eva)
+"eyr" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Conference Room Access";
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = -8;
+	pixel_y = 24
+	},
+/obj/structure/chair{
+	dir = 2
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge)
 "eyT" = (
 /obj/structure/table/wood,
 /obj/item/weapon/reagent_containers/food/snacks/beans,
@@ -2399,14 +2294,19 @@
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/telecomms/server)
-"eFb" = (
-/obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/machinery/portable_atmospherics/scrubber,
+"eFT" = (
+/obj/structure/chair,
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig{
+	name = "Departures Checkpoint"
+	})
 "eHf" = (
 /obj/structure/cryofeed/right,
 /obj/machinery/light{
@@ -2454,15 +2354,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/meeting_room)
-"eJB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "eLk" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp,
@@ -2563,17 +2454,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"eYb" = (
-/obj/machinery/mac_barrel{
-	dir = 4;
-	id = "weapon_k_1"
-	},
-/turf/open/floor/plating/warnplate/side{
-	tag = "icon-plating_warn_side (EAST)";
-	icon_state = "plating_warn_side";
-	dir = 4
-	},
-/area/shuttle/ftl/munitions)
 "eZf" = (
 /obj/structure/table,
 /obj/item/weapon/paper_bin,
@@ -2593,16 +2473,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/secondary/construction)
-"fbq" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 4;
-	filter_type = "o2";
-	icon_state = "filter_off";
-	on = 1;
-	tag = "icon-filter_off (EAST)"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "fbV" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engineering)
@@ -2795,19 +2665,6 @@
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/office)
-"fnU" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	tag = "icon-pump_map (NORTH)";
-	icon_state = "pump_map";
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "fnY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/power/apc/priority{
@@ -2831,6 +2688,9 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
+"fnZ" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/hallway/secondary/exit)
 "fpo" = (
 /obj/structure/window/reinforced{
 	dir = 2
@@ -2852,45 +2712,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/secondary/construction)
-"fqC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"frH" = (
-/obj/item/clothing/head/hardhat/cakehat,
-/obj/structure/closet/crate,
-/obj/item/clothing/shoes/sandal,
-/obj/item/weapon/card/id{
-	desc = "A plastic card with a sticker.";
-	icon_state = "gold";
-	name = "captain's spare ID";
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/weapon/card/id{
-	desc = "A plastic card with a sticker.";
-	icon_state = "emag";
-	name = "cryptographic sequencer";
-	pixel_x = 2
-	},
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 4;
-	name = "4maintenance loot spawner"
-	},
-/obj/item/weapon/storage/pill_bottle/dice,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/item/weapon/paint/blue,
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "fsy" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -2967,6 +2788,26 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/brig)
+"fBa" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/hor)
 "fBi" = (
 /obj/structure/chair{
 	dir = 1
@@ -2984,6 +2825,10 @@
 /obj/machinery/hologram/holopad,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
+"fDb" = (
+/obj/item/weapon/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "fDo" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -3009,6 +2854,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"fHO" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
 "fIK" = (
 /obj/structure/table,
 /obj/item/device/camera,
@@ -3016,6 +2870,18 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/cargo/mining)
+"fIU" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 5
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "fJA" = (
 /obj/machinery/light{
 	dir = 4
@@ -3041,6 +2907,23 @@
 /obj/item/weapon/storage/belt/utility,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/tool_storage)
+"fLT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = -8;
+	pixel_y = 22
+	},
+/obj/machinery/button/door{
+	device_type = null;
+	id = "shuttle1";
+	name = "ORM Shutter Control";
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "fLW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3075,15 +2958,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/entry)
-"fQk" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/turret_protected/ai)
 "fRJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -3201,6 +3075,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"gec" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "gfk" = (
 /turf/open/space,
 /turf/closed/wall/shuttle{
@@ -3208,6 +3094,21 @@
 	dir = 2
 	},
 /area/shuttle/ftl/subshuttle/pod_3)
+"gfB" = (
+/obj/structure/table,
+/obj/item/weapon/book/manual/wiki/security_space_law{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig{
+	name = "Departures Checkpoint"
+	})
 "gfO" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3288,13 +3189,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/entry)
-"glJ" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "glW" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -3397,6 +3291,18 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
+"gqJ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rd_shutters"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/hor)
 "grd" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3501,6 +3407,13 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/brig)
+"gyc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/atmos/equipment)
 "gye" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -3519,32 +3432,25 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/heads)
+"gzb" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "gzo" = (
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/bar)
-"gzA" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/button/door{
-	id = "starboard_external";
-	name = "Emergency Airlock Control";
-	pixel_x = -24;
-	pixel_y = -6;
-	req_access_txt = "0"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "gAB" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"gCK" = (
+/obj/effect/landmark/start{
+	name = "Bartender";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plasteel/bar,
+/area/shuttle/ftl/crew_quarters/bar)
 "gEa" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -3556,6 +3462,32 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/armory)
+"gEP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/atmos/equipment)
+"gFK" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	dir = 2;
+	icon_state = "manifold";
+	tag = "icon-manifold (EAST)"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "gGh" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -3611,13 +3543,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
-"gJx" = (
-/obj/machinery/computer/robotics,
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/hor)
 "gKx" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3653,12 +3578,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/secondary/construction)
-"gLv" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "gMi" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/metal/fifty,
@@ -3698,24 +3617,6 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engineering)
-"gOK" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"gPs" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/cargo)
 "gQg" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -3732,13 +3633,6 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/bar)
-"gQS" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engineering)
 "gRO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -3746,6 +3640,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"gSo" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "CO2 to Pure";
+	on = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "gSs" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3781,6 +3684,35 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/ftl/subshuttle/pod_1)
+"gTz" = (
+/obj/machinery/r_n_d/server/core,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/machinery/door/window/northright{
+	dir = 8;
+	name = "Server Room";
+	req_access_txt = "19"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/bluegrid{
+	name = "Server Base";
+	initial_gas_mix = "n2=500;TEMP=80"
+	},
+/area/shuttle/ftl/research/server)
+"gUe" = (
+/obj/machinery/meter,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 2;
+	initialize_directions = 11
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "gVb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -3844,6 +3776,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engineering)
+"gXQ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "gXV" = (
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3855,29 +3793,6 @@
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/virology)
-"gYc" = (
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip{
-	density = 0
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"gYv" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start{
-	name = "Lawyer"
-	},
-/turf/open/floor/plasteel/bar,
-/area/shuttle/ftl/crew_quarters/bar)
 "gYN" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -3898,28 +3813,6 @@
 /area/shuttle/ftl/crew_quarters/theatre{
 	name = "Library"
 	})
-"gZU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1;
-	external_pressure_bound = 0;
-	frequency = 1441;
-	id_tag = "n2_out";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	on = 1;
-	pressure_checks = 2;
-	pump_direction = 0
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/engine/n2,
-/area/shuttle/ftl/atmos)
 "hab" = (
 /obj/machinery/power/apc/priority{
 	auto_name = 1;
@@ -3933,6 +3826,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/locker)
+"haA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel/bar,
+/area/shuttle/ftl/crew_quarters/bar)
 "hdd" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/black,
@@ -3979,14 +3890,6 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"hhX" = (
-/obj/machinery/camera{
-	c_tag = "Aft Starboard External";
-	dir = 9
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/shuttle/ftl/space)
 "hjd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -4050,10 +3953,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/hos)
-"hnt" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/plasteel/bot,
-/area/shuttle/ftl/atmos)
 "hny" = (
 /turf/closed/wall,
 /area/shuttle/ftl/hallway/primary/port)
@@ -4097,6 +3996,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
+"hpK" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/machinery/power/apc/priority{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	dir = 1;
+	icon_state = "manifold";
+	tag = "icon-manifold (EAST)"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "hqW" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -4117,6 +4035,12 @@
 	dir = 1
 	},
 /area/shuttle/ftl/engine/break_room)
+"hrD" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "hrU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light_switch{
@@ -4162,14 +4086,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
-"hvU" = (
-/obj/machinery/meter,
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plasteel/red/side{
-	dir = 6
-	},
-/area/shuttle/ftl/atmos)
 "hwm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4201,13 +4117,6 @@
 /area/shuttle/ftl/bridge/meeting_room{
 	name = "Teleporter"
 	})
-"hyg" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 1
-	},
-/turf/open/floor/plasteel/bar,
-/area/shuttle/ftl/crew_quarters/bar)
 "hzw" = (
 /turf/closed/wall/shuttle{
 	icon_state = "swall1"
@@ -4225,13 +4134,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/armory)
-"hAY" = (
-/obj/structure/closet/boxinggloves,
-/obj/structure/closet/secure_closet/personal,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/shoes/winterboots,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/locker)
 "hBd" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4351,6 +4253,16 @@
 /area/shuttle/ftl/crew_quarters/theatre{
 	name = "Library"
 	})
+"hIs" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Air to Pure"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "hJg" = (
 /obj/structure/disposaloutlet{
 	dir = 2;
@@ -4376,12 +4288,6 @@
 	},
 /turf/open/floor/plasteel/warning/side,
 /area/shuttle/ftl/research/xenobiology)
-"hNG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "hPA" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -4392,6 +4298,31 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/medbay)
+"hQj" = (
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	dir = 4;
+	external_pressure_bound = 0;
+	frequency = 1441;
+	icon_state = "vent_map";
+	id_tag = "air_out";
+	internal_pressure_bound = 2000;
+	on = 1;
+	pressure_checks = 2;
+	pump_direction = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/engine/air,
+/area/shuttle/ftl/atmos)
+"hRo" = (
+/obj/structure/shuttle/engine/propulsion{
+	icon_state = "propulsion";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/engineering)
 "hRt" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4437,26 +4368,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/brig)
-"hUG" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/break_room)
 "hUM" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/machine/mac_barrel{
@@ -4475,12 +4386,18 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
-"hVq" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+"hXm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/mining)
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/medical/medbay)
+"hYr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/atmos/equipment)
 "hYt" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -4521,44 +4438,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"ibs" = (
+"icq" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
+	crit_fail = 0;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"ibU" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"idr" = (
-/obj/structure/table/wood,
-/obj/item/device/camera,
-/obj/item/weapon/folder/red{
-	pixel_x = 3
-	},
-/obj/item/weapon/folder/blue{
-	pixel_x = -2;
-	pixel_y = 3
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Library"
-	})
+/turf/open/space,
+/area/shuttle/ftl/space)
 "idx" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/mining)
@@ -4603,14 +4495,9 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/space)
-"igk" = (
-/obj/machinery/meter,
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plasteel/red/side{
-	dir = 10
-	},
-/area/shuttle/ftl/atmos)
+"igH" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/assembly/chargebay)
 "ijO" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -4620,6 +4507,13 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions/cannon)
+"iky" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "ilt" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -4632,6 +4526,15 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
+"ilu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Starboard Airlock"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
 "ilA" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -4657,13 +4560,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"inE" = (
-/obj/structure/closet/firecloset/full,
-/obj/structure/sign/poster{
-	pixel_x = -32
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "ioo" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -4684,23 +4580,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/break_room)
-"irB" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "atmos blast door"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/turf/open/floor/plasteel/delivery{
-	name = "floor"
-	},
-/area/shuttle/ftl/atmos)
 "irF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
@@ -4762,9 +4641,40 @@
 	},
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
+"iuL" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "hydrogen_sensor"
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/engine,
+/area/shuttle/ftl/atmos)
 "ixD" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
+"iyL" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6;
+	icon_state = "intact"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/computer/atmos_control/tank{
+	frequency = 1441;
+	input_tag = "o2_in";
+	name = "Oxygen Supply Control";
+	output_tag = "o2_out";
+	sensors = list("o2_sensor" = "Tank")
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "izw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4829,6 +4739,28 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
+"iEY" = (
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"iGm" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering{
+	name = "FTL and Shield Generator";
+	req_access_txt = "0";
+	req_one_access_txt = "7;15"
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "iGq" = (
 /obj/machinery/door/airlock/glass_virology{
 	name = "Isolation A";
@@ -4839,16 +4771,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/virology)
-"iHu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"iGv" = (
+/obj/item/weapon/storage/box/lights/mixed{
+	pixel_x = 2;
+	pixel_y = 2
 	},
-/obj/machinery/ai_status_display{
-	pixel_x = 0;
-	pixel_y = 32
-	},
+/obj/structure/table,
+/obj/item/weapon/storage/box/donkpockets,
+/obj/item/weapon/reagent_containers/food/snacks/cakeslice/plain,
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
+/area/shuttle/ftl/cargo/mining)
 "iHA" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -4874,6 +4806,22 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/sleep)
+"iIx" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Botanist";
+	shuttle_abstract_movable = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hydroponics)
 "iIB" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -4909,6 +4857,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/locker)
+"iJZ" = (
+/obj/structure/table,
+/obj/item/weapon/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/weapon/folder/red,
+/obj/item/weapon/pen,
+/obj/machinery/camera{
+	c_tag = "Departures Checkpoint";
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_x = -8;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig{
+	name = "Departures Checkpoint"
+	})
 "iKN" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -4920,34 +4888,30 @@
 	dir = 1
 	},
 /area/shuttle/ftl/engine/engineering)
-"iOd" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 4;
-	name = "4maintenance loot spawner"
+"iPP" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"iPl" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 2;
-	frequency = 1441;
-	id = "n2o_in";
-	pixel_y = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/engine/n2o,
-/area/shuttle/ftl/atmos)
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
 "iQM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 2
@@ -4966,15 +4930,39 @@
 	dir = 2
 	},
 /area/shuttle/ftl/subshuttle/pod_2)
-"iSH" = (
-/obj/machinery/door/airlock/glass{
-	name = "Starboard Airlock"
+"iRQ" = (
+/obj/item/clothing/head/hardhat/cakehat,
+/obj/structure/closet/crate,
+/obj/item/clothing/shoes/sandal,
+/obj/item/weapon/card/id{
+	desc = "A plastic card with a sticker.";
+	icon_state = "gold";
+	name = "captain's spare ID";
+	pixel_x = -4;
+	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/item/weapon/card/id{
+	desc = "A plastic card with a sticker.";
+	icon_state = "emag";
+	name = "cryptographic sequencer";
+	pixel_x = 2
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 4;
+	name = "4maintenance loot spawner"
+	},
+/obj/item/weapon/storage/pill_bottle/dice,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/item/weapon/paint/blue,
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "iSN" = (
 /obj/machinery/power/apc/priority{
 	auto_name = 1;
@@ -5019,6 +5007,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/chargebay)
+"iWC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "iXd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/firealarm{
@@ -5064,6 +5058,20 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/captain)
+"iYB" = (
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
+/obj/machinery/computer/rdservercontrol,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/hor)
+"iYI" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/item/weapon/reagent_containers/food/snacks/beans,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
 "iZx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -5079,6 +5087,12 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
+"jag" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "jcc" = (
 /obj/machinery/autolathe,
 /obj/machinery/ai_status_display{
@@ -5109,25 +5123,21 @@
 	},
 /turf/open/floor/plasteel/darkwarning,
 /area/shuttle/ftl/munitions)
-"jmJ" = (
-/obj/machinery/power/apc/priority{
-	auto_name = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
+"jmr" = (
 /obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
 	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/engineering)
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "jnP" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -5211,6 +5221,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"jub" = (
+/obj/machinery/computer/atmos_control/tank{
+	frequency = 1441;
+	input_tag = "mix_in";
+	name = "Gas Mix Tank Control";
+	output_tag = "mix_out";
+	sensors = list("mix_sensor" = "Tank")
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "jul" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5274,17 +5303,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/brig)
-"jCj" = (
-/obj/structure/chair,
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "jDl" = (
 /obj/structure/table,
 /obj/item/weapon/paper_bin,
@@ -5297,6 +5315,29 @@
 /obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
+"jDU" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"jEs" = (
+/obj/structure/chair/office/dark{
+	dir = 2
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig{
+	name = "Departures Checkpoint"
+	})
 "jFY" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -5383,6 +5424,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
+"jMK" = (
+/obj/machinery/mac_barrel{
+	dir = 4;
+	id = "weapon_k_1"
+	},
+/turf/open/floor/plasteel/darkwarning{
+	dir = 2
+	},
+/area/shuttle/ftl/munitions)
 "jOj" = (
 /obj/machinery/door/airlock/shuttle,
 /obj/structure/cable{
@@ -5412,13 +5462,6 @@
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/telecomms/server)
-"jPK" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	icon_state = "intact";
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "jQk" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -5567,6 +5610,10 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/telecomms/server)
+"jUJ" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plating,
+/area/shuttle/ftl/atmos/equipment)
 "jWr" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -5615,10 +5662,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/toilet)
-"kaG" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "kbF" = (
 /turf/open/space,
 /turf/closed/wall/shuttle{
@@ -5766,6 +5809,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
+"knu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/munitions)
 "kok" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -5874,30 +5923,6 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
-"kxr" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
 "kxt" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -5962,36 +5987,10 @@
 /obj/machinery/hologram/holopad,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/locker)
-"kCU" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"kDL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/engineering)
+"kDr" = (
+/obj/machinery/suit_storage_unit/atmos,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "kFZ" = (
 /obj/structure/closet/l3closet,
 /obj/machinery/firealarm{
@@ -6000,15 +5999,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"kGi" = (
-/obj/machinery/teleport/hub,
-/obj/machinery/newscaster{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/bridge/meeting_room{
-	name = "Teleporter"
-	})
 "kHA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_mining{
@@ -6053,6 +6043,18 @@
 /obj/item/weapon/pen,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
+"kLL" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/turret_protected/ai)
 "kNk" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/regular,
@@ -6161,19 +6163,6 @@
 	},
 /turf/open/floor/plasteel/bot,
 /area/shuttle/ftl/cargo/mining)
-"kTF" = (
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/bar)
 "kTO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -6210,6 +6199,14 @@
 "kWH" = (
 /turf/closed/wall,
 /area/shuttle/ftl/janitor)
+"kWU" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/atmos/equipment)
 "kXE" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/machinery/light{
@@ -6259,26 +6256,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"lav" = (
-/obj/effect/landmark/start{
-	name = "Assistant"
+"kZN" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
+/area/shuttle/ftl/atmos/equipment)
 "lbp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/secondary/exit)
-"lbL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/exit)
 "leS" = (
@@ -6331,16 +6327,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions/cannon)
-"lhw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/engineering)
-"lio" = (
-/obj/machinery/computer/security,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "llm" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
@@ -6367,6 +6353,21 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/cargo/mining)
+"lss" = (
+/obj/structure/table/wood,
+/obj/machinery/recharger,
+/obj/item/weapon/hand_tele,
+/obj/item/weapon/melee/chainofcommand,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/captain)
+"ltb" = (
+/obj/structure/table/wood,
+/obj/item/weapon/reagent_containers/food/snacks/cakeslice/plain,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "ltI" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -6501,34 +6502,12 @@
 	},
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/ftl/medical/cmo)
-"lDb" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	tag = "icon-dvalve_map (EAST)";
-	icon_state = "dvalve_map";
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/engineering)
 "lDx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"lEL" = (
-/obj/structure/table/glass,
-/obj/item/device/aicard,
-/obj/item/device/taperecorder{
-	pixel_x = -3
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/hor)
 "lFd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
@@ -6551,16 +6530,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"lGt" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
 "lJL" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable{
@@ -6596,18 +6565,28 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
-"lLE" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
+"lKO" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
+"lKP" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"lMJ" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6;
-	initialize_directions = 6
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
+"lLE" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
 "lNb" = (
@@ -6629,11 +6608,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"lNc" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "lOc" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/bridge{
@@ -6686,6 +6660,15 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/crew_quarters/heads)
+"lQD" = (
+/obj/machinery/door/poddoor{
+	id = "weapon_k_1";
+	name = "munitions launcher bay door"
+	},
+/turf/open/floor/plasteel/darkwarning{
+	dir = 2
+	},
+/area/shuttle/ftl/munitions)
 "lRW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -6746,6 +6729,22 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/armory)
+"lVS" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics South";
+	dir = 1
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "lWK" = (
 /obj/structure/table,
 /obj/item/weapon/paper_bin{
@@ -6787,21 +6786,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"lYY" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"lZi" = (
-/obj/item/weapon/reagent_containers/food/snacks/beans,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/bar)
 "lZl" = (
 /obj/structure/table/optable,
 /obj/structure/window/reinforced{
@@ -6828,21 +6812,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"mbZ" = (
+"mbw" = (
+/obj/machinery/meter,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+	dir = 4
 	},
-/obj/machinery/computer/atmos_control/tank{
-	frequency = 1441;
-	input_tag = "co2_in";
-	name = "Carbon Dioxide Supply Control";
-	output_tag = "co2_out";
-	sensors = list("co2_sensor" = "Tank")
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 2
 	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 1
-	},
+/turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
 "mca" = (
 /obj/machinery/computer/cargo,
@@ -6855,15 +6833,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"mex" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+"mcC" = (
+/obj/effect/landmark/start{
+	name = "Ship Engineer";
+	shuttle_abstract_movable = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair/office/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
+/area/shuttle/ftl/engine/break_room)
+"mcQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
+	},
+/obj/machinery/camera{
+	busy = 0;
+	c_tag = "Atmospherics North";
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "mfV" = (
 /obj/item/ammo_box/magazine/wt550m9/wtap{
 	pixel_x = 8;
@@ -6929,14 +6920,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
-"mhq" = (
-/obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/structure/sign/poster{
-	pixel_y = 32
+"miT" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8;
+	frequency = 1441;
+	id = "mix_in";
+	pixel_y = 1
+	},
+/turf/open/floor/engine/vacuum,
+/area/shuttle/ftl/atmos)
 "mjX" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -7001,16 +6997,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/break_room)
-"mnr" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
-	},
-/turf/closed/wall,
-/area/shuttle/ftl/hallway/secondary/entry)
 "mnA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -7056,6 +7042,19 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
+"mqo" = (
+/obj/machinery/computer/aifixer,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/hor)
 "mqD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -7103,6 +7102,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
+"mrT" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = "90Curve"
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/circuit,
+/area/shuttle/ftl/turret_protected/ai)
 "msG" = (
 /obj/structure/table/wood,
 /obj/item/weapon/storage/box/evidence,
@@ -7112,6 +7130,17 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
+"msW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"mtb" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plating,
+/area/shuttle/ftl/atmos/equipment)
 "mtt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	external_pressure_bound = 100;
@@ -7154,12 +7183,6 @@
 	},
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/ftl/medical/cmo)
-"mwb" = (
-/obj/item/chair{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "mwT" = (
 /obj/machinery/bluespace_beacon,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
@@ -7169,6 +7192,12 @@
 /area/shuttle/ftl/bridge/meeting_room{
 	name = "Teleporter"
 	})
+"mxi" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "mxR" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/storage)
@@ -7255,34 +7284,6 @@
 "mBU" = (
 /turf/open/floor/engine,
 /area/shuttle/ftl/munitions)
-"mCe" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/engineering)
-"mDY" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Atmospherics Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "15"
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/atmos)
 "mEC" = (
 /obj/machinery/status_display{
 	density = 0;
@@ -7310,13 +7311,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/virology)
-"mHn" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	icon_state = "intact";
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "mIw" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/nuke_storage)
@@ -7352,17 +7346,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"mKw" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/warning{
-	dir = 5
-	},
-/area/shuttle/ftl/atmos)
 "mKW" = (
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
@@ -7370,28 +7353,6 @@
 "mLl" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"mLG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 2;
-	external_pressure_bound = 0;
-	frequency = 1441;
-	id_tag = "tox_out";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	on = 1;
-	pressure_checks = 2;
-	pump_direction = 0
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/engine/plasma,
-/area/shuttle/ftl/atmos)
 "mLZ" = (
 /obj/machinery/ai_status_display{
 	pixel_x = -32;
@@ -7420,6 +7381,35 @@
 /obj/vehicle/janicart,
 /turf/open/floor/plating,
 /area/shuttle/ftl/janitor)
+"mNn" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 1;
+	icon_state = "intact"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"mOO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel/bar,
+/area/shuttle/ftl/crew_quarters/bar)
 "mQi" = (
 /obj/item/device/radio/beacon,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
@@ -7459,16 +7449,6 @@
 	},
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/ftl/medical/cmo)
-"mUr" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/shuttle/ftl/space)
 "mVc" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -7516,20 +7496,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
-"mWb" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/machinery/camera{
-	c_tag = "Mining Shuttle Storage";
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/mining)
 "mWl" = (
 /turf/open/space,
 /turf/closed/wall/shuttle{
@@ -7555,33 +7521,35 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/storage)
-"mZJ" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+"mZS" = (
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/computer/atmos_control/tank{
-	frequency = 1441;
-	input_tag = "n2o_in";
-	name = "Nitrous Oxide Supply Control";
-	output_tag = "n2o_out";
-	sensors = list("n2o_sensor" = "Tank")
+/obj/structure/table,
+/obj/item/weapon/tank/internals/emergency_oxygen{
+	pixel_x = -8;
+	pixel_y = 0
 	},
-/turf/open/floor/plasteel/escape{
-	dir = 1
+/obj/item/weapon/tank/internals/emergency_oxygen{
+	pixel_x = -8;
+	pixel_y = 0
 	},
-/area/shuttle/ftl/atmos)
-"nal" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 4;
-	icon_state = "mixer_off";
-	node1_concentration = 0.8;
-	node2_concentration = 0.2;
-	on = 1;
-	tag = "icon-mixer_off (EAST)"
+/obj/item/clothing/mask/breath{
+	pixel_x = 4;
+	pixel_y = 0
 	},
+/obj/item/clothing/mask/breath{
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/obj/item/weapon/electronics/airlock{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/electronics/airlock,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
+/area/shuttle/ftl/atmos/equipment)
 "naO" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Locker Room Maintenance";
@@ -7628,20 +7596,6 @@
 /obj/item/weapon/reagent_containers/syringe,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/main)
-"ncy" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
 "ndI" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	filter_type = "n2";
@@ -7673,6 +7627,17 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/brig)
+"ngw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table,
+/obj/item/device/multitool,
+/obj/item/device/radio,
+/obj/item/weapon/electronics/airlock{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "ngy" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -7720,17 +7685,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"nkT" = (
-/obj/structure/window/reinforced,
-/obj/machinery/computer/atmos_control/tank{
-	frequency = 1441;
-	input_tag = "air_in";
-	name = "Mixed Air Supply Control";
-	output_tag = "air_out";
-	sensors = list("air_sensor" = "Tank")
-	},
-/turf/open/floor/plasteel/arrival,
-/area/shuttle/ftl/atmos)
 "nll" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -7768,29 +7722,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engineering)
-"noc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/structure/sign/poster{
-	pixel_x = -32
-	},
-/mob/living/simple_animal/mouse,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"npj" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1;
-	frequency = 1441;
-	id = "n2_in"
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/engine/n2,
-/area/shuttle/ftl/atmos)
 "nqr" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -7810,6 +7741,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"nsg" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Atmospherics Maintenance";
+	req_access_txt = "0";
+	req_one_access_txt = "15"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 2
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/atmos)
 "nsu" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -7838,6 +7786,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
+"nwM" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
 "nxh" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -7955,12 +7909,6 @@
 	},
 /turf/open/floor/plasteel/warning/side,
 /area/shuttle/ftl/research/xenobiology)
-"nGK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 2
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/munitions)
 "nHz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -8006,12 +7954,30 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/chiefs_office)
-"nJR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
+"nKa" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/brig{
+	name = "Departures Checkpoint"
+	})
+"nKG" = (
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8;
+	external_pressure_bound = 0;
+	frequency = 1441;
+	id_tag = "hydrogen_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	on = 1;
+	pressure_checks = 2;
+	pump_direction = 0
+	},
+/turf/open/floor/engine,
 /area/shuttle/ftl/atmos)
 "nLk" = (
 /obj/machinery/light/small{
@@ -8028,12 +7994,6 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engineering)
-"nLF" = (
-/obj/structure/chair/office{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "nLN" = (
 /obj/machinery/atmospherics/components/binary/circulator{
 	dir = 2;
@@ -8042,6 +8002,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
+"nNf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Spare Canister Storage";
+	opacity = 1;
+	req_access_txt = "15"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/atmos/equipment)
 "nNi" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -8065,6 +8036,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"nTO" = (
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	external_pressure_bound = 0;
+	frequency = 1441;
+	id_tag = "co2_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	on = 1;
+	pressure_checks = 2;
+	pump_direction = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/engine/co2,
+/area/shuttle/ftl/atmos)
 "nUa" = (
 /obj/machinery/vending/cola,
 /obj/machinery/newscaster{
@@ -8072,36 +8061,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"nUK" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/starboard)
-"nVg" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light/small{
+"nVq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"nWD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "nYo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -8133,11 +8102,28 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
+"obp" = (
+/obj/effect/landmark/start{
+	name = "Botanist";
+	shuttle_abstract_movable = 1
+	},
+/obj/structure/chair{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hydroponics)
 "obZ" = (
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/meeting_room{
 	name = "Teleporter"
 	})
+"ocC" = (
+/obj/machinery/computer/munitions_console,
+/obj/machinery/newscaster{
+	pixel_x = -30
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/munitions)
 "ocJ" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -8157,6 +8143,16 @@
 "ody" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/starboard)
+"odX" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "oeK" = (
 /obj/machinery/computer/arcade,
 /obj/item/device/radio/intercom{
@@ -8169,6 +8165,14 @@
 	},
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
+"ogv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/space_heater,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "ohL" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms";
@@ -8312,6 +8316,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
+"ovT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
 "owa" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -8325,29 +8342,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/entry)
-"oxo" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"ozv" = (
-/obj/machinery/computer/munitions_console,
-/obj/machinery/newscaster{
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/munitions)
 "oAE" = (
 /obj/machinery/computer/cargo/request,
 /obj/machinery/camera{
@@ -8399,24 +8393,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/lab)
-"oCr" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "oCP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8511,6 +8487,12 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/warden)
+"oNm" = (
+/obj/structure/chair{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/locker)
 "oNC" = (
 /obj/structure/sign/directions/engineering{
 	desc = "A direction sign, pointing out which way the engineering department is.";
@@ -8609,24 +8591,24 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/meeting_room)
-"oSw" = (
-/obj/structure/closet/secure_closet/security,
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+"oSN" = (
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	external_pressure_bound = 0;
+	frequency = 1441;
+	id_tag = "n2_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	on = 1;
+	pressure_checks = 2;
+	pump_direction = 0
 	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 0;
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
+/turf/open/floor/engine/n2,
+/area/shuttle/ftl/atmos)
 "oTK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -8648,24 +8630,39 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/captain)
-"oVy" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+"oVq" = (
+/obj/structure/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12;
+	pixel_y = 2
 	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+/obj/item/weapon/storage/box/masks{
+	pixel_x = 6;
+	pixel_y = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 2;
-	initialize_directions = 11
+/obj/item/weapon/storage/box/bodybags{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/machinery/meter,
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/engineering)
+/obj/item/weapon/storage/box/rxglasses{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/obj/item/clothing/tie/stethoscope,
+/obj/item/clothing/tie/stethoscope,
+/obj/item/weapon/gun/syringe,
+/obj/structure/table/glass,
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/shuttle/ftl/medical/medbay)
 "oVE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -8693,38 +8690,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"oWm" = (
-/obj/structure/rack,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 4
-	},
+"oVW" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
+/area/shuttle/ftl/atmos/equipment)
 "oXA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 1
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/hos)
-"oXY" = (
-/obj/structure/table,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/device/multitool,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/munitions)
 "oYw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 1
@@ -8796,6 +8771,10 @@
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/engine/engineering)
+"pcY" = (
+/obj/machinery/vending/assist,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/tool_storage)
 "pdc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
@@ -8831,13 +8810,6 @@
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
-"pfe" = (
-/obj/machinery/computer/secure_data,
-/obj/machinery/newscaster{
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "pfp" = (
 /obj/machinery/vending/hydronutrients,
 /obj/machinery/firealarm{
@@ -8875,13 +8847,12 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"pin" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+"phR" = (
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
+/turf/open/floor/plasteel/bar,
+/area/shuttle/ftl/crew_quarters/bar)
 "pjz" = (
 /obj/machinery/space_heater,
 /obj/machinery/camera/motion{
@@ -8905,13 +8876,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"pkg" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/poster{
-	pixel_x = -32
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "plf" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -8923,26 +8887,15 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/bridge)
-"plL" = (
-/obj/structure/rack{
-	dir = 1
+"pmF" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/weapon/storage/toolbox/emergency,
-/obj/item/weapon/storage/toolbox/emergency{
-	pixel_x = 2;
-	pixel_y = -3
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/mining)
-"pmf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/munitions)
+/turf/open/floor/plating,
+/area/shuttle/ftl/atmos/equipment)
 "pnC" = (
 /obj/item/chair{
 	dir = 4
@@ -8953,6 +8906,38 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
+"pon" = (
+/obj/item/toy/foamblade,
+/obj/item/device/healthanalyzer,
+/obj/item/device/multitool,
+/obj/structure/closet/crate/medical,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/device/flashlight,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"ppN" = (
+/obj/machinery/door/airlock/research{
+	name = "Science Junction";
+	req_access_txt = "0";
+	req_one_access_txt = "18;26"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/research/lab)
 "ppV" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -8962,6 +8947,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
+"pqD" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/plating,
+/area/shuttle/ftl/atmos/equipment)
 "prl" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9084,6 +9073,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/crew_quarters/captain)
+"pAO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/shuttle/ftl/maintenance/security)
 "pBo" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -9097,18 +9090,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"pCY" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/poster{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "pDt" = (
 /obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
-"pDB" = (
-/obj/structure/table,
-/obj/item/weapon/wirecutters,
-/obj/item/weapon/weldingtool,
-/obj/item/weapon/screwdriver,
-/obj/item/device/assembly/signaler,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/tool_storage)
 "pEM" = (
 /obj/machinery/blackbox_recorder,
 /obj/machinery/light{
@@ -9126,16 +9118,6 @@
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/telecomms/server)
-"pFq" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "pFB" = (
 /obj/machinery/light{
 	dir = 1
@@ -9148,6 +9130,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
+"pGh" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
+"pGS" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rd_shutters"
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/hor)
 "pHP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9172,6 +9170,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/exit)
+"pHQ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig{
+	name = "Departures Checkpoint"
+	})
 "pIe" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -9186,6 +9195,15 @@
 /obj/item/clothing/shoes/winterboots,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/locker)
+"pLc" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Hydrogen to Pure";
+	on = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "pLk" = (
 /turf/open/floor/plasteel{
 	icon_state = "white"
@@ -9210,6 +9228,27 @@
 	dir = 4
 	},
 /area/shuttle/ftl/engine/engineering)
+"pNX" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "brig_enter_shutters";
+	layer = 2.7
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance";
+	req_access_txt = "1";
+	req_one_access_txt = "0"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/main)
 "pOU" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 2
@@ -9225,31 +9264,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/chargebay)
-"pPi" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/landmark/start{
-	name = "Lawyer"
-	},
-/turf/open/floor/plasteel/bar,
-/area/shuttle/ftl/crew_quarters/bar)
-"pPU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/maintenance{
-	name = "Atmospherics Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "15"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/atmos)
 "pQj" = (
 /obj/structure/table,
 /obj/item/weapon/paper_bin,
@@ -9274,6 +9288,16 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
+"pQT" = (
+/obj/machinery/meter,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "pRo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9372,6 +9396,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/chargebay)
+"pXd" = (
+/obj/machinery/computer/arcade,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "pXv" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_command{
@@ -9398,6 +9426,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/tool_storage)
+"pYF" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "pZQ" = (
 /obj/machinery/telecomms/receiver/preset_left/birdstation,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -9411,20 +9448,6 @@
 	},
 /turf/open/floor/plasteel/darkbrown,
 /area/shuttle/ftl/cargo/office)
-"qaz" = (
-/obj/machinery/door/airlock{
-	name = "Library"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Library"
-	})
 "qbE" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -9446,6 +9469,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
+"qcU" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "qcY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -9464,14 +9496,52 @@
 	},
 /turf/open/floor/plasteel/darkbrown,
 /area/shuttle/ftl/cargo/office)
-"qdp" = (
-/obj/machinery/door/airlock/research{
-	name = "Science Junction";
-	req_access_txt = "18;26";
-	req_one_access_txt = "0"
+"qgf" = (
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/port)
+"qgA" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/weapon/storage/belt/utility,
+/obj/item/device/t_scanner{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/device/t_scanner{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/device/t_scanner{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/clothing/glasses/meson/engine/tray,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
+"qho" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/warden)
+"qjK" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Equipment";
+	req_access_txt = "15"
 	},
 /obj/structure/cable{
 	crit_fail = 0;
@@ -9483,23 +9553,16 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/research/lab)
-"qgf" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/area/shuttle/ftl/atmos)
+"qkp" = (
+/obj/machinery/newscaster{
+	pixel_y = 30
 	},
+/obj/structure/frame,
 /turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/port)
-"qho" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 30
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/warden)
+/area/shuttle/ftl/bridge/meeting_room{
+	name = "Teleporter"
+	})
 "qkK" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/main)
@@ -9597,14 +9660,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"qqH" = (
-/obj/machinery/door/airlock/glass_external{
-	name = "Escape Shuttle";
-	req_one_access_txt = "1"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/security/brig)
 "qqU" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/plasteel/white,
@@ -9645,6 +9700,12 @@
 /obj/item/weapon/electronics/airlock,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
+"qvB" = (
+/obj/structure/plasticflaps/mining,
+/turf/open/floor/plasteel/darkwarning{
+	dir = 2
+	},
+/area/shuttle/ftl/munitions)
 "qvJ" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -9739,6 +9800,28 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/office)
+"qyT" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"qzo" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 2
+	},
+/turf/open/floor/plasteel/bar,
+/area/shuttle/ftl/crew_quarters/bar)
 "qCj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9751,18 +9834,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
-"qCT" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
 "qEj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
@@ -9794,6 +9865,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
+"qHW" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "co2_sensor"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/engine/co2,
+/area/shuttle/ftl/atmos)
 "qIm" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -9836,9 +9918,25 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
-"qMk" = (
-/turf/closed/wall,
-/area/shuttle/ftl/maintenance/bar)
+"qMa" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
+	},
+/obj/machinery/computer/atmos_control/tank{
+	frequency = 1441;
+	input_tag = "air_in";
+	name = "Mixed Air Supply Control";
+	output_tag = "air_out";
+	sensors = list("air_sensor" = "Tank")
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "qMD" = (
 /turf/closed/wall,
 /area/shuttle/ftl/research/lab)
@@ -9853,14 +9951,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"qNs" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	tag = "icon-pump_map (WEST)";
-	icon_state = "pump_map";
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "qOB" = (
 /obj/machinery/light{
 	dir = 2
@@ -9931,34 +10021,11 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
-"qSu" = (
-/obj/machinery/air_sensor{
-	frequency = 1441;
-	id_tag = "tox_sensor"
-	},
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/engine/plasma,
-/area/shuttle/ftl/atmos)
 "qSL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
-"qUk" = (
-/obj/effect/landmark/start{
-	name = "Botanist";
-	shuttle_abstract_movable = 1
-	},
-/obj/structure/chair/office{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hydroponics)
 "qZb" = (
 /obj/structure/closet/secure_closet/medical3,
 /turf/open/floor/plasteel/white,
@@ -9994,12 +10061,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"rav" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/research/server)
 "ray" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -10027,6 +10088,45 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
+"rbv" = (
+/obj/machinery/computer/atmos_control/tank{
+	frequency = 1441;
+	input_tag = "n2o_in";
+	name = "Nitrous Oxide Supply Control";
+	output_tag = "n2o_out";
+	sensors = list("n2o_sensor" = "Tank")
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"rbC" = (
+/obj/machinery/suit_storage_unit/rd,
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/hor)
+"rdc" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/start{
+	name = "Lawyer"
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel/bar,
+/area/shuttle/ftl/crew_quarters/bar)
 "rdz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_external{
@@ -10054,13 +10154,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/chargebay)
-"rfv" = (
-/obj/machinery/recharge_station,
-/obj/effect/landmark/start{
-	name = "Cyborg"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/engineering)
 "rfU" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -10084,18 +10177,41 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"riK" = (
-/obj/machinery/mineral/ore_redemption{
-	input_dir = 8;
-	output_dir = 4
+"rhn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "shuttle1";
-	layer = 2
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
+"rhQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"rii" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 2
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/bar,
+/area/shuttle/ftl/crew_quarters/bar)
 "rji" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -10108,6 +10224,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
+"rjr" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "rjz" = (
 /obj/machinery/computer/stockexchange,
 /obj/structure/table,
@@ -10136,14 +10267,15 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/warden)
-"rmz" = (
-/obj/item/weapon/storage/firstaid/regular,
-/obj/structure/table/glass,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+"rkN" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Air to Mix";
+	on = 0
 	},
-/turf/open/floor/plasteel/white,
-/area/shuttle/ftl/medical/medbay)
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "rnf" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -10220,19 +10352,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"ryp" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/r_n_d/server/robotics,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/turf/open/floor/bluegrid{
-	name = "Server Base";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
-/area/shuttle/ftl/research/server)
 "ryt" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -10404,6 +10523,9 @@
 /obj/machinery/shieldgen,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
+"rHF" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/maintenance/security)
 "rHG" = (
 /obj/structure/chair/office/dark{
 	dir = 2
@@ -10478,6 +10600,15 @@
 /area/shuttle/ftl/bridge/meeting_room{
 	name = "Teleporter"
 	})
+"rMQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "rNj" = (
 /obj/machinery/photocopier,
 /obj/machinery/firealarm{
@@ -10555,6 +10686,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
+"rTx" = (
+/obj/machinery/atmospherics/components/trinary/mixer/flipped{
+	node1_concentration = 0.2;
+	node2_concentration = 0.8;
+	on = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "rUd" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/computer/aifixer{
@@ -10633,6 +10772,33 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/chemistry)
+"san" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/hor)
+"sbx" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "O2 to Pure"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "sbH" = (
 /obj/structure/closet/crate/freezer,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -10755,14 +10921,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
-"skj" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rd_shutters"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/crew_quarters/hor)
 "slM" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4;
@@ -10898,6 +11056,16 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
+"stO" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance";
+	req_one_access_txt = "8;5"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/medbay)
 "suW" = (
 /obj/machinery/light{
 	dir = 4
@@ -10949,35 +11117,23 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
-"sye" = (
-/obj/structure/fireaxecabinet{
-	pixel_x = -31
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "syh" = (
 /obj/machinery/computer/cargo/request,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"syu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/mining)
-"szR" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/item/device/radio/intercom{
-	pixel_x = 32;
+"syH" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/munitions)
+/obj/machinery/atmospherics/pipe/manifold4w/cyan/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"sAz" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/atmos/equipment)
 "sBd" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -11126,6 +11282,26 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
+"sHF" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8;
+	external_pressure_bound = 0;
+	frequency = 1441;
+	id_tag = "n2o_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	on = 1;
+	pressure_checks = 2;
+	pump_direction = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/engine/n2o,
+/area/shuttle/ftl/atmos)
 "sIy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -11312,6 +11488,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
+"sZz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/medbay)
+"taM" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/item/weapon/storage/wallet/random,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/shoes/winterboots,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/locker)
 "tdj" = (
 /obj/machinery/button/door{
 	dir = 2;
@@ -11381,26 +11575,6 @@
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
-"tjt" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 4
-	},
-/obj/structure/sign/poster{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "tjx" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -11423,10 +11597,6 @@
 "tjG" = (
 /turf/closed/wall,
 /area/shuttle/ftl/hallway/primary/starboard)
-"tkg" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "tkm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -11542,6 +11712,11 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
+"tsb" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/atmos/equipment)
 "tuE" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -11643,6 +11818,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
+"tBG" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "tDU" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 0;
@@ -11701,17 +11883,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"tFr" = (
-/obj/structure/closet/crate/internals,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 4;
-	name = "4maintenance loot spawner"
+"tFN" = (
+/obj/machinery/r_n_d/server/robotics,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/door/window/northright{
+	dir = 8;
+	name = "Server Room";
+	req_access_txt = "19"
 	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/cargo/storage)
+/turf/open/floor/bluegrid{
+	name = "Server Base";
+	initial_gas_mix = "n2=500;TEMP=80"
+	},
+/area/shuttle/ftl/research/server)
 "tHy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -11759,6 +11945,19 @@
 /obj/item/weapon/stock_parts/cell/high,
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"tIP" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "brig_enter_shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/security{
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access = null;
+	req_access_txt = "38"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "tJu" = (
 /obj/machinery/recharge_station,
 /obj/effect/landmark/start{
@@ -11766,27 +11965,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/chargebay)
-"tKC" = (
-/obj/machinery/air_sensor{
-	frequency = 1441;
-	id_tag = "n2_sensor"
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/engine/n2,
-/area/shuttle/ftl/atmos)
-"tKK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "tLI" = (
 /turf/closed/wall,
 /area/shuttle/ftl/security/detectives_office)
@@ -11826,6 +12004,16 @@
 /obj/machinery/computer/security/wooden_tv,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
+"tOD" = (
+/obj/machinery/ai_status_display{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/structure/closet/secure_closet/personal,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/shoes/winterboots,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/locker)
 "tOV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -11861,6 +12049,14 @@
 	},
 /turf/open/floor/plasteel/darkbrown,
 /area/shuttle/ftl/cargo/office)
+"tPv" = (
+/obj/structure/closet/crate/internals,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 4;
+	name = "4maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/storage)
 "tQD" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 25
@@ -11935,35 +12131,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"tXv" = (
-/obj/machinery/door/airlock/security{
-	name = "Departures Checkpoint";
-	req_one_access_txt = "1"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/security/brig)
-"tXH" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "engineering security door"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access_txt = "15"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "tXM" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "qm_warehouse";
@@ -12012,6 +12179,30 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
+"uaS" = (
+/obj/machinery/power/apc/priority{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera{
+	c_tag = "FTL Drive";
+	dir = 2;
+	network = list("SS13","Supermatter")
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
 "ubo" = (
 /obj/machinery/computer/secure_data,
 /obj/structure/cable{
@@ -12131,24 +12322,6 @@
 /obj/item/weapon/reagent_containers/syringe,
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/virology)
-"ulE" = (
-/obj/structure/table,
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/weapon/folder/red,
-/obj/item/weapon/pen,
-/obj/machinery/camera{
-	c_tag = "Departures Checkpoint";
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	pixel_x = -8;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "ulK" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2
@@ -12243,6 +12416,23 @@
 	mouse_over_pointer = 0;
 	name = "Battle Bridge"
 	})
+"uub" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "uuf" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/reagent_containers/food/condiment/saltshaker{
@@ -12292,6 +12482,18 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/qm)
+"uxL" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "uyr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -12307,6 +12509,9 @@
 	dir = 2
 	},
 /area/shuttle/ftl/subshuttle/pod_3)
+"uBe" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/crew_quarters/bar)
 "uBE" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -12343,22 +12548,22 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engineering)
+"uCF" = (
+/obj/item/device/multitool{
+	pixel_x = 4
+	},
+/obj/structure/table,
+/obj/item/weapon/wirecutters,
+/obj/item/weapon/weldingtool,
+/obj/item/weapon/screwdriver,
+/obj/item/device/t_scanner,
+/obj/item/device/assembly/signaler,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/tool_storage)
 "uFe" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"uFj" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "uFK" = (
 /obj/structure/table,
 /obj/item/weapon/book/manual/ftl_wiki/munitions_manual,
@@ -12390,12 +12595,6 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/secondary/exit)
-"uJL" = (
-/obj/structure/chair/office/dark{
-	dir = 2
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "uKs" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -12407,11 +12606,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
-"uKE" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
 "uLW" = (
 /obj/structure/sign/directions/evac{
 	dir = 4
@@ -12431,6 +12625,13 @@
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/hallway/primary/central)
+"uMH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
+	},
+/obj/machinery/pipedispenser/disposal/transit_tube,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "uNx" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -12461,6 +12662,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"uQQ" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "uRQ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -12469,16 +12682,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
-"uVm" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 8;
-	filter_type = "n2o";
-	icon_state = "filter_off";
-	on = 1;
-	tag = "icon-filter_off (WEST)"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "uVn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
@@ -12489,18 +12692,6 @@
 "uZt" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/break_room)
-"uZL" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
 "vbm" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -12522,34 +12713,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"vcp" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/starboard)
-"vcL" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "vcQ" = (
 /obj/item/device/t_scanner,
 /obj/structure/table,
@@ -12578,13 +12741,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
-"vfA" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+"vgw" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/computer/atmos_control/tank{
+	frequency = 1441;
+	input_tag = "co2_in";
+	name = "Carbon Dioxide Supply Control";
+	output_tag = "co2_out";
+	sensors = list("co2_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
+/area/shuttle/ftl/atmos)
 "viD" = (
 /obj/item/device/radio,
 /obj/structure/closet/secure_closet/security/sec,
@@ -12617,28 +12786,6 @@
 /area/shuttle/ftl/crew_quarters/theatre{
 	name = "Library"
 	})
-"vkL" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmos RC";
-	pixel_x = 30;
-	pixel_y = 4
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "vkQ" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel,
@@ -12652,6 +12799,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/entry)
+"von" = (
+/obj/machinery/vending/sovietsoda,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/engineering)
 "vpd" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -12732,52 +12883,13 @@
 /area/shuttle/ftl/crew_quarters/theatre{
 	name = "Library"
 	})
-"vuo" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
+"vwf" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Pure to Ports";
+	on = 0
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"vvR" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Bar";
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/plasteel/bar,
-/area/shuttle/ftl/crew_quarters/bar)
-"vwy" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 2;
-	frequency = 1441;
-	id = "tox_in";
-	pixel_y = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/engine/plasma,
 /area/shuttle/ftl/atmos)
 "vwI" = (
 /turf/open/space,
@@ -12865,6 +12977,18 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/cargo/mining)
+"vEb" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "vFf" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -12891,16 +13015,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/exit)
-"vFR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "vGj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12934,6 +13048,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
+"vHL" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "vHV" = (
 /obj/machinery/porta_turret/ai{
 	dir = 1
@@ -12944,6 +13064,37 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/secondary/construction)
+"vKd" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "tox_sensor"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/engine/plasma,
+/area/shuttle/ftl/atmos)
+"vLt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/sign/poster{
+	pixel_y = 32
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
+"vNA" = (
+/obj/machinery/light{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
 "vNU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13055,6 +13206,35 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/captain)
+"vTS" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "brig_enter_shutters"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/door/airlock/security{
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access = null;
+	req_access_txt = "38"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "vTW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13102,12 +13282,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/telecomms/computer)
-"vVu" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "vVC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -13141,26 +13315,11 @@
 /area/shuttle/ftl/crew_quarters/sleep)
 "wbq" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "0-4";
+	d2 = 4
 	},
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
-"wdB" = (
-/obj/effect/landmark/start{
-	name = "Cook";
-	shuttle_abstract_movable = 1
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/shuttle/ftl/crew_quarters/kitchen)
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
 "weD" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -13179,25 +13338,6 @@
 /obj/machinery/computer/mech_bay_power_console,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"wfQ" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "wgd" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/plasteel/black,
@@ -13208,19 +13348,6 @@
 	},
 /turf/open/floor/plasteel/darkbrown,
 /area/shuttle/ftl/cargo/office)
-"wkZ" = (
-/obj/machinery/air_sensor{
-	frequency = 1441;
-	id_tag = "n2o_sensor"
-	},
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/engine/n2o,
-/area/shuttle/ftl/atmos)
 "wno" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel/warning{
@@ -13237,23 +13364,10 @@
 /area/shuttle/ftl/crew_quarters/theatre{
 	name = "Library"
 	})
-"wnH" = (
-/obj/structure/table/wood,
-/obj/machinery/recharger,
-/obj/item/weapon/melee/chainofcommand,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/captain)
 "woN" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"wqq" = (
-/obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "wre" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -13295,21 +13409,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
+"wro" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "wrr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
 /turf/open/floor/plasteel/darkbrown,
 /area/shuttle/ftl/cargo/office)
-"wrH" = (
-/obj/machinery/door/poddoor{
-	id = "weapon_k_1";
-	name = "munitions launcher bay door"
-	},
-/turf/open/floor/plating/warnplate/side{
-	tag = "icon-plating_warn_side (EAST)";
-	icon_state = "plating_warn_side";
-	dir = 4
-	},
-/area/shuttle/ftl/munitions)
 "wsH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -13323,21 +13432,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/brig)
-"wsO" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "wtA" = (
 /obj/machinery/doorButtons/access_button{
 	idDoor = "virology_airlock_exterior";
@@ -13372,33 +13466,21 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/brig)
-"wxw" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/glass_external{
-	name = "External Access";
-	req_one_access_txt = "8"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"wxz" = (
+"wxL" = (
 /obj/structure/closet/crate/medical,
 /obj/item/weapon/tank/internals/emergency_oxygen,
 /obj/item/weapon/tank/internals/emergency_oxygen,
 /obj/item/clothing/mask/gas,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/item/weapon/storage/firstaid/regular,
 /obj/machinery/light_switch{
 	pixel_x = 8;
 	pixel_y = 24
 	},
+/obj/item/weapon/storage/box/lights/mixed{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/firstaid/regular,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
 "wyy" = (
@@ -13422,21 +13504,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/armory)
-"wAX" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/door/airlock/hatch{
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "outercore";
-	locked = 1;
-	name = "Maintenance Hatch";
-	req_access_txt = "8"
-	},
-/obj/machinery/door/poddoor{
-	id = "Supermatter doors"
-	},
-/turf/open/floor/noslip,
-/area/shuttle/ftl/engine/engineering)
 "wCc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13444,6 +13511,11 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
+"wCB" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Library"
+	})
 "wEA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -13457,11 +13529,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"wFl" = (
+"wFt" = (
 /obj/structure/cable{
+	crit_fail = 0;
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "15"
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
@@ -13471,27 +13551,25 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
-"wHe" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass{
-	amount = 50
+"wGT" = (
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/item/weapon/storage/belt/utility,
-/obj/item/device/t_scanner{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/item/device/t_scanner{
-	pixel_x = 2;
-	pixel_y = 2
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8;
+	external_pressure_bound = 0;
+	frequency = 1441;
+	id_tag = "mix_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	on = 1;
+	pressure_checks = 2;
+	pump_direction = 0
 	},
-/obj/item/device/t_scanner{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/item/clothing/glasses/meson/engine/tray,
-/turf/open/floor/plasteel,
+/turf/open/floor/engine/vacuum,
 /area/shuttle/ftl/atmos)
 "wJm" = (
 /obj/structure/cable{
@@ -13530,15 +13608,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"wMn" = (
+"wLS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 2
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
 "wNr" = (
 /obj/structure/table/reinforced,
 /obj/item/device/assembly/flash/handheld,
@@ -13562,16 +13643,6 @@
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"wOg" = (
-/obj/machinery/meter{
-	name = "Mixed Air Tank In"
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plasteel/arrival{
-	dir = 10
-	},
-/area/shuttle/ftl/atmos)
 "wQt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -13584,6 +13655,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"wRj" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "wRx" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -13607,6 +13684,23 @@
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
+"wSg" = (
+/obj/machinery/computer/atmos_control{
+	sensors = list("n2_sensor" = "Nitrogen Tank", "o2_sensor" = "Oxygen Tank", "co2_sensor" = "Carbon Dioxide Tank", "tox_sensor" = "Plasma Tank", "n2o_sensor" = "Nitrous Oxide Tank", "hydrogen_sensor" = "Hydrogen Tank", "air_sensor" = "Mixed Air Tank", "mix_sensor" = "Mix Tank", "distro_meter" = "Distribution Loop", "waste_meter" = "Waste Loop")
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
+"wUp" = (
+/obj/machinery/door/airlock/hatch{
+	frequency = 1449;
+	icon_state = "door_locked";
+	id_tag = "outercore";
+	locked = 1;
+	name = "Maintenance Hatch";
+	req_access_txt = "8"
+	},
+/turf/open/floor/noslip,
+/area/shuttle/ftl/engine/engineering)
 "wUF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -13626,11 +13720,6 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
-"wWm" = (
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/item/device/pipe_painter,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "wWn" = (
 /obj/machinery/hologram/holopad,
 /turf/open/floor/plasteel,
@@ -13669,6 +13758,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
+"xaE" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
 "xcz" = (
 /obj/item/weapon/reagent_containers/food/snacks/grilledcheese{
 	pixel_y = 6
@@ -13701,22 +13805,6 @@
 "xei" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/nuke_storage)
-"xeo" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/button/door{
-	id = "shuttle2";
-	name = "ORM Shutter Control";
-	pixel_x = 6;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/mining)
 "xeP" = (
 /obj/machinery/door/airlock/shuttle,
 /obj/structure/cable{
@@ -13728,18 +13816,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"xfx" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "xgQ" = (
 /obj/machinery/status_display{
 	pixel_y = -32
@@ -13775,6 +13851,13 @@
 /obj/machinery/computer/card/minor/ce,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/chiefs_office)
+"xmD" = (
+/obj/structure/closet/crate,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/clothing/tie/stethoscope,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/medbay)
 "xnd" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -13789,38 +13872,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engineering)
-"xqw" = (
-/obj/structure/chair/office{
-	dir = 2
-	},
-/obj/item/device/radio/intercom{
-	pixel_x = 0;
-	pixel_y = 28
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/secondary/construction)
-"xqE" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/light_switch{
-	pixel_x = -8;
-	pixel_y = -22
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/cargo)
-"xrp" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j1"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "xsf" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -13866,15 +13917,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/chemistry)
-"xsW" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "xtB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -13906,6 +13948,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
+"xwt" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/computer/atmos_control/tank{
+	frequency = 1441;
+	input_tag = "hydrogen_in";
+	name = "Hydrogen Supply Control";
+	output_tag = "hydrogen_out";
+	sensors = list("hydrogen_sensor" = "Tank")
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "xyj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -13960,15 +14015,6 @@
 	},
 /turf/open/floor/plasteel/bot,
 /area/shuttle/ftl/cargo/mining)
-"xAQ" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Clown"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "xBo" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -14017,19 +14063,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"xEy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	icon_state = "intact";
-	dir = 10
+"xEp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 2
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/effect/landmark{
-	name = "lightsout"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/storage)
 "xEG" = (
 /obj/machinery/suit_storage_unit/engine,
 /obj/structure/cable{
@@ -14040,13 +14079,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
-"xFw" = (
-/obj/machinery/light_switch{
-	pixel_x = 8;
-	pixel_y = 22
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/engineering)
 "xHg" = (
 /obj/machinery/camera{
 	c_tag = "Engine Monitoring";
@@ -14096,18 +14128,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/chargebay)
-"xJT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/hor)
 "xKh" = (
 /obj/structure/table,
 /obj/item/weapon/folder/yellow,
@@ -14170,28 +14190,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/munitions)
-"xPT" = (
-/obj/structure/closet/athletic_mixed,
-/obj/machinery/ai_status_display{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/structure/closet/secure_closet/personal,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/shoes/winterboots,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/locker)
-"xQL" = (
-/obj/effect/landmark/start{
-	name = "Ship Engineer";
-	shuttle_abstract_movable = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/chair/office{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/break_room)
 "xQO" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/locker)
@@ -14241,26 +14239,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"xWH" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"xVU" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 10
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "xXo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14283,15 +14267,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"xXB" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "xYB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -14302,6 +14277,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"xZa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Atmospherics Storage";
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/atmos/equipment)
 "xZo" = (
 /obj/machinery/recharge_station,
 /obj/effect/landmark/start{
@@ -14318,12 +14304,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/exit)
-"yct" = (
-/obj/structure/table/wood,
-/obj/item/device/flashlight/lamp,
-/obj/item/weapon/gun/projectile/revolver/russian,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "ydl" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 2
@@ -14334,13 +14314,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"yhj" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater,
-/obj/machinery/firealarm{
-	pixel_y = 26
+"yfw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "yjy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 2
@@ -14363,32 +14342,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
-"yny" = (
-/obj/structure/plasticflaps/mining,
-/turf/open/floor/plating/warnplate/side{
-	tag = "icon-plating_warn_side (EAST)";
-	icon_state = "plating_warn_side";
-	dir = 4
-	},
-/area/shuttle/ftl/munitions)
-"ynW" = (
-/obj/machinery/vending/autodrobe,
-/obj/machinery/newscaster{
-	pixel_x = 30
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"yoF" = (
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	tag = "icon-dvalve_map (EAST)";
-	icon_state = "dvalve_map";
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	pixel_y = -26
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/engineering)
 "ypj" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -14440,17 +14393,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"yrh" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/engineering)
 "yul" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -14530,12 +14472,6 @@
 /obj/effect/landmark/latejoin,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/exit)
-"yxU" = (
-/obj/structure/chair/office{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/locker)
 "yyn" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -14574,27 +14510,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"yzD" = (
-/obj/item/toy/foamblade,
-/obj/item/device/healthanalyzer,
-/obj/item/device/multitool,
-/obj/structure/closet/crate/medical,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/device/flashlight,
-/obj/machinery/power/apc{
-	auto_name = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "yAc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14629,15 +14544,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
-"yDy" = (
-/obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/machinery/portable_atmospherics/pump,
-/obj/machinery/ai_status_display{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "yEw" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Research Director";
@@ -14712,16 +14618,6 @@
 /obj/item/weapon/reagent_containers/spray/pepper,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/brig)
-"yLt" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "yLS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14733,6 +14629,21 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
+"yMA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/hor)
 "yNm" = (
 /obj/machinery/door/window/southright{
 	dir = 2;
@@ -14741,6 +14652,9 @@
 	},
 /turf/open/floor/plasteel/shuttle/red,
 /area/shuttle/ftl/subshuttle/pod_3)
+"yNC" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "yNL" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "EVA Storage";
@@ -14754,35 +14668,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
-"yOh" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/warning{
-	dir = 9
-	},
-/area/shuttle/ftl/atmos)
-"yQM" = (
-/obj/structure/window/reinforced,
-/obj/machinery/computer/atmos_control/tank{
-	frequency = 1441;
-	input_tag = "n2_in";
-	name = "Nitrogen Supply Control";
-	output_tag = "n2_out";
-	sensors = list("n2_sensor" = "Tank")
-	},
-/turf/open/floor/plasteel/red/side,
-/area/shuttle/ftl/atmos)
-"ySe" = (
-/obj/structure/sign/poster{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/engine/engineering)
+"yQc" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/crew_quarters/toilet)
 "yTd" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14803,12 +14691,42 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
+"yUG" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 1;
+	filter_type = "n2o";
+	icon_state = "filter_off";
+	on = 1;
+	tag = "icon-filter_off (WEST)"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"yVX" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "yWA" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/entry)
+"yXu" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
 "yYn" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -14880,21 +14798,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
-"zfY" = (
-/obj/item/device/camera_film,
-/obj/structure/table/wood,
-/obj/item/weapon/reagent_containers/food/snacks/cheesiehonkers,
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/obj/item/device/camera,
-/obj/item/weapon/lipstick/random{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/weapon/lipstick/random,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "zht" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -14907,18 +14810,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/locker)
-"zhO" = (
+"zhL" = (
+/obj/machinery/computer/card/minor/rd,
+/obj/machinery/light_switch{
+	pixel_x = 22;
+	pixel_y = -22
+	},
+/obj/machinery/button/door{
+	id = "rd_shutters";
+	name = "Science Shutters Control";
+	pixel_x = 24;
+	pixel_y = -32;
+	req_access_txt = "0"
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/hor)
 "ziX" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -14957,20 +14869,6 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/cargo/mining)
-"zpY" = (
-/obj/machinery/camera{
-	c_tag = "R&D Server Room";
-	name = "security camera";
-	network = list("SS13","RD")
-	},
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/research/server)
 "zqm" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/structure/cable/cyan{
@@ -15044,14 +14942,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/nuke_storage)
-"zyB" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "zCK" = (
 /obj/machinery/status_display{
 	density = 0;
@@ -15082,13 +14972,6 @@
 /obj/machinery/gravity_generator/main/station,
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engine_smes)
-"zEI" = (
-/obj/machinery/computer/rdservercontrol,
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/research/server)
 "zGe" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/black,
@@ -15098,6 +14981,13 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
+"zJd" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 2
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "zKm" = (
 /obj/machinery/door_timer{
 	id = "Cell 2";
@@ -15132,6 +15022,17 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
+"zNr" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 2;
+	initialize_directions = 11
+	},
+/obj/machinery/meter,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "zNY" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -15203,16 +15104,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"zSW" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 8;
-	filter_type = "co2";
-	icon_state = "filter_off";
-	on = 1;
-	tag = "icon-filter_off (WEST)"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "zTg" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -15254,16 +15145,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
-"zXn" = (
-/obj/machinery/light{
-	dir = 2
-	},
-/obj/item/device/radio/intercom{
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "zXM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2
@@ -15395,21 +15276,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"Acd" = (
-/obj/machinery/computer/card/minor/rd,
-/obj/machinery/light_switch{
-	pixel_x = 22;
-	pixel_y = -22
-	},
-/obj/machinery/button/door{
-	id = "rd_shutters";
-	name = "Science Shutters Control";
-	pixel_x = 24;
-	pixel_y = -32;
-	req_access_txt = "0"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/hor)
 "Aje" = (
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/ftl/subshuttle/pod_3)
@@ -15448,18 +15314,25 @@
 	mouse_over_pointer = 0;
 	name = "Battle Bridge"
 	})
-"AmJ" = (
-/obj/machinery/door/airlock/glass{
-	name = "Starboard Airlock"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+"AlB" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
+/area/shuttle/ftl/atmos)
 "AmR" = (
 /turf/closed/wall,
 /area/shuttle/ftl/medical/chemistry)
+"AmW" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
+"AnI" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "Apf" = (
 /obj/machinery/computer/ftl_weapons,
 /turf/open/floor/plasteel/black,
@@ -15571,17 +15444,20 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/surgery)
-"AwM" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+"AwJ" = (
+/obj/machinery/meter,
+/obj/structure/window/reinforced{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
+"AwL" = (
+/obj/structure/closet/athletic_mixed,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
 "AxA" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -15602,17 +15478,6 @@
 /obj/item/weapon/reagent_containers/food/snacks/cakeslice/plain,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"AyS" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 5
-	},
-/area/shuttle/ftl/atmos)
 "AAg" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -15632,18 +15497,9 @@
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/exit)
-"ABs" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/rack,
-/obj/item/weapon/aiModule/core/full/corp,
-/obj/item/weapon/aiModule/core/full/asimov,
-/turf/open/floor/plasteel/circuit,
-/area/shuttle/ftl/turret_protected/ai)
+"ABo" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/hallway/primary/starboard)
 "ADL" = (
 /obj/structure/table/glass,
 /obj/item/weapon/stock_parts/console_screen,
@@ -15703,18 +15559,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/tool_storage)
-"AGC" = (
-/obj/machinery/air_sensor{
-	frequency = 1441;
-	id_tag = "air_sensor"
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/engine/air,
-/area/shuttle/ftl/atmos)
 "AGO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 2
@@ -15749,12 +15593,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
-"AIO" = (
-/obj/structure/table,
-/obj/item/weapon/storage/box/donkpockets,
-/obj/item/weapon/reagent_containers/food/snacks/cakeslice/plain,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/mining)
 "AJw" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -15842,6 +15680,22 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/warden)
+"AOs" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
 "AOP" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -15866,6 +15720,12 @@
 /obj/structure/closet/secure_closet/captains,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/captain)
+"AQa" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "ASx" = (
 /obj/machinery/door/airlock/command{
 	name = "Bridge";
@@ -15987,11 +15847,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/brig)
-"AWQ" = (
-/turf/open/floor/plasteel/darkwarning{
-	dir = 8
-	},
-/area/shuttle/ftl/munitions)
 "AXE" = (
 /obj/item/weapon/storage/fancy/cigarettes/cigars,
 /obj/structure/closet/secure_closet/hos,
@@ -16014,6 +15869,13 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/surgery)
+"AYL" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/atmos/equipment)
 "AZH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -16110,6 +15972,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/medbay)
+"Bix" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 8;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Mix to Waste";
+	on = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "BiD" = (
 /obj/machinery/computer/card,
 /obj/structure/cable{
@@ -16223,6 +16097,10 @@
 /obj/item/weapon/storage/toolbox/emergency,
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
+"Bpx" = (
+/obj/structure/closet/wardrobe/mixed,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/locker)
 "BpK" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -16332,6 +16210,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/chargebay)
+"BwR" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/engineering)
 "BwY" = (
 /obj/machinery/status_display{
 	density = 0;
@@ -16350,6 +16233,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/toilet)
+"Bxl" = (
+/obj/structure/closet/wardrobe/grey,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/locker)
 "Byw" = (
 /turf/closed/wall/shuttle{
 	icon_state = "swall1";
@@ -16372,6 +16259,20 @@
 /obj/item/weapon/storage/belt/utility,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/secondary/construction)
+"BBz" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance";
+	req_access_txt = "0";
+	req_one_access_txt = "0"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "BCe" = (
 /obj/machinery/computer/communications,
 /turf/open/floor/carpet,
@@ -16413,16 +16314,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/exit)
-"BGj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/machinery/light_switch{
-	pixel_x = -8;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "BJJ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -16444,6 +16335,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
+"BLw" = (
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/item/device/pipe_painter,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "BMN" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Armory";
@@ -16478,6 +16382,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"BNQ" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 0
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/cargo/office)
 "BPx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -16552,15 +16466,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"BWv" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 2
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engineering)
 "BXZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -16578,10 +16483,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"BYB" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/plasteel/bot,
-/area/shuttle/ftl/atmos)
 "CbN" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -16609,6 +16510,20 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
+"CcP" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j1"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "Cde" = (
 /turf/closed/wall,
 /area/shuttle/ftl/maintenance/security)
@@ -16624,6 +16539,10 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
+"CfD" = (
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "ChJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -16658,6 +16577,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"CiB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "CiD" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -16709,21 +16634,24 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/engine/engineering)
-"Cni" = (
-/obj/machinery/door/firedoor,
+"Cny" = (
+/obj/machinery/door/airlock/security{
+	name = "Departures Checkpoint";
+	req_one_access_txt = "1"
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Shield Generator";
-	req_access_txt = "34";
-	req_one_access_txt = "0"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 2
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engineering)
+/area/shuttle/ftl/security/brig{
+	name = "Departures Checkpoint"
+	})
 "CoX" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -16739,24 +16667,21 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/space)
+"CqB" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "n2_sensor"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/engine/n2,
+/area/shuttle/ftl/atmos)
 "CqG" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"CrQ" = (
-/turf/closed/wall,
-/area/shuttle/ftl/maintenance/cargo)
-"Csw" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "8;20"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "Ctf" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/cafeteria,
@@ -16858,6 +16783,25 @@
 "CyV" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"CyX" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/maintenance/engineering)
+"CAn" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/airlock/engineering{
+	name = "FTL Drive";
+	req_access_txt = "0";
+	req_one_access_txt = "34;15"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
 "CAN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -16870,6 +16814,9 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
+"CBp" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/cargo/qm)
 "CBC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -16879,46 +16826,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"CCI" = (
+"CBP" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	moving_diagonally = 0;
+	name = "Tool Storage";
+	req_access_txt = "0"
+	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/tool_storage)
+"CCP" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/grille,
 /turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"CCY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
-	dir = 1;
-	external_pressure_bound = 0;
-	frequency = 1441;
-	icon_state = "vent_map";
-	id_tag = "air_out";
-	internal_pressure_bound = 2000;
-	on = 1;
-	pressure_checks = 2;
-	pump_direction = 0
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/engine/air,
-/area/shuttle/ftl/atmos)
-"CGH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
 /area/shuttle/ftl/engine/engineering)
 "CIy" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
@@ -16974,29 +16900,12 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
-"CKA" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"CLf" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/circuit,
-/area/shuttle/ftl/turret_protected/ai)
-"CLe" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics East";
-	dir = 8
-	},
-/obj/machinery/pipedispenser,
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"CLF" = (
-/obj/structure/table,
-/obj/item/device/t_scanner,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/tool_storage)
+/area/shuttle/ftl/atmos/equipment)
 "CLT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
@@ -17033,6 +16942,16 @@
 /obj/item/weapon/storage/backpack/satchel_vir,
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/virology)
+"CQs" = (
+/obj/effect/landmark/start{
+	name = "Cook";
+	shuttle_abstract_movable = 1
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
 "CQW" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -17046,22 +16965,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"CRF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Botanist";
-	shuttle_abstract_movable = 1
-	},
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hydroponics)
 "CSC" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -17069,6 +16972,17 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engineering)
+"CSK" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "o2_sensor"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/engine/o2,
+/area/shuttle/ftl/atmos)
 "CSP" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/machinery/power/apc{
@@ -17092,15 +17006,6 @@
 /obj/item/clothing/under/suit_jacket/charcoal,
 /turf/open/floor/plasteel/darkbrown,
 /area/shuttle/ftl/cargo/qm)
-"CSV" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "CTf" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -17133,18 +17038,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"CTD" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	icon_state = "intact";
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	tag = "icon-pump_map (NORTH)";
-	icon_state = "pump_map";
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "CTH" = (
 /turf/closed/wall,
 /area/shuttle/ftl/medical/virology)
@@ -17217,36 +17110,6 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"DbC" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "brig_enter_shutters"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/door/airlock/security{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access = null;
-	req_access_txt = "38"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "DbF" = (
 /obj/structure/chair{
 	dir = 8
@@ -17312,27 +17175,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/munitions)
-"DgQ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "Dhv" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/toolbox/mechanical,
@@ -17357,23 +17199,52 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"DiH" = (
-/obj/structure/chair/office{
-	dir = 1
+"Djy" = (
+/obj/structure/table,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/device/multitool,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/munitions)
 "DjF" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -25
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/nuke_storage)
+"Dly" = (
+/obj/machinery/meter,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "Dnn" = (
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/theatre{
 	name = "Library"
 	})
+"DnZ" = (
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8;
+	frequency = 1441;
+	id = "n2o_in";
+	pixel_y = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/engine/n2o,
+/area/shuttle/ftl/atmos)
 "Dpn" = (
 /obj/structure/closet/wardrobe/robotics_black,
 /turf/open/floor/plasteel,
@@ -17383,6 +17254,34 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
+"Dtf" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
+"Duu" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 4
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
 "DuV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -17397,24 +17296,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/entry)
-"Dyt" = (
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Research Director's Office";
-	network = list("SS13","RD")
-	},
-/obj/machinery/suit_storage_unit/rd,
+"DxK" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/hor)
+/area/shuttle/ftl/hallway/secondary/exit)
 "DyA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 1
@@ -17427,6 +17329,15 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engine_smes)
+"DAx" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Plasma to Pure";
+	on = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "DDk" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -17440,21 +17351,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/heads)
-"DDo" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/bar,
-/area/shuttle/ftl/crew_quarters/bar)
 "DEA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -17469,6 +17365,12 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/bar)
+"DGU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 2
+	},
+/turf/closed/wall,
+/area/shuttle/ftl/cargo/storage)
 "DHh" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -17522,6 +17424,28 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/meeting_room)
+"DLS" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/munitions)
+"DMm" = (
+/obj/machinery/computer/atmos_control/tank{
+	frequency = 1441;
+	input_tag = "tox_in";
+	name = "Plasma Supply Control";
+	output_tag = "tox_out";
+	sensors = list("tox_sensor" = "Tank")
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "DMu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
@@ -17541,6 +17465,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
+"DMV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Shield Generator";
+	req_access_txt = "0";
+	req_one_access_txt = "34;15"
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/engineering)
 "DOD" = (
 /obj/machinery/door/firedoor,
 /obj/structure/fans/tiny,
@@ -17569,6 +17510,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"DOT" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "mix_sensor"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/engine/vacuum,
+/area/shuttle/ftl/atmos)
 "DOY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -17625,21 +17576,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/toilet)
-"DQi" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1;
-	frequency = 1441;
-	id = "o2_in"
+"DQy" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/landmark/start{
+	name = "Ship Engineer";
+	shuttle_abstract_movable = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/engine/o2,
-/area/shuttle/ftl/atmos)
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
 "DQS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -17701,11 +17649,6 @@
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/medical/virology)
-"DYM" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/ftl/security/brig)
 "DZF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -17727,12 +17670,35 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
+"EbM" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/cargo/storage)
+"Ecu" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "Edd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engine_smes)
+"EdJ" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "EeC" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/black,
@@ -17745,20 +17711,32 @@
 "EgM" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/medical/chemistry)
+"EgT" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 0
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/hallway/secondary/entry)
 "Ehg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"EhN" = (
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+"Eii" = (
+/obj/structure/sign/poster{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 1
-	},
+/obj/machinery/space_heater,
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/mining)
+/area/shuttle/ftl/atmos/equipment)
+"EiR" = (
+/obj/item/weapon/storage/firstaid/regular,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/white,
+/area/shuttle/ftl/medical/medbay)
 "EiW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -17769,11 +17747,28 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
+"EiX" = (
+/obj/structure/table/glass,
+/obj/item/device/aicard,
+/obj/item/device/taperecorder{
+	pixel_x = -3
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/hor)
 "EjS" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/tool_storage)
+"Ekx" = (
+/turf/open/floor/plating,
+/area/shuttle/ftl/atmos/equipment)
 "EkZ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -17821,6 +17816,55 @@
 	},
 /turf/open/floor/plasteel/blue,
 /area/shuttle/ftl/medical/genetics)
+"EmY" = (
+/obj/structure/closet/wardrobe/atmospherics_yellow,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
+"Enw" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"EnU" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 2
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge)
 "EnY" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -17866,6 +17910,20 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
+"EzJ" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4;
+	frequency = 1441;
+	id = "air_in"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/engine/air,
+/area/shuttle/ftl/atmos)
 "EzK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -17891,10 +17949,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
+"ECt" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/hallway/secondary/entry)
 "ECL" = (
 /obj/machinery/droneDispenser,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
+"EDx" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "EFC" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 1";
@@ -17905,6 +17972,14 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
+"EFT" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Port to Waste";
+	on = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "EGe" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -17954,19 +18029,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"EJo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "EKq" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -18030,6 +18092,31 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/brig)
+"EQz" = (
+/obj/item/device/camera_film,
+/obj/structure/table/wood,
+/obj/item/weapon/reagent_containers/food/snacks/cheesiehonkers,
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
+/obj/item/device/camera,
+/obj/item/weapon/lipstick/random{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/lipstick/random,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"ESN" = (
+/obj/effect/landmark/start{
+	name = "Cook";
+	shuttle_abstract_movable = 1
+	},
+/obj/structure/chair{
+	dir = 2
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/shuttle/ftl/crew_quarters/kitchen)
 "ESR" = (
 /obj/machinery/light{
 	dir = 4
@@ -18060,26 +18147,12 @@
 /obj/item/clothing/head/fedora,
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
-"EUO" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/status_display{
-	pixel_y = -32
+"EUs" = (
+/obj/structure/plasticflaps/mining,
+/turf/open/floor/plasteel/darkwarning{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"EVi" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
+/area/shuttle/ftl/munitions)
 "EVU" = (
 /obj/structure/table,
 /obj/machinery/newscaster{
@@ -18093,6 +18166,30 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
+"EWr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Atmospheric Technician";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/atmos/equipment)
+"EZq" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/space,
+/area/shuttle/ftl/space)
 "EZQ" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/secondary/construction)
@@ -18282,19 +18379,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/entry)
-"Fqs" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/r_n_d/server/core,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/turf/open/floor/bluegrid{
-	name = "Server Base";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
-/area/shuttle/ftl/research/server)
 "Fra" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -18309,12 +18393,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/bridge)
-"FrA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/munitions)
 "FrX" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -18327,21 +18405,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"Fsp" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/item/weapon/restraints/handcuffs,
-/obj/item/device/taperecorder{
-	pixel_x = 4;
-	pixel_y = 0
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 25
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "Fst" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -18363,6 +18426,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"FsK" = (
+/obj/structure/chair{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/medbay)
+"Ftb" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = -26;
+	pixel_y = 22
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "FtU" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -18375,13 +18465,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
-"Fuu" = (
-/obj/structure/closet/wardrobe/pjs,
-/obj/structure/closet/secure_closet/personal,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/shoes/winterboots,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/locker)
 "Fuv" = (
 /obj/machinery/vending/coffee,
 /obj/structure/extinguisher_cabinet{
@@ -18469,25 +18552,6 @@
 	},
 /turf/open/floor/plasteel/blue,
 /area/shuttle/ftl/medical/genetics)
-"Fww" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics West";
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8
-	},
-/obj/structure/closet/firecloset/full,
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "Fxg" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -18650,14 +18714,15 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/nuke_storage)
-"FLx" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8;
-	initialize_directions = 11
+"FMa" = (
+/obj/machinery/mineral/ore_redemption,
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "shuttle1";
+	layer = 2
 	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "FNm" = (
 /obj/item/stack/packageWrap,
 /obj/item/device/assembly/timer{
@@ -18704,12 +18769,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/cargo/mining)
-"FOs" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "FOv" = (
 /obj/machinery/light{
 	dir = 2
@@ -18769,18 +18828,6 @@
 /obj/item/device/radio,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"FTO" = (
-/obj/machinery/air_sensor{
-	frequency = 1441;
-	id_tag = "o2_sensor"
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/engine/o2,
-/area/shuttle/ftl/atmos)
 "FUA" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -18794,6 +18841,30 @@
 /obj/item/weapon/storage/firstaid/regular,
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
+"FVg" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel/bar,
+/area/shuttle/ftl/crew_quarters/bar)
+"FVG" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Waste to Filter"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "FWl" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/hug/medical{
@@ -18929,19 +19000,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"Gmq" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	tag = "icon-pump_map (EAST)";
-	icon_state = "pump_map";
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "GmS" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -18955,6 +19013,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/blue,
 /area/shuttle/ftl/medical/genetics)
+"Gnj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "Gnw" = (
 /obj/structure/chair{
 	dir = 4
@@ -18968,21 +19033,25 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
-"Goe" = (
+"GnB" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"GpJ" = (
 /obj/structure/cable{
 	crit_fail = 0;
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "GrI" = (
 /obj/structure/lattice,
 /obj/effect/landmark{
@@ -19005,28 +19074,6 @@
 	dir = 2
 	},
 /area/shuttle/ftl/subshuttle/pod_1)
-"Gvp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 2;
-	external_pressure_bound = 0;
-	frequency = 1441;
-	id_tag = "co2_out";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	on = 1;
-	pressure_checks = 2;
-	pump_direction = 0
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/engine/co2,
-/area/shuttle/ftl/atmos)
 "Gvr" = (
 /obj/machinery/button/massdriver{
 	id = "exec_driver";
@@ -19065,19 +19112,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/research/lab)
-"GwJ" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	tag = "icon-pump_map (NORTH)";
-	icon_state = "pump_map";
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "Gyv" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -19137,19 +19171,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"GAF" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "GBm" = (
 /obj/machinery/suit_storage_unit/mining/eva,
 /turf/open/floor/plasteel,
@@ -19157,6 +19178,16 @@
 "GEx" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/munitions/cannon)
+"GIn" = (
+/obj/machinery/door/airlock/glass_external{
+	name = "Escape Shuttle";
+	req_one_access_txt = "1"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/security/brig{
+	name = "Departures Checkpoint"
+	})
 "GJe" = (
 /turf/closed/wall,
 /area/shuttle/ftl/engine/tool_storage)
@@ -19205,6 +19236,18 @@
 "GKy" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engine_smes)
+"GKL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/maintenance/medbay)
 "GLA" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/plasteel/white,
@@ -19231,18 +19274,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"GNr" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "GNG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -19268,26 +19299,52 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"GNU" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"GOq" = (
+/obj/structure/table/wood,
+/obj/item/device/camera,
+/obj/item/weapon/folder/red{
+	pixel_x = 3
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "engineering security door"
+/obj/item/weapon/folder/blue{
+	pixel_x = -2;
+	pixel_y = 3
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Equipment";
-	req_access_txt = "15"
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	auto_name = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Library"
+	})
+"GPW" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/northleft{
+	dir = 2;
+	icon_state = "left";
+	name = "Reception Window";
+	req_access_txt = "0"
+	},
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "RnD Desk";
+	req_access_txt = "26"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rnd_shutters";
+	layer = 2;
+	level = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/research/lab)
+"GSF" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
 "GTL" = (
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/plasma{
@@ -19333,6 +19390,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
+"GVF" = (
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	tag = "icon-dvalve_map (EAST)";
+	icon_state = "dvalve_map";
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
 "GWB" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio2";
@@ -19345,6 +19414,23 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
+"GXx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
+	},
+/obj/item/device/analyzer,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"GZj" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "HaT" = (
 /obj/machinery/camera{
 	c_tag = "Robotics East";
@@ -19357,10 +19443,23 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"HbO" = (
-/obj/structure/sign/securearea,
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/atmos)
+"Hbu" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
 "HbP" = (
 /obj/structure/chair/bridge{
 	dir = 4
@@ -19370,6 +19469,17 @@
 	mouse_over_pointer = 0;
 	name = "Battle Bridge"
 	})
+"Hci" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "O2 to Airmix";
+	on = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "Hcm" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -19456,10 +19566,6 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engine_smes)
-"Hha" = (
-/obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "HhR" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -19485,6 +19591,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
+"Hks" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/atmos/equipment)
 "HlZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -19499,6 +19612,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"Hnc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/medbay)
 "Hnk" = (
 /obj/machinery/camera{
 	c_tag = "Janitor's Closet";
@@ -19523,21 +19648,6 @@
 	dir = 2
 	},
 /area/shuttle/ftl/hydroponics)
-"Hoq" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "8;7"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/starboard)
 "Hqa" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -19583,30 +19693,73 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
+"HrR" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance";
+	req_access_txt = "0";
+	req_one_access_txt = "0"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
 "HtO" = (
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/cargo/mining)
-"Huf" = (
-/obj/machinery/air_sensor{
-	frequency = 1441;
-	id_tag = "co2_sensor"
+"Hun" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
-/obj/structure/window/reinforced,
-/turf/open/floor/engine/co2,
-/area/shuttle/ftl/atmos)
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
 "HuB" = (
 /obj/structure/sign/poster{
 	pixel_y = -32
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engine_smes)
+"Hvh" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/rack,
+/obj/item/weapon/aiModule/core/full/corp,
+/obj/item/weapon/aiModule/core/full/asimov,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/circuit,
+/area/shuttle/ftl/turret_protected/ai)
+"Hyt" = (
+/obj/structure/window/reinforced{
+	dir = 2
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8;
+	frequency = 1441;
+	id = "hydrogen_in";
+	pixel_y = 1
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/atmos)
 "HyL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -19681,6 +19834,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
+"HCM" = (
+/obj/machinery/meter,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "HCN" = (
 /obj/structure/table,
 /obj/item/weapon/extinguisher{
@@ -19774,15 +19937,6 @@
 "HHX" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/hor)
-"HIh" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "HIp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -19835,6 +19989,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"HLi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "HLs" = (
 /obj/structure/chair/bridge{
 	dir = 8
@@ -19923,6 +20086,24 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
+"HQg" = (
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Research Director's Office";
+	network = list("SS13","RD")
+	},
+/obj/structure/closet/secure_closet/RD,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/hor)
 "HQp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
@@ -19944,6 +20125,15 @@
 /obj/machinery/food_cart,
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
+"HRN" = (
+/obj/structure/chair,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig{
+	name = "Departures Checkpoint"
+	})
 "HSG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -20056,6 +20246,15 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/subshuttle/pod_3)
+"Imk" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "Ioh" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -20092,25 +20291,21 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/brig)
-"Iui" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+"Ism" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"IvO" = (
-/obj/machinery/washing_machine,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/atmos/equipment)
+"IuX" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/atmos/equipment)
 "Iye" = (
 /obj/structure/cryofeed/right,
 /turf/open/floor/plasteel/white,
@@ -20175,19 +20370,6 @@
 "IIy" = (
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/virology)
-"IIM" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "brig_enter_shutters"
-	},
-/obj/machinery/door/airlock/security{
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access = null;
-	req_access_txt = "38"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "IKh" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -20230,24 +20412,6 @@
 	},
 /turf/open/floor/plasteel/blue,
 /area/shuttle/ftl/medical/genetics)
-"INV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/bar,
-/area/shuttle/ftl/crew_quarters/bar)
 "IOT" = (
 /obj/structure/grille,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -20342,24 +20506,34 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
-"IRZ" = (
-/obj/item/weapon/storage/wallet/random,
-/obj/structure/closet/masks,
-/obj/structure/closet/secure_closet/personal,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/shoes/winterboots,
+"ISm" = (
+/obj/effect/landmark/start{
+	name = "Ship Engineer";
+	shuttle_abstract_movable = 1
+	},
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/locker)
+/area/shuttle/ftl/engine/engineering)
+"ISN" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 2;
+	filter_type = "co2";
+	icon_state = "filter_off";
+	on = 1;
+	tag = "icon-filter_off (WEST)"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"ITx" = (
+/obj/machinery/camera{
+	c_tag = "Shield Generator";
+	dir = 4;
+	network = list("SS13","Supermatter")
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
 "IUK" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"IUQ" = (
-/obj/machinery/recharge_station,
-/obj/effect/landmark/start{
-	name = "Cyborg"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "IVj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -20414,6 +20588,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
+"JbE" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "JbS" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/energy/gun/advtaser{
@@ -20433,19 +20614,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
-"JdY" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
-	dir = 9
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "JeA" = (
 /obj/machinery/power/apc/priority{
 	auto_name = 1;
@@ -20472,23 +20640,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/entry)
-"JkB" = (
-/obj/structure/chair/office{
-	dir = 2
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/effect/landmark/start{
-	name = "Chaplain"
+"JhQ" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig{
+	name = "Departures Checkpoint"
+	})
+"Jjz" = (
+/obj/machinery/vending/autodrobe,
+/obj/machinery/newscaster{
+	pixel_x = 30
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
+"JkU" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/chair,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "JlD" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -20530,6 +20707,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
+"JnM" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "Jol" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
@@ -20537,37 +20720,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"JoJ" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 2
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/shuttle/ftl/crew_quarters/kitchen)
 "Jpd" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/warden)
-"Jqj" = (
-/obj/structure/chair,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/effect/landmark/start{
-	name = "Assistant"
-	},
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "JsC" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -20635,6 +20790,23 @@
 	},
 /turf/open/floor/plasteel/blue,
 /area/shuttle/ftl/medical/genetics)
+"JwP" = (
+/obj/structure/rack{
+	dir = 1
+	},
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/weapon/storage/toolbox/emergency{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/obj/item/stack/sheet/mineral/wood{
+	amount = 30
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
 "Jxa" = (
 /obj/machinery/vending/security,
 /obj/structure/sign/poster{
@@ -20678,18 +20850,6 @@
 /obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
-"JDg" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "JEk" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/poster{
@@ -20697,21 +20857,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/secondary/construction)
-"JEs" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 2
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "JEv" = (
 /obj/machinery/vending/clothing,
 /obj/machinery/firealarm{
@@ -20806,10 +20951,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
-"JKK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/engineering)
+"JLJ" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "JOb" = (
 /obj/structure/table,
 /obj/item/weapon/weldingtool,
@@ -20867,6 +21021,40 @@
 	dir = 2
 	},
 /area/shuttle/ftl/cargo/mining)
+"JQt" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/ai_status_display{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"JQL" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8;
+	external_pressure_bound = 0;
+	frequency = 1441;
+	id_tag = "tox_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	on = 1;
+	pressure_checks = 2;
+	pump_direction = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/engine/plasma,
+/area/shuttle/ftl/atmos)
 "JRc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -20875,6 +21063,47 @@
 /obj/machinery/door/airlock/bridge,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
+"JRz" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "brig_enter_shutters"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/door/airlock/security{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access = null;
+	req_access_txt = "38"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
+"JSw" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "n2o_sensor"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/engine/n2o,
+/area/shuttle/ftl/atmos)
 "JUz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_medical{
@@ -20915,16 +21144,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/locker)
-"JXp" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Ship Engineer";
-	shuttle_abstract_movable = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engineering)
 "JXF" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/light{
@@ -21071,6 +21290,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"Kmu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel/loadingarea{
+	dir = 2
+	},
+/area/shuttle/ftl/hallway/primary/port)
 "KmN" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel,
@@ -21127,6 +21357,17 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/meeting_room)
+"KqL" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/clothing/shoes/magboots{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/engineering)
 "Ksn" = (
 /obj/machinery/shieldwallgen,
 /obj/machinery/light{
@@ -21257,10 +21498,6 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"KEb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/engine/engineering)
 "KEm" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -21299,48 +21536,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/exit)
-"KHe" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/machinery/meter,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"KHL" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall13";
-	dir = 2
-	},
-/area/shuttle/ftl/subshuttle/pod_3)
-"KIG" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance";
-	req_access_txt = "1";
-	req_one_access_txt = "0"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "brig_enter_shutters";
-	layer = 2
-	},
+"KHq" = (
 /obj/structure/cable{
 	crit_fail = 0;
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
+"KHL" = (
+/turf/closed/wall/shuttle{
+	icon_state = "swall13";
+	dir = 2
 	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/security/main)
+/area/shuttle/ftl/subshuttle/pod_3)
 "KIK" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -21434,20 +21645,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"KMc" = (
-/obj/machinery/door/airlock/hatch{
-	frequency = 1449;
-	icon_state = "door_locked";
-	id_tag = "outercore";
-	locked = 1;
-	name = "Maintenance Hatch";
-	req_access_txt = "8"
-	},
-/obj/machinery/door/poddoor{
-	id = "Supermatter doors"
-	},
-/turf/open/floor/noslip,
-/area/shuttle/ftl/engine/engineering)
 "KMs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -21466,22 +21663,12 @@
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
-"KOh" = (
-/obj/structure/closet/secure_closet/RD,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+"KNC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/hor)
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/atmos)
 "KOu" = (
 /obj/machinery/sleeper{
 	dir = 8;
@@ -21517,6 +21704,21 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/main)
+"KRR" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/effect/landmark/start{
+	name = "Chaplain"
+	},
+/obj/structure/chair,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "KRW" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -21538,6 +21740,21 @@
 "KUu" = (
 /turf/closed/wall,
 /area/shuttle/ftl/security/brig)
+"KVe" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Starboard Airlock"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
 "KVv" = (
 /obj/structure/table/glass,
 /obj/item/clothing/suit/straight_jacket,
@@ -21594,16 +21811,23 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
+"KZM" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4;
+	frequency = 1441;
+	id = "o2_in"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/engine/o2,
+/area/shuttle/ftl/atmos)
 "KZS" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/medical/genetics)
-"Lcd" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	icon_state = "intact";
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "LdU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -21648,18 +21872,27 @@
 /obj/item/weapon/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
+"Lfj" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 1;
+	filter_type = -1;
+	on = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "LgU" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"Lhi" = (
-/obj/machinery/computer/atmos_alert,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "LhB" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall/shuttle,
 /area/shuttle/ftl/cargo/mining)
+"Lim" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/atmos)
 "LiB" = (
 /obj/structure/closet/wardrobe/chaplain_black,
 /obj/item/weapon/storage/book/bible,
@@ -21692,25 +21925,6 @@
 	mouse_over_pointer = 0;
 	name = "Battle Bridge"
 	})
-"LjR" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Research Director";
-	shuttle_abstract_movable = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 2
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/hor)
 "Lkb" = (
 /turf/open/floor/plasteel{
 	icon_state = "white"
@@ -21736,6 +21950,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"LkI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "LkS" = (
 /obj/structure/chair/comfy/black{
 	dir = 2
@@ -21781,15 +22004,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions/cannon)
-"LoB" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/loadingarea{
-	dir = 4
-	},
-/area/shuttle/ftl/hallway/primary/port)
 "LoE" = (
 /obj/structure/sink{
 	dir = 8;
@@ -21810,19 +22024,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
-"Lpu" = (
-/obj/machinery/vending/cola,
-/obj/machinery/camera{
-	c_tag = "Mineral Depot";
-	dir = 8;
-	network = list("SS13","RD")
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
 "Lqp" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -21861,6 +22062,14 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
+"LwW" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
 "Lxq" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -21883,11 +22092,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/exit)
+"LyL" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 0
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/hallway/primary/port)
 "LAB" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
+"LBF" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/tool_storage)
 "LBG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -21939,6 +22161,22 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/nuke_storage)
+"LCD" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/pipedispenser,
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	dir = 1;
+	icon_state = "manifold";
+	tag = "icon-manifold (EAST)"
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "LDX" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -21958,19 +22196,31 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engineering)
+"LGe" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig{
+	name = "Departures Checkpoint"
+	})
 "LGQ" = (
 /obj/machinery/ammo_rack/full,
 /turf/open/floor/plasteel/darkwarning/side{
 	dir = 4
 	},
 /area/shuttle/ftl/munitions)
-"LHB" = (
-/obj/machinery/computer/aifixer,
-/obj/machinery/light{
-	dir = 4
+"LHW" = (
+/obj/structure/sign/poster{
+	pixel_x = 32;
+	pixel_y = 0
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/hor)
+/obj/machinery/recharge_station,
+/obj/effect/landmark/start{
+	name = "Cyborg"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/engineering)
 "LIP" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 1
@@ -22008,6 +22258,13 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
+"LLi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "LLj" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -22072,6 +22329,16 @@
 /obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel/darkbrown,
 /area/shuttle/ftl/cargo/qm)
+"LTD" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
 "LTP" = (
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	tag = "icon-dvalve_map (EAST)";
@@ -22114,6 +22381,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/virology)
+"LXu" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
 "LXX" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -22175,14 +22457,6 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/shuttle/ftl/space)
-"Mdn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/meter,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "MdH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 4
@@ -22222,6 +22496,13 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
+"MlG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
+	},
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "MnO" = (
 /obj/machinery/shower{
 	dir = 8
@@ -22280,38 +22561,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/surgery)
-"MvT" = (
-/obj/machinery/computer/teleporter,
-/obj/machinery/camera{
-	c_tag = "Teleporter Room";
-	dir = 4
-	},
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/bridge/meeting_room{
-	name = "Teleporter"
-	})
-"MvV" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/machinery/computer/atmos_control/tank{
-	frequency = 1441;
-	input_tag = "tox_in";
-	name = "Plasma Supply Control";
-	output_tag = "tox_out";
-	sensors = list("tox_sensor" = "Tank")
-	},
-/turf/open/floor/plasteel/warning{
-	dir = 1
-	},
-/area/shuttle/ftl/atmos)
 "Mwo" = (
 /obj/effect/landmark/start{
 	name = "Botanist";
@@ -22356,27 +22605,36 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
-"MAp" = (
-/obj/structure/chair,
-/obj/machinery/light{
-	dir = 1
+"MAV" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"MBo" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
 "MBE" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
-"MEY" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
+"MEE" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/weapon/storage/box/lights/mixed,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "MFq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -22389,12 +22647,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"MFv" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "MHy" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -22422,22 +22674,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/office)
-"MIW" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/circuit,
-/area/shuttle/ftl/turret_protected/ai)
 "MJj" = (
 /obj/machinery/door/airlock/shuttle{
 	aiControlDisabled = 1;
@@ -22489,21 +22725,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"MLH" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Warehouse Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "20"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/cargo/storage)
 "MLM" = (
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
+"MLN" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 2
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
+"MMj" = (
+/obj/machinery/camera{
+	c_tag = "Bar";
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/plasteel/bar,
+/area/shuttle/ftl/crew_quarters/bar)
 "MNm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
@@ -22512,24 +22759,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"MOH" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "MQB" = (
 /obj/machinery/camera{
 	c_tag = "Departures Lobby 1";
@@ -22550,6 +22779,14 @@
 /obj/effect/landmark/latejoin,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/exit)
+"MQL" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "N2 to Pure"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "MSr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 2
@@ -22567,6 +22804,12 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engineering)
+"MTM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "MUz" = (
 /obj/machinery/mass_driver{
 	dir = 8;
@@ -22663,11 +22906,17 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/hos)
-"Nbe" = (
-/obj/structure/table/wood,
-/obj/item/weapon/hand_tele,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/captain)
+"NbF" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 2
+	},
+/obj/machinery/meter,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "NcX" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/condiment/enzyme{
@@ -22730,35 +22979,6 @@
 	mouse_over_pointer = 0;
 	name = "Battle Bridge"
 	})
-"Ngo" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "brig_enter_shutters"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/door/airlock/security{
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access = null;
-	req_access_txt = "38"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "Nhf" = (
 /obj/structure/table/wood,
 /obj/item/weapon/card/id/captains_spare,
@@ -22802,23 +23022,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/shuttle/ftl/bridge)
-"NmO" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 2;
-	frequency = 1441;
-	id = "co2_in";
-	pixel_y = 1
+"Noe" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/engine/co2,
-/area/shuttle/ftl/atmos)
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/medbay)
 "Now" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -22835,6 +23050,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
+"NoK" = (
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/obj/structure/table,
+/obj/item/weapon/folder/blue,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/device/lightreplacer,
+/obj/item/weapon/pen,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/break_room)
 "NoN" = (
 /obj/structure/janitorialcart,
 /turf/open/floor/plating,
@@ -22876,20 +23118,21 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/toilet)
+"Nrt" = (
+/obj/machinery/computer/secure_data,
+/obj/machinery/newscaster{
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig{
+	name = "Departures Checkpoint"
+	})
 "Nry" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/telecomms/computer)
 "NrF" = (
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/main)
-"NrN" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/ai_status_display{
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "Nsj" = (
 /obj/machinery/processor,
 /obj/machinery/status_display{
@@ -22938,6 +23181,14 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/armory)
+"NuU" = (
+/obj/machinery/conveyor{
+	dir = 2;
+	id = "munitions";
+	tag = "munitions west"
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/munitions)
 "Nvh" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -23059,12 +23310,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"NIK" = (
-/obj/structure/dresser,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/locker)
-"NJa" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
+"NFe" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
+"NGC" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 8;
+	icon_state = "intact"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
 "NJM" = (
@@ -23155,16 +23415,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/meeting_room)
-"NQU" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
-	},
-/turf/closed/wall,
-/area/shuttle/ftl/maintenance/engineering)
 "NQZ" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -23216,9 +23466,13 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"NSK" = (
-/turf/closed/wall,
-/area/shuttle/ftl/medical/surgery)
+"NVn" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
+/obj/item/weapon/wrench,
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
 "NVD" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -23247,23 +23501,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/toilet)
-"NWc" = (
-/obj/item/weapon/storage/secure/briefcase{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/weapon/implanter/tracking,
-/obj/item/weapon/storage/lockbox/medal,
-/obj/structure/table/wood,
-/obj/item/weapon/disk/nuclear,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/captain)
-"NWe" = (
-/obj/machinery/light{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/mining)
 "NXR" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -23284,6 +23521,24 @@
 	},
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
+"NYo" = (
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	external_pressure_bound = 0;
+	frequency = 1441;
+	id_tag = "o2_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	on = 1;
+	pressure_checks = 2;
+	pump_direction = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/engine/o2,
+/area/shuttle/ftl/atmos)
 "NYX" = (
 /obj/structure/sink{
 	dir = 8;
@@ -23368,6 +23623,18 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
+"OdU" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/door/airlock/hatch{
+	frequency = 1449;
+	icon_state = "door_locked";
+	id_tag = "outercore";
+	locked = 1;
+	name = "Maintenance Hatch";
+	req_access_txt = "8"
+	},
+/turf/open/floor/noslip,
+/area/shuttle/ftl/engine/engineering)
 "Ofa" = (
 /obj/structure/table,
 /obj/machinery/firealarm{
@@ -23390,27 +23657,33 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
+"OfB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
+	},
+/obj/machinery/pipedispenser/disposal,
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"Ogm" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "munitions";
+	pixel_x = -10
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/munitions)
 "Ogz" = (
 /obj/structure/closet/wardrobe/botanist,
 /turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
 /area/shuttle/ftl/hydroponics)
-"Ohj" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "Oie" = (
 /obj/structure/closet/wardrobe/red,
 /obj/machinery/power/apc{
@@ -23578,20 +23851,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"OoM" = (
-/obj/machinery/teleport/station,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/bridge/meeting_room{
-	name = "Teleporter"
-	})
 "Oph" = (
 /obj/machinery/ftl_drive,
 /turf/open/floor/engine,
@@ -23626,6 +23885,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/virology)
+"Otx" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/shuttle/ftl/atmos/equipment)
 "Ouh" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -23728,29 +23991,6 @@
 	mouse_over_pointer = 0;
 	name = "Battle Bridge"
 	})
-"OCE" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 2
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"OCV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/engineering)
 "OEc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -23792,30 +24032,23 @@
 /obj/item/device/radio/intercom,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
-"OIT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+"OLm" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6;
+	icon_state = "intact"
 	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/cargo/storage)
-"OJi" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Engine North";
-	dir = 6;
-	network = list("SS13","Supermatter")
-	},
-/obj/structure/table,
-/obj/item/weapon/storage/firstaid/fire,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8;
-	icon_state = "intact";
-	tag = "icon-intact (NORTH)"
+/obj/machinery/computer/atmos_control/tank{
+	frequency = 1441;
+	input_tag = "n2_in";
+	name = "Nitrogen Supply Control";
+	output_tag = "n2_out";
+	sensors = list("n2_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engineering)
+/area/shuttle/ftl/atmos)
 "OLz" = (
 /obj/machinery/computer/ftl_weapons{
 	name = "Auxiliary Tacitcal Console";
@@ -23842,10 +24075,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"ONn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "ONA" = (
 /obj/machinery/computer/station_alert,
 /turf/open/floor/plasteel/circuit,
@@ -23890,16 +24119,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/main)
-"OQN" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
-	},
-/turf/closed/wall,
-/area/shuttle/ftl/hallway/primary/port)
 "OTN" = (
 /obj/machinery/computer/prisoner,
 /obj/machinery/button/door{
@@ -23929,14 +24148,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/chargebay)
-"OUH" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	tag = "icon-manifold (NORTH)";
-	icon_state = "manifold";
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "OVU" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -23967,22 +24178,6 @@
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
-"OYf" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/device/radio/beacon,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "OYC" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
@@ -24010,6 +24205,14 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"Pbx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/portable_atmospherics/scrubber/huge,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "Pcf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 1
@@ -24120,35 +24323,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"PlV" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
+"Pmg" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
-/obj/item/weapon/storage/box/bodybags{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/weapon/storage/box/rxglasses{
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/obj/item/clothing/tie/stethoscope,
-/obj/item/clothing/tie/stethoscope,
-/obj/item/weapon/gun/syringe,
-/obj/structure/table/glass,
-/obj/machinery/airalarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/shuttle/ftl/medical/medbay)
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
 "Pmm" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -24159,6 +24339,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/secondary/construction)
+"PmA" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Pure to Mix";
+	on = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "PmF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 4
@@ -24220,21 +24409,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/telecomms/server)
-"Poj" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 22
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "PqU" = (
 /obj/machinery/turretid{
 	control_area = "AI Chamber";
@@ -24278,15 +24452,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"PrV" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Mineral Depot"
+"PrF" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 2
 	},
-/obj/structure/fans/tiny,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/engineering)
 "Pwf" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
@@ -24306,9 +24484,6 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/captain)
-"PAN" = (
-/turf/closed/wall,
-/area/shuttle/ftl/hallway/secondary/entry)
 "PBH" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
@@ -24385,24 +24560,6 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/captain)
-"PIU" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 2
-	},
-/obj/machinery/door/airlock/glass_engineering{
-	name = "FTL Drive";
-	req_access_txt = "34";
-	req_one_access_txt = "0"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engineering)
 "PKp" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "bar_shutters"
@@ -24531,6 +24688,52 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"PSC" = (
+/obj/machinery/camera{
+	c_tag = "Mining Shuttle Storage";
+	dir = 10
+	},
+/obj/machinery/button/door{
+	id = "shuttle2";
+	name = "ORM Shutter Control";
+	pixel_x = 6;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"PSM" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
+"PTv" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "PTO" = (
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion";
@@ -24648,6 +24851,45 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
+"Qdw" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Research Director";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 2
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/hor)
+"QdG" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "N2 to Airmix";
+	on = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "Qfs" = (
 /obj/structure/closet/firecloset/full,
 /obj/structure/cable{
@@ -24730,6 +24972,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/virology)
+"Qlh" = (
+/obj/item/weapon/reagent_containers/food/snacks/cakeslice/plain,
+/turf/open/floor/plasteel/darkwarning{
+	dir = 1
+	},
+/area/shuttle/ftl/munitions)
 "QnO" = (
 /obj/machinery/pdapainter,
 /obj/machinery/camera{
@@ -24748,6 +24996,39 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/lab)
+"QoT" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/brig{
+	name = "Departures Checkpoint"
+	})
+"Qqa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/obj/structure/table,
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/clothing/head/welding{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/device/assembly/signaler,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
+"Qqv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "QuZ" = (
 /obj/structure/window/reinforced{
 	dir = 2
@@ -24797,36 +25078,40 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/meeting_room)
+"QwW" = (
+/obj/machinery/computer/station_alert,
+/obj/machinery/newscaster{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "QxK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"QxT" = (
-/obj/machinery/light/small{
-	dir = 4
+"QAl" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 2
 	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
+"QBK" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 32
 	},
-/obj/machinery/recharge_station,
-/obj/effect/landmark/start{
-	name = "Cyborg"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
-/turf/open/floor/plasteel/circuit,
-/area/shuttle/ftl/turret_protected/ai)
-"Qzy" = (
-/obj/machinery/computer/arcade,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"QDc" = (
-/obj/structure/closet/crate,
-/obj/item/weapon/reagent_containers/food/snacks/grilledcheese,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
+"QCh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/engineering)
 "QDl" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -24937,6 +25222,26 @@
 	dir = 2
 	},
 /area/shuttle/ftl/hydroponics)
+"QLG" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"QLP" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 2
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
 "QML" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -24968,14 +25273,6 @@
 	dir = 1
 	},
 /area/shuttle/ftl/engine/engineering)
-"QOz" = (
-/obj/machinery/meter,
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plasteel/blue/side{
-	dir = 6
-	},
-/area/shuttle/ftl/atmos)
 "QOC" = (
 /obj/structure/table,
 /obj/item/weapon/paper_bin,
@@ -25183,28 +25480,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/meeting_room)
-"RdL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1;
-	external_pressure_bound = 0;
-	frequency = 1441;
-	id_tag = "o2_out";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	on = 1;
-	pressure_checks = 2;
-	pump_direction = 0
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/engine/o2,
-/area/shuttle/ftl/atmos)
 "RdP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -25267,9 +25542,11 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engineering)
-"Riq" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel/bot,
+"RiV" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
 "Rjd" = (
 /obj/machinery/power/apc{
@@ -25291,24 +25568,6 @@
 /obj/machinery/suit_storage_unit/cmo,
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/ftl/medical/cmo)
-"RkL" = (
-/obj/machinery/power/apc/priority{
-	auto_name = 1;
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	tag = "icon-dvalve_map (EAST)";
-	icon_state = "dvalve_map";
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/engineering)
 "Rms" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -25334,6 +25593,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/chemistry)
+"RnF" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Air to Mix";
+	on = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "RnV" = (
 /obj/structure/sink{
 	dir = 8;
@@ -25367,20 +25637,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/crew_quarters/heads)
-"Rpd" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 22
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "Rpy" = (
 /obj/structure/chair/stool/bar,
 /obj/structure/cable{
@@ -25405,16 +25661,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/ftl/assembly/robotics)
-"Rqm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "munitions";
-	pixel_x = -10
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/munitions)
 "RqB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -25458,17 +25704,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
-"Rtx" = (
-/obj/structure/window/reinforced,
-/obj/machinery/computer/atmos_control/tank{
-	frequency = 1441;
-	input_tag = "o2_in";
-	name = "Oxygen Supply Control";
-	output_tag = "o2_out";
-	sensors = list("o2_sensor" = "Tank")
-	},
-/turf/open/floor/plasteel/blue/side,
-/area/shuttle/ftl/atmos)
 "RtR" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -25517,6 +25752,12 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"Rvb" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "Rxa" = (
 /obj/structure/closet/firecloset/full,
 /obj/machinery/status_display{
@@ -25526,28 +25767,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/meeting_room)
-"Rxy" = (
-/obj/structure/table,
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/clothing/head/welding{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/device/multitool,
-/obj/item/device/radio,
-/obj/item/weapon/electronics/airlock{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/device/assembly/signaler,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "Ryi" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -25558,21 +25777,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"Ryj" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/engineering)
 "RzX" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -25673,6 +25877,14 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/telecomms/server)
+"RJs" = (
+/obj/structure/table/wood,
+/obj/item/weapon/locator,
+/obj/item/weapon/disk/nuclear,
+/obj/item/weapon/implanter/tracking,
+/obj/item/weapon/implanter/tracking,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/captain)
 "RLO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
@@ -25703,6 +25915,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"RMU" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/maintenance/medbay)
 "RMW" = (
 /obj/item/device/radio,
 /obj/structure/rack,
@@ -25752,6 +25967,18 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
+"RPK" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "RQJ" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -25866,16 +26093,73 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
+"RZl" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/item/stack/rods{
+	amount = 2
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge/meeting_room{
+	name = "Teleporter"
+	})
 "RZy" = (
 /obj/machinery/cryopod/right,
 /turf/open/floor/plasteel/white/side{
 	dir = 9
 	},
 /area/shuttle/ftl/crew_quarters/sleep)
+"RZF" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j1"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "Sao" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
+"SaL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Library"
+	})
 "SbS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -25928,6 +26212,26 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
+"Sep" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"SeP" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/chair,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "SfN" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -25959,12 +26263,6 @@
 "ShW" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"SiK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "Sjk" = (
 /obj/structure/filingcabinet/chestdrawer/wheeled,
 /obj/machinery/firealarm{
@@ -25980,28 +26278,6 @@
 	dir = 2
 	},
 /area/shuttle/ftl/cargo/mining)
-"Smi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 2;
-	external_pressure_bound = 0;
-	frequency = 1441;
-	id_tag = "n2o_out";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	on = 1;
-	pressure_checks = 2;
-	pump_direction = 0
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/engine/n2o,
-/area/shuttle/ftl/atmos)
 "SpE" = (
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -26066,21 +26342,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/telecomms/server)
-"SqT" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	moving_diagonally = 0;
-	name = "Tool Storage";
-	req_access_txt = "8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/tool_storage)
 "SqV" = (
 /obj/structure/chair,
 /obj/machinery/light/small{
@@ -26166,6 +26427,12 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions/cannon)
+"Suk" = (
+/obj/structure/frame,
+/turf/open/floor/plasteel/darkwarning{
+	dir = 1
+	},
+/area/shuttle/ftl/munitions)
 "Swu" = (
 /obj/machinery/light{
 	dir = 8
@@ -26271,41 +26538,20 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/atmos)
-"SFc" = (
-/obj/machinery/light{
-	dir = 2
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 2
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/meter,
-/obj/machinery/camera{
-	c_tag = "FTL Drive";
-	dir = 1
+"SFN" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engineering)
-"SGy" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "SGO" = (
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engine_smes)
+"SHc" = (
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig{
+	name = "Departures Checkpoint"
+	})
 "SIu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
@@ -26438,20 +26684,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/entry)
-"STO" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8
-	},
-/obj/structure/closet/firecloset/full,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/ai_status_display{
-	pixel_x = -32;
+"SRN" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
 	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
+"SSd" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"STt" = (
+/turf/open/floor/plasteel/darkwarning{
+	dir = 2
+	},
+/area/shuttle/ftl/munitions)
 "SVf" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "tele_shutters"
@@ -26517,6 +26772,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
+"Taf" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
 "Tar" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 1
@@ -26610,14 +26886,6 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/ftl/subshuttle/pod_3)
-"Tcv" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "TcG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -26631,6 +26899,31 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"Tej" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start{
+	name = "Lawyer"
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/bar,
+/area/shuttle/ftl/crew_quarters/bar)
+"Tes" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 9
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "TeP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -26662,38 +26955,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Tgx" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"Thq" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1;
-	frequency = 1441;
-	id = "air_in"
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/engine/air,
-/area/shuttle/ftl/atmos)
 "Tht" = (
 /obj/structure/table/wood/poker,
 /obj/item/device/instrument/guitar,
@@ -26731,6 +26992,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
+"TjK" = (
+/obj/structure/closet/boxinggloves,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
 "Tka" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/entry)
@@ -26750,6 +27015,21 @@
 /obj/item/weapon/book/manual/ftl_wiki/supermatter,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/chiefs_office)
+"TmI" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4;
+	frequency = 1441;
+	id = "co2_in";
+	pixel_y = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/engine/co2,
+/area/shuttle/ftl/atmos)
 "TnA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
@@ -26783,22 +27063,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/virology)
-"Tqs" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"Txm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"Trh" = (
-/obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
+/turf/open/floor/engine,
+/area/shuttle/ftl/munitions)
 "Tzr" = (
 /obj/structure/table/glass,
 /obj/structure/sink{
@@ -26918,6 +27188,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"THT" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "N2O to Pure";
+	on = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "TIa" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
@@ -26980,6 +27259,26 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/turret_protected/ai)
+"TKS" = (
+/obj/machinery/door/airlock{
+	name = "Library"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Library"
+	})
 "TKV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -26992,6 +27291,16 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/chemistry)
+"TLf" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/atmos/equipment)
 "TLV" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -27040,6 +27349,19 @@
 	icon_state = "delivery"
 	},
 /area/shuttle/ftl/engine/engineering)
+"TPs" = (
+/obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing,
+/obj/structure/table/wood,
+/obj/item/device/pda{
+	desc = "The prized possession of any greedy assistant. Too bad the slick surface has rubbed off.";
+	icon_state = "pda-clown";
+	name = "dusty clown pda"
+	},
+/obj/item/device/paicard,
+/obj/item/weapon/dice/d20,
+/obj/item/weapon/dice,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "TQF" = (
 /obj/machinery/door/airlock/shuttle,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -27116,13 +27438,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/exit)
-"UaN" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics Storage"
-	},
-/obj/machinery/suit_storage_unit/atmos,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "UaY" = (
 /obj/structure/closet/secure_closet/freezer/money,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/vodka/badminka,
@@ -27172,6 +27487,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"UiN" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "air_sensor"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/engine/air,
+/area/shuttle/ftl/atmos)
 "Ulg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2
@@ -27238,40 +27564,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"UoA" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
-"Upn" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Conference Room Access";
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = -8;
-	pixel_y = 24
-	},
-/obj/structure/chair/office{
-	dir = 2
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/bridge)
 "UpO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -27299,27 +27591,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"UqQ" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/chair/office{
-	dir = 2
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/bridge)
 "Urg" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -27347,6 +27618,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"UrZ" = (
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/structure/chair{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/secondary/construction)
 "Ute" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -27376,49 +27657,11 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
-"UyI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "UzY" = (
 /obj/structure/window/shuttle,
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/ftl/subshuttle/pod_3)
-"UAm" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/priority{
-	auto_name = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"UBb" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "UBf" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4
@@ -27431,6 +27674,18 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/telecomms/computer)
+"UCj" = (
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "UCP" = (
 /obj/structure/chair/comfy/captain{
 	dir = 1
@@ -27449,15 +27704,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engineering)
-"UEZ" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/obj/structure/table,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "UFa" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2
@@ -27473,6 +27719,18 @@
 "UFB" = (
 /turf/open/floor/mech_bay_recharge_floor,
 /area/shuttle/ftl/cargo/mining)
+"UFQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/atmos)
 "UGw" = (
 /obj/machinery/power/apc{
 	auto_name = 1;
@@ -27488,6 +27746,11 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/surgery)
+"UGB" = (
+/turf/closed/wall,
+/area/shuttle/ftl/security/brig{
+	name = "Departures Checkpoint"
+	})
 "UIa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -27519,19 +27782,23 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"UKx" = (
+"UKD" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/structure/chair/office{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/bar,
-/area/shuttle/ftl/crew_quarters/bar)
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig{
+	name = "Departures Checkpoint"
+	})
+"UKU" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/medical/surgery)
 "ULj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -27559,6 +27826,15 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/cargo/mining)
+"UND" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Clown"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "UNF" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -27608,22 +27884,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"UQK" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"URw" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "URB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -27642,6 +27902,20 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/brig)
+"USv" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "brig_enter_shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/security{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access = null;
+	req_access_txt = "38"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "UWI" = (
 /obj/machinery/computer/pmanagement,
 /obj/structure/cable{
@@ -27656,14 +27930,6 @@
 /mob/living/simple_animal/parrot/Poly,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/chiefs_office)
-"UXy" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	tag = "icon-intact (SOUTHWEST)";
-	icon_state = "intact";
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "Vam" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -27676,18 +27942,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"Vaq" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "VaM" = (
 /obj/effect/landmark/ship_fire,
 /turf/open/space,
@@ -27779,18 +28033,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
+"VjA" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/atmos/equipment)
 "VkC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/office)
-"Vlg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/shuttle/ftl/medical/medbay)
 "VlG" = (
 /obj/structure/table,
 /obj/item/weapon/book/random,
@@ -27845,6 +28102,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
+"Vpe" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
+"Vpt" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "Vqh" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engineering)
@@ -27860,17 +28134,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/hos)
-"VrQ" = (
-/obj/structure/closet/wardrobe/atmospherics_yellow,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/obj/machinery/newscaster{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "VsA" = (
 /obj/structure/chair{
 	dir = 4
@@ -27899,6 +28162,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"VtY" = (
+/obj/item/chair{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "VvF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 2
@@ -27954,12 +28227,29 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"VAK" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 4;
-	initialize_directions = 11
+"VyV" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
 	},
-/obj/machinery/meter,
+/obj/item/weapon/wrench,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"VBu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/obj/structure/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12
+	},
+/obj/effect/landmark{
+	name = "lightsout"
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
 "VBx" = (
@@ -27969,19 +28259,6 @@
 /obj/machinery/computer/scan_consolenew,
 /turf/open/floor/plasteel/blue,
 /area/shuttle/ftl/medical/genetics)
-"VBH" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/bar,
-/area/shuttle/ftl/crew_quarters/bar)
 "VDa" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 0;
@@ -28000,6 +28277,17 @@
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
+"VDn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/atmos)
 "VEq" = (
 /obj/structure/sign/poster{
 	pixel_x = -32
@@ -28015,6 +28303,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
+"VFG" = (
+/obj/machinery/computer/security,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig{
+	name = "Departures Checkpoint"
+	})
 "VGf" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -28082,6 +28376,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"VIZ" = (
+/obj/machinery/light/small{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 2
+	},
+/obj/structure/fireaxecabinet{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "VLP" = (
 /obj/structure/cryofeed,
 /turf/open/floor/plasteel/white,
@@ -28119,29 +28425,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"VPc" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/shuttle/ftl/medical/medbay)
-"VPN" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 9
-	},
-/area/shuttle/ftl/atmos)
 "VPO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -28199,6 +28482,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/toilet)
+"VTV" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig{
+	name = "Departures Checkpoint"
+	})
 "VUr" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -28247,12 +28547,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"VXZ" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "VZz" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -28264,6 +28558,14 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/brig)
+"VZS" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor/shutters{
+	id = "shuttle2";
+	name = "shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/mining)
 "VZU" = (
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
@@ -28300,6 +28602,22 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/shuttle/ftl/space)
+"Wdr" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/weapon/storage/wallet/random,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/locker)
+"WdT" = (
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/item/device/pipe_painter,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "Wei" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -28315,6 +28633,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
+"WeZ" = (
+/obj/structure/shuttle/engine/heater{
+	icon_state = "heater";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/engineering)
 "Wiq" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/xenobiology)
@@ -28336,42 +28661,29 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/hos)
-"Wkt" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "starboard_external"
+"WlB" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 2;
+	filter_type = "o2";
+	icon_state = "filter_off";
+	on = 1;
+	tag = "icon-filter_off (EAST)"
 	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"WkX" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics External Access";
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"Wmy" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"WmJ" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Shield Generator";
-	dir = 2
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/engineering)
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/secondary/exit)
 "Wox" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4;
@@ -28395,6 +28707,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
+"Wtg" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/device/analyzer,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
 "Wts" = (
 /obj/machinery/camera{
 	c_tag = "Bridge South";
@@ -28403,6 +28725,11 @@
 /obj/machinery/computer/security,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
+"Wtt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/shuttle/ftl/atmos/equipment)
 "Wuo" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
@@ -28524,6 +28851,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/chemistry)
+"WDG" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = -10;
+	pixel_y = 22
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
 "WDK" = (
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
@@ -28562,39 +28908,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/storage)
-"WFZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"WGQ" = (
-/obj/machinery/meter,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	tag = "icon-manifold (EAST)";
-	icon_state = "manifold";
-	dir = 4
-	},
-/obj/machinery/pipedispenser/disposal,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"WHV" = (
-/obj/structure/closet/crate,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 22
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
 "WIy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -28702,19 +29015,28 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"WSw" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 8;
-	filter_type = "plasma";
-	icon_state = "filter_off";
-	on = 1;
-	tag = "icon-filter_off (WEST)"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "WSQ" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/tool_storage)
+"WSR" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/recharge_station,
+/obj/effect/landmark/start{
+	name = "Cyborg"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/circuit,
+/area/shuttle/ftl/turret_protected/ai)
 "WUb" = (
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/warden)
@@ -28729,16 +29051,6 @@
 	},
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
-"WVB" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/meter{
-	name = "Mixed Air Tank Out"
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/arrival{
-	dir = 6
-	},
-/area/shuttle/ftl/atmos)
 "WWc" = (
 /obj/structure/table/reinforced,
 /obj/item/device/mmi,
@@ -28756,23 +29068,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"WYN" = (
-/obj/machinery/door/window/northright{
-	dir = 8;
-	name = "Server Room";
-	req_access_txt = "19"
+"WZO" = (
+/obj/machinery/light{
+	dir = 2
 	},
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
-	dir = 8
-	},
-/turf/open/floor/bluegrid{
-	name = "Server Base";
-	initial_gas_mix = "n2=500;TEMP=80"
-	},
-/area/shuttle/ftl/research/server)
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/cargo/mining)
 "WZV" = (
 /obj/machinery/smartfridge/chemistry/virology,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -28898,6 +29202,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engineering)
+"XnS" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "XoS" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -28909,6 +29220,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
+"XpM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
 "Xrd" = (
 /obj/machinery/cryopod,
 /turf/open/floor/plasteel/white,
@@ -28936,6 +29256,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/toilet)
+"Xsh" = (
+/obj/machinery/door/poddoor{
+	id = "weapon_k_1";
+	name = "munitions launcher bay door"
+	},
+/turf/open/floor/plasteel/darkwarning{
+	dir = 1
+	},
+/area/shuttle/ftl/munitions)
 "Xsn" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -28957,23 +29286,16 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/surgery)
-"Xtd" = (
-/obj/structure/table,
-/obj/item/weapon/storage/toolbox/emergency,
-/obj/item/weapon/storage/toolbox/emergency,
-/obj/item/weapon/crowbar/large,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/tool_storage)
-"Xvh" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	pixel_x = -8;
-	pixel_y = -22
+"XtO" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
+/area/shuttle/ftl/atmos/equipment)
 "XvL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 1
@@ -28999,6 +29321,24 @@
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
+"XwH" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 0
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/hallway/secondary/exit)
+"Xxx" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Distro";
+	on = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "XxM" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -29023,21 +29363,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"Xyw" = (
-/obj/machinery/door/airlock/glass{
-	name = "Starboard Airlock"
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "XyU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
@@ -29113,16 +29438,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
-"XDt" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/space,
-/area/shuttle/ftl/space)
 "XFE" = (
 /obj/machinery/camera/motion{
 	c_tag = "AI Chamber South";
@@ -29168,22 +29483,6 @@
 	dir = 4
 	},
 /area/shuttle/ftl/crew_quarters/sleep)
-"XIf" = (
-/obj/structure/table/wood,
-/obj/item/weapon/reagent_containers/food/snacks/cakeslice/plain,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
-"XJl" = (
-/obj/machinery/meter,
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plasteel/blue/side{
-	dir = 10
-	},
-/area/shuttle/ftl/atmos)
 "XLo" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -29198,15 +29497,6 @@
 	dir = 10
 	},
 /area/shuttle/ftl/hydroponics)
-"XNV" = (
-/obj/structure/table,
-/obj/machinery/ai_status_display{
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/item/weapon/reagent_containers/food/snacks/cakeslice/plain,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "XOm" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/black,
@@ -29257,6 +29547,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"XWC" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "XYf" = (
 /obj/item/device/radio/intercom{
 	pixel_x = 0;
@@ -29292,6 +29588,12 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/brig)
+"XZi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/munitions)
 "Yah" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -29314,9 +29616,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/office)
-"YdM" = (
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
 "YeG" = (
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor"
@@ -29352,17 +29651,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/crew_quarters/heads)
-"Yiy" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/cargo/mining)
 "Yjb" = (
 /obj/machinery/light{
 	dir = 2
@@ -29408,16 +29696,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"Ymw" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "atmos blast door"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel/delivery{
-	name = "floor"
-	},
-/area/shuttle/ftl/atmos)
 "YmQ" = (
 /turf/closed/wall,
 /area/shuttle/ftl/hallway/primary/central)
@@ -29439,12 +29717,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
-"YnD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 1
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/engine/engineering)
 "YnT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -29462,20 +29734,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"Yol" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "brig_enter_shutters"
-	},
-/obj/machinery/door/airlock/security{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access = null;
-	req_access_txt = "38"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "Yoz" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -29490,25 +29748,6 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
-"YoN" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/northleft{
-	dir = 2;
-	icon_state = "left";
-	name = "Reception Window";
-	req_access_txt = "0"
-	},
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "RnD Desk";
-	req_access_txt = "26"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rnd_shutters";
-	layer = 2
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/research/lab)
 "YrB" = (
 /obj/structure/cryofeed/right,
 /obj/machinery/light/small{
@@ -29516,14 +29755,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/crew_quarters/sleep)
-"YrN" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "shuttle2";
-	name = "shutters"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/shuttle/ftl/cargo/mining)
 "YsL" = (
 /obj/structure/shuttle/engine/propulsion/burst{
 	tag = "icon-propulsion (NORTH)";
@@ -29560,6 +29791,20 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions)
+"YuR" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4;
+	frequency = 1441;
+	id = "n2_in"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/engine/n2,
+/area/shuttle/ftl/atmos)
 "Yvz" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -29568,6 +29813,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
+"Ywl" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	icon_state = "pump_map";
+	name = "Distro to Vents";
+	tag = "icon-pump_map (NORTH)"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "Yxq" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -29666,6 +29935,16 @@
 	},
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
+"YEU" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "YFG" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -29757,6 +30036,15 @@
 	dir = 1
 	},
 /area/shuttle/ftl/hydroponics)
+"YNz" = (
+/obj/item/weapon/storage/secure/briefcase{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/structure/table/wood,
+/obj/item/weapon/storage/lockbox/medal,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/captain)
 "YPg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -29772,18 +30060,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/brig)
-"YPG" = (
-/obj/structure/table/wood,
-/obj/item/device/pda{
-	desc = "The prized possession of any greedy assistant. Too bad the slick surface has rubbed off.";
-	icon_state = "pda-clown";
-	name = "dusty clown pda"
-	},
-/obj/item/device/paicard,
-/obj/item/weapon/dice/d20,
-/obj/item/weapon/dice,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "YQu" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -29901,6 +30177,12 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/main)
+"ZaY" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "Zbs" = (
 /obj/structure/chair{
 	dir = 4
@@ -29915,23 +30197,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/entry)
-"ZcN" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 22
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 1;
-	icon_state = "manifold";
-	tag = "icon-manifold (EAST)"
+"ZcO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair/office/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
+/area/shuttle/ftl/engine/break_room)
+"ZcT" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/item/weapon/wrench,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
+"Zde" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/medbay)
 "ZdO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -29943,14 +30229,6 @@
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/telecomms/server)
-"Zfk" = (
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 1";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "ZgC" = (
 /obj/structure/table/wood,
 /obj/machinery/airalarm{
@@ -29971,6 +30249,16 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
+"Zjm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 25
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "Zjw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -29997,6 +30285,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
+"ZkE" = (
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8;
+	frequency = 1441;
+	id = "tox_in";
+	pixel_y = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/engine/plasma,
+/area/shuttle/ftl/atmos)
 "Zma" = (
 /obj/machinery/door/airlock/glass{
 	name = "Port Airlock"
@@ -30012,22 +30313,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"Zpj" = (
-/turf/open/floor/plasteel/darkwarning{
-	dir = 5
-	},
-/area/shuttle/ftl/munitions)
-"Zps" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/escape{
-	dir = 5
-	},
-/area/shuttle/ftl/atmos)
 "Zqr" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 2;
@@ -30061,6 +30346,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/virology)
+"Zrs" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "ZrK" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
@@ -30100,6 +30391,12 @@
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engineering)
+"ZvY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/medbay)
 "Zwc" = (
 /obj/machinery/atmospherics/components/binary/circulator{
 	dir = 2
@@ -30114,6 +30411,22 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
+"ZxA" = (
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
 "Zzs" = (
 /obj/structure/closet/wardrobe/miner,
 /obj/structure/window/reinforced{
@@ -30121,6 +30434,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
+"ZzY" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "ZAS" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -30189,6 +30508,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
+"ZGt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "ZGM" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -30232,10 +30557,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/brig)
-"ZSt" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plasteel/bot,
-/area/shuttle/ftl/atmos)
 "ZSy" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/medical/virology)
@@ -30257,16 +30578,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"ZZP" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/effect/landmark/start{
-	name = "Bartender";
-	shuttle_abstract_movable = 1
-	},
-/turf/open/floor/plasteel/bar,
-/area/shuttle/ftl/crew_quarters/bar)
+"ZUa" = (
+/obj/machinery/computer/atmos_alert,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 
 (1,1,1) = {"
 Kky
@@ -49645,7 +49960,7 @@ toK
 toK
 toK
 toK
-Cde
+rHF
 PTO
 PTO
 PTO
@@ -49695,11 +50010,11 @@ toK
 toK
 toK
 toK
-wqq
-wqq
-wqq
-wqq
-ZEY
+hRo
+hRo
+hRo
+hRo
+Vqh
 toK
 toK
 toK
@@ -49902,7 +50217,7 @@ toK
 toK
 toK
 toK
-Cde
+rHF
 Yof
 Yof
 Yof
@@ -49911,7 +50226,7 @@ PTO
 PTO
 PTO
 PTO
-Cde
+rHF
 toK
 toK
 toK
@@ -49947,16 +50262,16 @@ toK
 toK
 toK
 toK
-ZEY
-wqq
-wqq
-wqq
-wqq
-Trh
-Trh
-Trh
-Trh
-ZEY
+Vqh
+hRo
+hRo
+hRo
+hRo
+WeZ
+WeZ
+WeZ
+WeZ
+Vqh
 toK
 toK
 toK
@@ -50158,17 +50473,17 @@ toK
 toK
 toK
 NVL
-Cde
-Cde
-Cde
-Cde
-Cde
-Cde
+rHF
+rHF
+rHF
+rHF
+rHF
+rHF
 Yof
 Yof
 Yof
 Yof
-Cde
+rHF
 toK
 toK
 toK
@@ -50200,21 +50515,21 @@ toK
 toK
 toK
 toK
-hhX
 toK
 toK
 toK
-ZEY
-Trh
-Trh
-Trh
-Trh
-ZEY
-ZEY
-ZEY
-ZEY
-ZEY
-ZEY
+toK
+Vqh
+WeZ
+WeZ
+WeZ
+WeZ
+Vqh
+Vqh
+Vqh
+Vqh
+Vqh
+Vqh
 NVL
 toK
 toK
@@ -50418,18 +50733,18 @@ toK
 VgA
 ShW
 LiB
-qCT
-DiH
-Vqh
-Vqh
-Vqh
-Vqh
-Vqh
-Vqh
+UCj
+EDx
+rHF
+rHF
+rHF
+rHF
+rHF
+rHF
 qSL
 qSL
 qSL
-hny
+BnG
 toK
 toK
 toK
@@ -50457,21 +50772,21 @@ toK
 toK
 toK
 toK
-tjG
-HTE
-HTE
-HTE
+sAz
+tsb
+tsb
+tsb
 Vqh
 Vqh
 Vqh
 Vqh
 Vqh
 Vqh
-pFq
-NrN
-pkg
-frH
-ctE
+GSF
+ZAS
+ZAS
+GSF
+BwR
 toK
 toK
 toK
@@ -50675,18 +50990,18 @@ toK
 VgA
 ShW
 EPK
-DiH
-DiH
-Vqh
-Mkl
-Mkl
-gNL
-ZAS
-Vqh
+EDx
+EDx
+Cde
+GZj
+bHR
+pCY
+iRQ
+Cde
 drw
 Kwf
 hTs
-hny
+BnG
 toK
 toK
 toK
@@ -50704,7 +51019,7 @@ Mkl
 Rik
 MHR
 nLk
-KMc
+wUp
 iMF
 eqA
 zcI
@@ -50714,21 +51029,21 @@ toK
 toK
 toK
 toK
-tjG
-IvO
-IvO
-UoA
+sAz
+Eii
+iky
+lKO
 Vqh
+Mkl
 Mkl
 gNL
-Mkl
-ZAS
-Vqh
-YPG
-FOC
-xAQ
-XIf
-ctE
+NFe
+erH
+NVn
+SFN
+AmW
+MLN
+BwR
 toK
 toK
 toK
@@ -50928,23 +51243,23 @@ toK
 toK
 toK
 NVL
-Cde
-Cde
-JkB
+rHF
+rHF
+KRR
 EMr
 DWa
 KdR
-Vqh
-xFw
-Mkl
-Mkl
-yoF
-Vqh
+Cde
+TPs
+ShW
+UND
+ltb
+Cde
 hjd
 uQo
-lGt
-hny
-hny
+iEY
+BnG
+BnG
 toK
 toK
 toK
@@ -50970,23 +51285,23 @@ KPe
 toK
 toK
 toK
-tjG
-tjG
-Jqj
-hNG
-zXn
+sAz
+sAz
+uub
+Ecu
+VIZ
 Vqh
-xFw
+Mkl
 Mkl
 Mkl
 LTP
+Mkl
+Mkl
+Mkl
+Mkl
+GVF
 Vqh
-zfY
-bia
-fqC
-yzD
-ZEY
-ZEY
+Vqh
 NVL
 toK
 toK
@@ -51189,19 +51504,19 @@ VgA
 spa
 ilt
 eyT
-DiH
-Xvh
-Vqh
-Wmy
-Mkl
-tRm
-oVy
-Cni
-uZL
+EDx
+dPj
+Cde
+EQz
+XnS
+yfw
+pon
+Cde
+JkU
 FXc
 gSv
 ZTg
-hny
+BnG
 toK
 toK
 toK
@@ -51218,7 +51533,7 @@ CSC
 mtt
 myD
 yEB
-wAX
+OdU
 wno
 oEI
 XYf
@@ -51227,23 +51542,23 @@ KPe
 toK
 toK
 toK
-tjG
-GNr
-mex
-JEs
-xfx
-PIU
-mCe
+sAz
+JbE
+gXQ
+aDx
+gec
+CAn
+Dtf
 Mkl
 Oph
-SFc
-Vqh
-yct
-FOC
-WFZ
-Goe
-vPe
-lNc
+Vpe
+Mkl
+Mkl
+Mkl
+tRm
+yXu
+ITx
+CCP
 toK
 toK
 toK
@@ -51446,19 +51761,19 @@ VgA
 yux
 ilt
 SVC
-DiH
-DiH
-Vqh
-lhw
-Mkl
-Mkl
-RkL
-Vqh
-mVf
+EDx
+EDx
+Cde
+dEa
+ShW
+jag
+Qqv
+Cde
+SeP
 PRp
 gSv
 Rgh
-hny
+BnG
 NVL
 NVL
 NVL
@@ -51484,23 +51799,23 @@ Vqh
 NVL
 NVL
 NVL
-tjG
-mhq
-tKK
-UBb
-BGj
+sAz
+JbE
+pYF
+uQQ
+hrD
 Vqh
-jmJ
+uaS
 Mkl
 Mkl
-lDb
-Vqh
-Qzy
-ynW
-mwb
-Iui
-qQI
-lNc
+fHO
+Mkl
+Mkl
+Mkl
+Mkl
+fHO
+Mkl
+CCP
 toK
 toK
 toK
@@ -51698,24 +52013,24 @@ toK
 toK
 toK
 toK
-Cde
-Cde
+rHF
+rHF
 Cde
 lym
 Cde
 Cde
 Cde
-Vqh
-OCV
-kDL
-JKK
-CGH
-KEb
+Cde
+pXd
+Jjz
+VtY
+Gnj
+pAO
 GyI
 flo
 lDx
 nkA
-hny
+BnG
 toK
 toK
 toK
@@ -51741,24 +52056,24 @@ KPe
 toK
 toK
 toK
-tjG
-eFb
-tKK
-OYf
-Zfk
-YnD
-dYW
-Ryj
-Ewj
-yrh
+sAz
+sAz
+Ism
+iGm
+hYr
 Vqh
-ZEY
-ZEY
-ZEY
-kCU
-ZEY
-ZEY
-ZEY
+WDG
+Ewj
+Ewj
+MBo
+Taf
+Ewj
+Ewj
+Ewj
+Duu
+Mkl
+CCP
+toK
 toK
 toK
 toK
@@ -51956,23 +52271,23 @@ toK
 toK
 toK
 VgA
-uKE
+MEE
 RBt
 ilt
 pjz
 uaH
 Ayi
-Vqh
-RTM
-Vqh
-Vqh
-Vqh
-Vqh
+Cde
+Cde
+Cde
+BBz
+Cde
+Cde
 wEA
 vXV
 Pbr
 fDo
-hny
+BnG
 toK
 toK
 toK
@@ -51998,24 +52313,24 @@ KPe
 toK
 toK
 toK
-tjG
-pgo
-tBC
-nCY
-GVv
+sAz
+WdT
+iWC
+qcU
+Qqa
+Vqh
+RTM
 Vqh
 Vqh
 Vqh
+QCh
 Vqh
 Vqh
 Vqh
-QDc
-VZz
-inE
-wsO
-vVu
-URw
-ctE
+DMV
+Vqh
+Vqh
+sAz
 toK
 toK
 toK
@@ -52222,14 +52537,14 @@ Ryi
 Ryi
 UpO
 Ryi
-zhO
+odX
 Ryi
-nUK
+HrR
 LTR
 lNb
 rGM
 NxH
-hny
+BnG
 toK
 toK
 toK
@@ -52248,31 +52563,31 @@ aqY
 ZNv
 Zwc
 tFh
-BWv
+Wtg
 TOw
 Vqh
 KPe
 toK
 toK
-toK
-tjG
-yDy
-awh
-MOH
-Ohj
-vcp
-JDg
-JDg
-JDg
-JDg
-JDg
-JDg
-JDg
-JDg
-xWH
-lYY
-xXB
-ctE
+sAz
+sAz
+BLw
+iWC
+qcU
+qgA
+eee
+Pbx
+ogv
+ngw
+mZS
+gyc
+Wtt
+EWr
+xZa
+gEP
+TLf
+VjA
+sAz
 toK
 toK
 toK
@@ -52469,7 +52784,7 @@ toK
 toK
 toK
 toK
-Cde
+rHF
 SLV
 fgN
 fgN
@@ -52486,13 +52801,13 @@ ELw
 Gzd
 gVn
 hny
-hny
-ZEY
-ZEY
-ZEY
+BnG
+CyX
+CyX
+CyX
 Vqh
 jnP
-OJi
+cVL
 BCy
 Ylm
 sGm
@@ -52502,7 +52817,7 @@ jYN
 XHE
 CZl
 CIy
-buf
+DQy
 EId
 IWl
 naR
@@ -52512,24 +52827,24 @@ Vqh
 UDs
 Vqh
 Vqh
-tjG
-tjG
-iSH
-Xyw
-AmJ
-tjG
-ZEY
-ZEY
-ZEY
-ZEY
-ZEY
-ZEY
-ZEY
-ZEY
-ZEY
-ZEY
-aIf
-ZEY
+kDr
+yNC
+JnM
+KHq
+LLi
+nWD
+CLf
+nWD
+nWD
+nWD
+nNf
+Ekx
+Ekx
+Ekx
+Ekx
+Ekx
+pmF
+sAz
 toK
 toK
 toK
@@ -52726,7 +53041,7 @@ toK
 toK
 toK
 toK
-Cde
+rHF
 SLV
 fgN
 ltI
@@ -52750,43 +53065,43 @@ FOC
 VZz
 Vqh
 Hii
-JXp
+ISm
 IWl
 IWl
 wLG
 rsX
 xyt
 zqm
-gQS
+ZcT
 Jol
 xNR
 nLN
 KnP
 BqR
 myW
-gWY
-rfv
+fjw
 fbV
-StH
-Vqh
-Ioh
-Hoq
-JnI
-ibs
-Umf
-tjG
-toK
-toK
-toK
-toK
-GrI
-toK
-toK
-NVL
-toK
-toK
-XDt
-rXw
+fbV
+fbV
+fjw
+yNC
+QAl
+gXQ
+qcU
+mxi
+rhn
+bBi
+yNC
+yNC
+kZN
+sAz
+Otx
+jUJ
+mtb
+pqD
+oVW
+XtO
+sAz
 toK
 toK
 toK
@@ -52983,7 +53298,7 @@ toK
 toK
 toK
 toK
-Cde
+rHF
 SLV
 fgN
 IPM
@@ -53021,30 +53336,30 @@ LRK
 LRK
 TIa
 llm
-fjw
-ySe
-aKT
-aWV
+gWY
+LHW
+KqL
+StH
 Vqh
-bqu
-tjG
-TiP
-KsI
-Umf
-HTE
+EmY
+fDb
+iWC
+qcU
+ZGt
+QwW
+ZUa
+wSg
+AnI
+pGh
+sAz
+Otx
+Hks
+mtb
+pqD
+AYL
+XtO
+sAz
 toK
-rXw
-rXw
-rXw
-rXw
-rXw
-rXw
-rXw
-rXw
-rXw
-fQk
-rXw
-rXw
 toK
 toK
 toK
@@ -53240,7 +53555,7 @@ toK
 toK
 toK
 toK
-Cde
+rHF
 SLV
 fgN
 EwL
@@ -53259,7 +53574,7 @@ Kmh
 hny
 xuG
 FOC
-FOC
+bia
 FOC
 ZEY
 Vqh
@@ -53283,25 +53598,25 @@ Vqh
 Vqh
 Vqh
 Vqh
-bqu
-tjG
-jRr
-KsI
-Umf
-HTE
-NVL
-rXw
-VDa
-vHV
-xzy
-vHV
-apk
-oNY
-mSc
-KiY
-ABs
-vHV
-rXw
+sAz
+sAz
+vLt
+cco
+PSM
+sAz
+tsb
+tsb
+tsb
+tsb
+sAz
+sAz
+sAz
+sAz
+sAz
+sAz
+IuX
+kWU
+qnB
 toK
 toK
 toK
@@ -53498,7 +53813,7 @@ toK
 toK
 qkK
 qkK
-KIG
+pNX
 fgN
 fgN
 wAL
@@ -53540,25 +53855,25 @@ XwB
 Vfd
 FOC
 sjK
-bqu
-tjG
-tNs
-bLx
-Umf
-rXw
-rXw
-rXw
-vsr
-eQT
-lFd
-opI
-hEq
-hEq
-xdU
-hEq
-MIW
-wXu
-rXw
+FOC
+qnB
+KNC
+qjK
+SDP
+EzJ
+UiN
+hQj
+YuR
+CqB
+oSN
+KZM
+CSK
+NYo
+TmI
+qHW
+nTO
+JQt
+qnB
 toK
 toK
 toK
@@ -53771,7 +54086,7 @@ ETk
 NXR
 oCP
 hny
-bia
+von
 FOC
 sJI
 FOC
@@ -53787,7 +54102,7 @@ bGf
 kQZ
 XeO
 VHj
-dqL
+NoK
 uZt
 rpX
 hqW
@@ -53797,26 +54112,26 @@ MUF
 MUF
 MUF
 MUF
-uFj
-tjG
-tNs
-wfQ
-EJo
-yqg
-vQo
-TJC
-OXN
-eLF
-xzy
-izC
-RtR
-JFg
-YaG
-XFE
-CKA
-ZSG
-rXw
-bZp
+PrF
+nsg
+gFK
+Ftb
+VBu
+HCM
+qMa
+gUe
+GnB
+OLm
+zNr
+GnB
+iyL
+zNr
+AwJ
+vgw
+Dly
+GpJ
+Lim
+toK
 toK
 toK
 toK
@@ -54056,23 +54371,23 @@ Nry
 Nry
 Nry
 Nry
-OOH
-KsI
-FOs
-VOb
-VOb
-VOb
-tiA
-DTo
-VOb
-WAq
-bNN
-rXw
-PqU
-rXw
-CKA
-ONA
-rXw
+hpK
+PTv
+wRj
+FVG
+RnF
+hIs
+WlB
+QdG
+MQL
+ndI
+Hci
+sbx
+ISN
+sPc
+gSo
+fIU
+hYL
 toK
 toK
 toK
@@ -54299,7 +54614,7 @@ fEG
 RmT
 RmT
 RmT
-hUG
+Hbu
 YQu
 zYr
 amg
@@ -54313,23 +54628,23 @@ vVa
 tpF
 aSl
 Nry
-OOH
-KsI
-Umf
-HTE
-NVL
-rXw
-jsF
-aUC
-rXw
-wVj
-XhI
-rXw
-SpE
-rXw
-QxT
-soh
-rXw
+CiB
+uxL
+MTM
+Rvb
+msW
+xVU
+Zrs
+EdJ
+aeg
+Zrs
+EdJ
+aeg
+Zrs
+Zrs
+lLE
+RPK
+hYL
 toK
 toK
 toK
@@ -54570,23 +54885,23 @@ ANd
 IKh
 MbN
 Nry
-TiP
-KsI
-Umf
-HTE
-toK
-rXw
-rXw
-rXw
-rXw
-rXw
-rXw
-rXw
-rXw
-rXw
-fQk
-rXw
-rXw
+LkI
+uxL
+MTM
+ZaY
+HLi
+cLA
+cLA
+rTx
+cLA
+cLA
+AQa
+vzE
+vzE
+vzE
+Xsn
+JLJ
+qnB
 toK
 toK
 toK
@@ -54811,9 +55126,9 @@ uZt
 uZt
 nYo
 eHQ
-xQL
+mcC
 bjR
-eHQ
+ZcO
 DON
 jul
 aeQ
@@ -54827,23 +55142,23 @@ nEB
 ZGM
 bIb
 Nry
-OOH
-KsI
-Umf
-tjG
-toK
-toK
-toK
-toK
-NVL
-toK
-toK
-NVL
-toK
-toK
-mUr
-rXw
-toK
+CiB
+uxL
+MTM
+vzE
+GXx
+vzE
+vzE
+vzE
+vzE
+vzE
+SLD
+ZzY
+XWC
+vzE
+Xsn
+RPK
+hYL
 toK
 toK
 toK
@@ -55084,23 +55399,23 @@ KhH
 VQK
 KhH
 eaI
-OOH
-KsI
-RWj
-qnB
-qnB
-qnB
-qnB
-qnB
-qnB
-qnB
-qnB
-qnB
-qnB
-ZEY
-aIf
-ZEY
-ZEY
+mcQ
+uxL
+wRj
+EFT
+tBG
+QLG
+MAV
+MAV
+VyV
+RiV
+Lfj
+CfD
+CfD
+vwf
+zJd
+lVS
+hYL
 toK
 toK
 toK
@@ -55341,23 +55656,23 @@ RIF
 PnL
 eER
 eaI
-wMn
-KsI
-FOs
-tXH
-Ymw
-Mdn
-vuo
-STO
-Fww
-sye
-noc
-ONn
-pPU
-bMe
-Vaq
-nLF
-ctE
+MlG
+uxL
+MTM
+adh
+rMQ
+gzb
+vzE
+vzE
+Vpt
+Vpt
+Vpt
+Vpt
+Vpt
+vzE
+Xsn
+RPK
+hYL
 toK
 toK
 toK
@@ -55598,23 +55913,23 @@ pZQ
 sRF
 gWU
 eaI
-OOH
-KsI
-Umf
+LCD
+Ywl
+mNn
+syH
+jmr
+SRN
+Imk
+Imk
+Imk
+Imk
+Imk
+Imk
+Imk
+Imk
+qyT
+Enw
 qnB
-yhj
-MFv
-qNs
-qNs
-nJR
-aDl
-tkg
-gLv
-qnB
-qnB
-nVg
-FOC
-ctE
 toK
 toK
 toK
@@ -55855,23 +56170,23 @@ Sqi
 QXq
 pEM
 eaI
-iHu
-KsI
-hob
-qnB
-Smi
-cZz
-gOK
-Hha
-eJB
-zyB
-sPc
-igk
-npj
-qnB
-UQK
-IUQ
-ctE
+OfB
+uxL
+MTM
+Xxx
+CiB
+elD
+SSd
+AlB
+AlB
+SSd
+AlB
+AlB
+SSd
+AlB
+wro
+RPK
+hYL
 toK
 toK
 toK
@@ -56112,23 +56427,23 @@ UbC
 sRF
 gWU
 eaI
-OOH
-KsI
-Umf
-qnB
-wkZ
-mZJ
-MEY
-azp
-xEy
-ndI
-Tcv
-yQM
-tKC
-qnB
-UQK
-ZEY
-ZEY
+uMH
+uxL
+wRj
+Bix
+rkN
+PmA
+pLc
+sPc
+vHL
+DAx
+sPc
+cTP
+THT
+sPc
+yUG
+Tes
+hYL
 toK
 toK
 VoJ
@@ -56369,23 +56684,23 @@ RIF
 Tar
 jPG
 eaI
-OOH
-KsI
-Umf
-qnB
-iPl
-Zps
-uVm
-elD
-lMJ
-FLx
-GwJ
-hvU
-gZU
-qnB
-UQK
-ZEY
-toK
+Zjm
+rjr
+NbF
+NGC
+jub
+mbw
+lKP
+xwt
+yVX
+pQT
+DMm
+bLV
+YEU
+rbv
+eaR
+vEb
+Lim
 toK
 toK
 toK
@@ -56590,10 +56905,10 @@ Hee
 tuY
 DPy
 uuS
-Ngo
+vTS
 ett
 Ruo
-DbC
+JRz
 pRo
 ryt
 ulK
@@ -56626,23 +56941,23 @@ eaI
 mVc
 eaI
 eaI
-ULA
-nCY
-EUO
+KNC
+wFt
+SDP
+wGT
+DOT
+miT
+nKG
+iuL
+Hyt
+JQL
+vKd
+ZkE
+sHF
+JSw
+DnZ
+rhQ
 qnB
-mLG
-yOh
-gOK
-aVU
-CTD
-Lcd
-fbq
-XJl
-DQi
-qnB
-UQK
-ZEY
-toK
 toK
 toK
 toK
@@ -56887,19 +57202,19 @@ OOH
 KsI
 Umf
 qnB
-qSu
-MvV
-MEY
-OUH
-CTD
-mHn
-MEY
-Rtx
-FTO
 qnB
-UQK
-ZEY
-toK
+qnB
+qnB
+qnB
+qnB
+qnB
+qnB
+qnB
+qnB
+qnB
+UFQ
+VDn
+qnB
 toK
 toK
 toK
@@ -57104,10 +57419,10 @@ eZf
 BSb
 CZP
 SWS
-IIM
+tIP
 ZEm
 SDf
-Yol
+USv
 ohV
 CQW
 oOF
@@ -57141,22 +57456,22 @@ Vhw
 UKd
 myf
 mrO
-bkf
-Umf
-qnB
-vwy
-mKw
-WSw
-Xsn
-nal
-VAK
-GwJ
-QOz
-RdL
-qnB
-UQK
-ctE
+AOs
+LwW
+ABo
 toK
+NVL
+toK
+toK
+GrI
+toK
+toK
+NVL
+toK
+toK
+icq
+rXw
+NVL
 toK
 toK
 toK
@@ -57399,21 +57714,21 @@ cjr
 gct
 rat
 vPl
-vfA
-qnB
-Gvp
-VPN
-gOK
-lLE
-jPK
-kaG
-HIh
-wOg
-Thq
-qnB
-UQK
-ctE
+Umf
+Lrh
 toK
+rXw
+rXw
+rXw
+rXw
+rXw
+rXw
+rXw
+rXw
+rXw
+kLL
+rXw
+rXw
 toK
 toK
 toK
@@ -57657,20 +57972,20 @@ mnA
 TfF
 NQZ
 VNP
-qnB
-Huf
-mbZ
-MEY
-Xsn
-zyB
-sPc
-ibU
-nkT
-AGC
-qnB
-UQK
-ctE
-toK
+HTE
+NVL
+rXw
+VDa
+vHV
+xzy
+vHV
+apk
+oNY
+mSc
+KiY
+Hvh
+vHV
+rXw
 toK
 toK
 toK
@@ -57914,20 +58229,20 @@ JZg
 OOH
 KsI
 Umf
-HbO
-NmO
-AyS
-zSW
-UXy
-fnU
-aUg
-cXQ
-WVB
-CCY
-qnB
-UQK
-ZEY
-toK
+rXw
+rXw
+rXw
+vsr
+eQT
+lFd
+opI
+hEq
+hEq
+xdU
+hEq
+mrT
+wXu
+rXw
 toK
 toK
 toK
@@ -58122,8 +58437,8 @@ toK
 toK
 toK
 toK
-bqI
-fno
+bir
+BNQ
 ebR
 Umo
 ErC
@@ -58169,22 +58484,22 @@ ioo
 tRl
 kWH
 IRr
-dsn
-aoB
-dBf
-irB
-KHe
-DgQ
-Tqs
-JdY
-Gmq
-eje
-Lhi
-SGy
-qnB
-UQK
-ZEY
-toK
+iPP
+ovT
+yqg
+vQo
+TJC
+OXN
+eLF
+xzy
+izC
+RtR
+JFg
+YaG
+XFE
+izC
+ZSG
+rXw
 toK
 toK
 toK
@@ -58406,9 +58721,9 @@ Onv
 xkV
 qKI
 NKA
-kGi
-OoM
-MvT
+qkp
+RZl
+aBj
 exG
 lxj
 PBH
@@ -58425,23 +58740,23 @@ ElM
 dFN
 QDl
 kWH
-vFR
-xrp
+OOH
+KsI
 FjX
-qnB
-qnB
-vkL
-ZcN
-bfB
-CLe
-WGQ
-GAF
-EVi
-aXt
-qnB
-UQK
-ZEY
-NVL
+VOb
+VOb
+VOb
+tiA
+DTo
+VOb
+WAq
+bNN
+rXw
+PqU
+rXw
+izC
+ONA
+rXw
 toK
 toK
 toK
@@ -58636,7 +58951,7 @@ toK
 toK
 toK
 toK
-bqI
+bir
 bqI
 tPc
 KKN
@@ -58682,23 +58997,23 @@ gIB
 iQM
 tyy
 kYu
-OCE
-oCr
-Kuu
-pin
-qnB
-qnB
-GNU
-hYL
-hYL
-hYL
-hYL
-qnB
-mDY
-qnB
-wxw
-NQU
-ZEY
+QLP
+ypj
+Umf
+HTE
+NVL
+rXw
+jsF
+aUC
+rXw
+wVj
+XhI
+rXw
+SpE
+rXw
+WSR
+soh
+rXw
 toK
 toK
 toK
@@ -58942,20 +59257,20 @@ kWH
 Rms
 KsI
 Umf
-XNV
-qnB
-wWm
-Poj
-Rxy
-xsW
-ZSt
-ZSt
-qnB
-CCI
-gzA
-Tgx
-FOC
-Wkt
+HTE
+toK
+rXw
+rXw
+rXw
+rXw
+rXw
+rXw
+rXw
+rXw
+rXw
+kLL
+rXw
+rXw
 toK
 toK
 toK
@@ -59150,8 +59465,8 @@ toK
 toK
 toK
 toK
-bqI
-jpJ
+bir
+CBp
 uwx
 uwx
 jpJ
@@ -59199,20 +59514,20 @@ kWH
 OOH
 KsI
 Umf
-UEZ
-qnB
-wWm
-AwM
-wHe
-vzE
-Riq
-NJa
-qnB
-WkX
-SiK
-UQK
-FOC
-Wkt
+ABo
+toK
+NVL
+toK
+toK
+NVL
+toK
+toK
+NVL
+toK
+toK
+EZq
+rXw
+NVL
 toK
 toK
 toK
@@ -59456,20 +59771,20 @@ kWH
 OOH
 KsI
 Umf
-gYc
-qnB
-UaN
-wFl
-oxo
-SLD
-hnt
-hnt
-qnB
-oWm
-glJ
-yLt
-vPe
-Wkt
+RMU
+RMU
+RMU
+RMU
+RMU
+RMU
+RMU
+RMU
+RMU
+RMU
+RMU
+GKL
+RMU
+RMU
 toK
 toK
 toK
@@ -59699,7 +60014,7 @@ toK
 toK
 toK
 toK
-RXd
+yQc
 Nrg
 RXd
 elB
@@ -59711,22 +60026,22 @@ YrB
 Iye
 TpE
 tNs
-bLx
-Umf
-dbN
-qnB
-VrQ
-Rpd
-tjt
-UAm
-BYB
-BYB
-qnB
-iOd
-bzT
-UQK
-qQI
-Wkt
+LXu
+XpM
+stO
+Zde
+Zde
+Zde
+Zde
+Zde
+Zde
+Zde
+Zde
+ZvY
+bvN
+Hnc
+bvN
+RMU
 toK
 toK
 toK
@@ -59922,7 +60237,7 @@ toK
 toK
 toK
 toK
-jpJ
+CBp
 CSP
 Bbn
 kHA
@@ -59944,7 +60259,7 @@ Kaw
 Kaw
 Kaw
 Kaw
-UqQ
+EnU
 hvr
 qOZ
 mIw
@@ -59956,7 +60271,7 @@ toK
 toK
 toK
 toK
-RXd
+yQc
 ePA
 RXd
 dRq
@@ -59967,23 +60282,23 @@ rND
 rND
 RZy
 TpE
-UyI
-KsI
+Sep
+jDU
 Umf
-qnB
-qnB
-qnB
-qnB
-SDP
-qnB
-qnB
-qnB
-qnB
-Vlg
+bNf
+bNf
+bNf
+bNf
+bNf
+bNf
+bNf
+bNf
+bNf
+hXm
 kPS
-wxw
-NQU
-ZEY
+Noe
+bvN
+diw
 toK
 toK
 toK
@@ -60179,7 +60494,7 @@ toK
 toK
 toK
 toK
-jpJ
+CBp
 jpJ
 jpJ
 jpJ
@@ -60201,7 +60516,7 @@ bUj
 POW
 mBM
 Kaw
-Upn
+eyr
 hvr
 Yni
 mIw
@@ -60213,7 +60528,7 @@ NVL
 NVL
 NVL
 NVL
-RXd
+yQc
 KJd
 VRh
 KJd
@@ -60231,16 +60546,16 @@ hPB
 nUa
 vQG
 nDt
-rmz
+EiR
 hPB
 Nxz
 mac
 oVK
 leS
 kPS
-UQK
-ZEY
-NVL
+Noe
+FsK
+diw
 toK
 toK
 toK
@@ -60470,7 +60785,7 @@ toK
 toK
 toK
 toK
-RXd
+yQc
 kRm
 KJd
 KJd
@@ -60488,16 +60803,16 @@ JWP
 yAc
 ScT
 rgG
-VPc
+SCF
 JUz
 SCF
 LrX
 Btj
 vxR
 Bie
-vcL
-ZEY
-toK
+sZz
+bvN
+diw
 toK
 toK
 toK
@@ -60711,7 +61026,7 @@ vxK
 oCP
 Kaw
 PHE
-Nbe
+RJs
 qPa
 LXX
 Kaw
@@ -60727,7 +61042,7 @@ toK
 toK
 toK
 toK
-RXd
+yQc
 toV
 KJd
 KJd
@@ -60752,9 +61067,9 @@ ilA
 Qkx
 AaM
 kPS
-FOC
-ZEY
-toK
+bvN
+xmD
+RMU
 toK
 toK
 toK
@@ -60950,7 +61265,7 @@ toK
 toK
 toK
 toK
-bqI
+bir
 bqI
 fno
 tWm
@@ -60984,7 +61299,7 @@ oAG
 oAG
 toK
 toK
-RXd
+yQc
 KxO
 evW
 evW
@@ -61009,9 +61324,9 @@ GKh
 zlm
 Idm
 kPS
-FOC
-ZEY
-toK
+bvN
+RMU
+RMU
 toK
 toK
 toK
@@ -61241,7 +61556,7 @@ AOP
 oAG
 NVL
 NVL
-RXd
+yQc
 NVQ
 MnO
 MnO
@@ -61266,8 +61581,8 @@ kqm
 vOh
 kPS
 kPS
-FOC
-ZEY
+bvN
+RMU
 toK
 toK
 VoJ
@@ -61475,9 +61790,9 @@ dXt
 uhL
 mZI
 sbH
-OIT
-RVZ
-vVC
+xEp
+DGU
+BNO
 vxK
 dyJ
 ZdO
@@ -61498,8 +61813,8 @@ dTm
 oAG
 toK
 toK
-RXd
-RXd
+yQc
+yQc
 RXd
 RXd
 naO
@@ -61523,8 +61838,8 @@ KEm
 WzZ
 Vyd
 kPS
-FOC
-ZEY
+bvN
+diw
 toK
 toK
 toK
@@ -61732,16 +62047,16 @@ axr
 vUP
 xcz
 NRc
-tFr
+tPv
 RVZ
 vVC
 vxK
 Yjb
 Kaw
-wnH
+lss
 oUl
 Fhs
-NWc
+YNz
 Kaw
 Onv
 qoa
@@ -61766,9 +62081,9 @@ sPa
 BmT
 VLP
 TpE
-OOH
-KsI
-Umf
+cdg
+KVe
+ilu
 AmR
 FNm
 CZE
@@ -61780,8 +62095,8 @@ wRx
 Ehg
 nZS
 kPS
-FOC
-ZEY
+bvN
+diw
 toK
 toK
 toK
@@ -61978,20 +62293,20 @@ toK
 toK
 toK
 toK
-bqI
-bqI
-bqI
+bir
+bir
+bir
 RzX
 RzX
 RzX
-RVZ
-RVZ
-RVZ
-RVZ
-RVZ
-MLH
-RVZ
-vVC
+EbM
+EbM
+EbM
+EbM
+EbM
+EbM
+EbM
+klw
 vxK
 oCP
 Kaw
@@ -62024,8 +62339,8 @@ Ool
 Ool
 Ool
 SbS
-KsI
-hob
+xaE
+vNA
 AmR
 emh
 Rnt
@@ -62037,8 +62352,8 @@ enh
 Dfn
 QKM
 kPS
-FOC
-ZEY
+bvN
+RMU
 toK
 toK
 toK
@@ -62245,13 +62560,13 @@ Fii
 Fii
 zpN
 toK
-CrQ
-aEe
-hny
+toK
+toK
+BnG
 vVC
 vxK
 mtV
-hny
+BnG
 toK
 toK
 toK
@@ -62268,17 +62583,17 @@ zaK
 bpB
 PcC
 zZU
-oXY
-ozv
+Djy
+ocC
 mBU
 oAG
 eel
 Ool
-NIK
+taM
 iJM
 zht
 StG
-pJm
+Bpx
 Ool
 qFJ
 KsI
@@ -62295,8 +62610,8 @@ kPS
 hPB
 kPS
 unP
-kPS
-kPS
+bNf
+bNf
 toK
 toK
 toK
@@ -62502,10 +62817,10 @@ idx
 idx
 idx
 Sjm
-CrQ
-gPs
-Csw
-BNO
+toK
+toK
+BnG
+vVC
 vxK
 oCP
 qSL
@@ -62525,8 +62840,8 @@ pUT
 eaB
 LKU
 pUT
-FrA
-pmf
+XZi
+Txm
 mBU
 oAG
 eel
@@ -62537,9 +62852,9 @@ xQO
 xQO
 xQO
 Ool
-iSH
-Xyw
-AmJ
+OOH
+KsI
+Umf
 AmR
 WCZ
 ueM
@@ -62550,10 +62865,10 @@ tHy
 qbE
 kPS
 KVv
-PlV
+oVq
 zvq
 kFZ
-kPS
+bNf
 toK
 toK
 toK
@@ -62759,9 +63074,9 @@ bOi
 bOi
 bOi
 fDu
-CrQ
-xqE
-hny
+toK
+toK
+BnG
 vVC
 vxK
 oCP
@@ -62782,8 +63097,8 @@ flV
 McE
 Ofs
 UtA
-UtA
-UtA
+NuU
+NuU
 RMq
 oAG
 eel
@@ -63016,10 +63331,10 @@ wfy
 UFB
 kjK
 fDu
-CrQ
-CrQ
-hny
-klw
+toK
+toK
+BnG
+vVC
 vxK
 oCP
 qSL
@@ -63038,15 +63353,15 @@ jWr
 xPb
 JuS
 Aah
-nGK
-Rqm
-szR
+knu
+Ogm
+DLS
 uwl
 oAG
 eel
 Ool
 JEv
-yxU
+oNm
 uOR
 tVc
 mWO
@@ -63275,7 +63590,7 @@ vkQ
 FlV
 nIC
 Sjm
-hny
+BnG
 vVC
 vxK
 oCP
@@ -63295,10 +63610,10 @@ jWr
 LGQ
 nsu
 jdi
-AWQ
 lxg
 oAG
-eYb
+Suk
+jMK
 oAG
 eel
 Ool
@@ -63532,7 +63847,7 @@ Pwf
 VEq
 upw
 FlV
-hny
+BnG
 xYB
 vxK
 oCP
@@ -63552,10 +63867,10 @@ jWr
 aZM
 nsu
 gMA
-pUT
 jfb
 oAG
-czb
+xIW
+STt
 oAG
 eel
 Ool
@@ -63581,7 +63896,7 @@ aor
 afi
 Dbp
 QYJ
-kPS
+bNf
 toK
 toK
 toK
@@ -63786,8 +64101,8 @@ Byw
 kAr
 jOn
 jOn
-hVq
-syu
+xyj
+Pwf
 doW
 edW
 vVC
@@ -63809,15 +64124,15 @@ MJP
 KIQ
 nsu
 gMA
-pUT
 YhE
 MXx
-czb
+xIW
+STt
 oAG
 eel
 Ool
 TOa
-yxU
+oNm
 rJe
 xQO
 gGq
@@ -63837,8 +64152,8 @@ kPS
 glW
 glW
 glW
-kPS
-kPS
+bNf
+bNf
 toK
 toK
 toK
@@ -64043,14 +64358,14 @@ kdU
 URB
 Zzs
 scO
-OEc
-NWe
+Pmg
+WZO
 vFf
-OQN
+LyL
 fSC
 vxK
 oCP
-hny
+BnG
 toK
 toK
 toK
@@ -64066,10 +64381,10 @@ jWr
 RpE
 Ifg
 Uec
-pUT
 YhE
 pry
-czb
+xIW
+STt
 oAG
 eel
 Ool
@@ -64094,7 +64409,7 @@ osZ
 kBe
 HBf
 Auo
-NSK
+UKU
 toK
 toK
 toK
@@ -64307,7 +64622,7 @@ qSL
 vVC
 xsf
 Ulg
-hny
+BnG
 NVL
 tHS
 tHS
@@ -64323,18 +64638,18 @@ tHS
 JOb
 nsu
 xIW
-pUT
 YhE
 pry
-czb
+xIW
+STt
 oAG
 eel
 Ool
-Fuu
-IRZ
-xPT
-hAY
-StG
+pJm
+Wdr
+tOD
+pJm
+Bxl
 Ool
 OOH
 KsI
@@ -64351,7 +64666,7 @@ IPS
 oOM
 XsA
 UGw
-NSK
+UKU
 toK
 toK
 toK
@@ -64564,7 +64879,7 @@ qSL
 vVC
 vxK
 oCP
-hny
+BnG
 toK
 NLj
 brv
@@ -64580,10 +64895,10 @@ NLj
 eMY
 nsu
 xIW
-pUT
 YhE
 pry
-czb
+xIW
+STt
 oAG
 eel
 Ool
@@ -64608,7 +64923,7 @@ ska
 bfs
 AYI
 MtI
-NSK
+UKU
 toK
 toK
 toK
@@ -64815,10 +65130,10 @@ QEi
 WeT
 OkZ
 OEc
-Pwf
-vXg
-qSL
-vVC
+PSC
+NtU
+BnG
+fLT
 vxK
 oCP
 qSL
@@ -64836,11 +65151,11 @@ Dhv
 Rat
 Ofa
 nsu
-Zpj
 cWz
 cbj
 pry
-czb
+Qlh
+STt
 oAG
 eel
 eel
@@ -65072,10 +65387,10 @@ EaW
 kZa
 WEu
 ouQ
-mWb
-NtU
-hny
-qcY
+nVq
+VZS
+FMa
+Kmu
 vxK
 oCP
 qSL
@@ -65096,8 +65411,8 @@ pry
 pry
 pry
 oAG
-oAG
-yny
+xIW
+STt
 oAG
 eel
 eel
@@ -65330,9 +65645,9 @@ QuZ
 WOP
 OEc
 Pwf
-vXg
-qSL
-vVC
+NtU
+BnG
+YnT
 vxK
 oCP
 qSL
@@ -65352,11 +65667,11 @@ toK
 toK
 toK
 toK
-toK
 oAG
-czb
+EUs
+qvB
 oAG
-zMz
+eel
 eel
 CwJ
 far
@@ -65581,7 +65896,7 @@ TQF
 NtU
 WaW
 NJM
-plL
+JwP
 RPy
 oMr
 BDU
@@ -65592,7 +65907,7 @@ qSL
 vVC
 vxK
 oCP
-hny
+BnG
 toK
 NLj
 oAE
@@ -65609,14 +65924,14 @@ toK
 toK
 toK
 toK
-toK
 oAG
-wrH
+xIW
+STt
 oAG
-qMk
+zMz
 eel
 CwJ
-xqw
+UrZ
 ngy
 rKR
 Pmm
@@ -65625,7 +65940,7 @@ JnI
 zZi
 LJm
 tjG
-wxz
+wxL
 sIC
 teq
 KBz
@@ -65866,11 +66181,11 @@ toK
 toK
 toK
 toK
-toK
-gsQ
-NVL
-biT
-qMk
+oAG
+Xsh
+lQD
+oAG
+PQF
 eel
 CwJ
 Jfk
@@ -66095,14 +66410,14 @@ Ooy
 QbW
 fDu
 nhV
-AIO
+iGv
 DMJ
 yZi
 FlV
-OEc
-NWe
+QBK
+WZO
 vFf
-OQN
+LyL
 fSC
 vxK
 oCP
@@ -66123,10 +66438,10 @@ toK
 toK
 toK
 toK
-toK
+gsQ
 NVL
-toK
 NVL
+biT
 ZLo
 eel
 CwJ
@@ -66140,8 +66455,8 @@ nCY
 GVv
 tjG
 abD
-eel
-kTF
+nwM
+ZxA
 eel
 sFj
 ZSy
@@ -66356,8 +66671,8 @@ euM
 htJ
 sFU
 xeP
-Yiy
-EhN
+Hun
+wbq
 doW
 edW
 RMT
@@ -66380,10 +66695,10 @@ toK
 toK
 toK
 toK
+NVL
 toK
 toK
-toK
-toK
+NVL
 ZLo
 eel
 CwJ
@@ -66614,9 +66929,9 @@ DHu
 dyY
 WaW
 KAE
-xeo
+LTD
 WaW
-hny
+BnG
 vVC
 vxK
 oCP
@@ -66870,10 +67185,10 @@ jOj
 LhB
 sRb
 rRf
-hzw
-YrN
+TFo
+TFo
 xUf
-hny
+BnG
 vVC
 vxK
 oCP
@@ -66902,8 +67217,8 @@ ZLo
 eel
 eel
 eel
-eel
-eel
+AwL
+TjK
 fiL
 tjG
 OOH
@@ -66919,7 +67234,7 @@ Wca
 kxq
 bRB
 peM
-vvR
+MMj
 JHg
 gQn
 toK
@@ -67127,11 +67442,11 @@ GML
 Pwf
 QUJ
 vXg
-hny
-riK
-hny
-hny
-YnT
+toK
+toK
+toK
+AJw
+vVC
 vxK
 oCP
 qSL
@@ -67155,9 +67470,9 @@ toK
 toK
 toK
 toK
-qMk
-lZi
-cGO
+PQF
+iYI
+eel
 hRt
 eel
 eel
@@ -67384,13 +67699,13 @@ ppV
 OIx
 kcn
 vXg
+toK
+toK
+toK
 AJw
-LoB
-acx
-VXZ
-XTc
-pBo
-cWs
+vVC
+vxK
+oCP
 qSL
 toK
 NVL
@@ -67412,10 +67727,10 @@ toK
 toK
 toK
 toK
-qMk
+PQF
 ZLo
 ZLo
-qMk
+PQF
 Ihk
 LgU
 uFe
@@ -67425,11 +67740,11 @@ ibr
 bBv
 uKs
 VvF
-gYv
+Tej
 VvF
 pnC
 PYc
-eaT
+rii
 dKH
 yyu
 VvF
@@ -67641,11 +67956,11 @@ tRA
 myX
 kNk
 vXg
+toK
+toK
+toK
 AJw
-YdM
-lav
-PrV
-ohV
+mVf
 Xjz
 oCP
 qSL
@@ -67681,7 +67996,7 @@ pFB
 KsI
 Umf
 gQn
-bXN
+dRi
 jWs
 Zxy
 ETR
@@ -67689,9 +68004,9 @@ iuv
 ZEJ
 kxq
 NXS
-ZZP
+gCK
 pVp
-hyg
+qzo
 DFv
 toK
 toK
@@ -67898,9 +68213,9 @@ vXg
 vXg
 vXg
 xUf
-AJw
-Lpu
-WHV
+toK
+toK
+toK
 AJw
 vVC
 vxK
@@ -67939,11 +68254,11 @@ yql
 SYy
 DOY
 JKf
-VBH
-pPi
-UKx
-INV
-DDo
+mOO
+rdc
+mOO
+haA
+FVg
 Rpy
 NZH
 bAk
@@ -68155,9 +68470,9 @@ Wiq
 Wiq
 Wiq
 Wiq
-BnG
-BnG
-BnG
+Wiq
+Wiq
+Wiq
 BnG
 vVC
 vxK
@@ -68456,7 +68771,7 @@ Lfg
 mQx
 mQx
 mQx
-mQx
+phR
 YTa
 mQx
 PKp
@@ -68720,8 +69035,8 @@ gzo
 gzo
 AKj
 BPK
-gzo
-qMk
+uBe
+PQF
 toK
 toK
 toK
@@ -68978,7 +69293,7 @@ XMC
 Eab
 ZrQ
 KYA
-qMk
+PQF
 toK
 toK
 toK
@@ -69229,7 +69544,7 @@ nAx
 QvV
 eOt
 YMY
-CRF
+iIx
 ixD
 QLA
 Eab
@@ -69491,7 +69806,7 @@ QWi
 dkA
 gis
 Eab
-ehJ
+izy
 ZLo
 toK
 toK
@@ -69739,7 +70054,7 @@ Umf
 ThX
 nAx
 tyz
-wdB
+CQs
 rpz
 ssA
 YMY
@@ -70006,7 +70321,7 @@ ixD
 Hom
 Eab
 VVJ
-qMk
+PQF
 toK
 toK
 toK
@@ -70251,7 +70566,7 @@ TfF
 NQZ
 GVv
 ThX
-wdB
+ESN
 fSQ
 nAx
 KsW
@@ -70259,7 +70574,7 @@ ssA
 YMY
 TSn
 QWi
-qUk
+obp
 gum
 Eab
 izy
@@ -70463,9 +70778,9 @@ Fjq
 Fjq
 Fjq
 Fjq
-Fjq
-skj
-skj
+HHX
+pGS
+pGS
 HHX
 HHX
 XzP
@@ -70500,16 +70815,16 @@ toK
 toK
 toK
 toK
-tjG
+ABo
 hYt
-tjG
+ABo
 tjG
 jRr
 Qhj
 fSD
 uuf
 yjy
-JoJ
+wLS
 tnx
 nAx
 AqW
@@ -70717,12 +71032,12 @@ toK
 toK
 toK
 Fjq
-zEI
 slM
 emP
 Fjq
-Dyt
-lEL
+HQg
+rbC
+EiX
 eQO
 IVW
 jrt
@@ -70730,7 +71045,7 @@ Vni
 joy
 QVu
 mrJ
-ncy
+CcP
 cWs
 pwE
 Yxq
@@ -70974,13 +71289,13 @@ toK
 toK
 toK
 Fjq
-zpY
-rav
+biM
 AFo
 qtj
-KOh
-LjR
-xJT
+yMA
+fBa
+Qdw
+san
 yEw
 lJL
 GwD
@@ -71034,7 +71349,7 @@ dim
 NqQ
 Bqc
 dOe
-qMk
+PQF
 toK
 toK
 toK
@@ -71231,13 +71546,13 @@ toK
 toK
 toK
 Fjq
-Fqs
-WYN
-ryp
+gTz
+tFN
 Fjq
-gJx
-LHB
-Acd
+iYB
+aNq
+mqo
+zhL
 HHX
 Kgt
 Fuv
@@ -71270,11 +71585,11 @@ toK
 toK
 toK
 toK
-KUu
-KUu
-KUu
-KUu
-KUu
+nKa
+nKa
+UGB
+UGB
+UGB
 ULj
 Now
 YFG
@@ -71491,12 +71806,12 @@ Fjq
 Fjq
 Fjq
 Fjq
-Fjq
-skj
-skj
-skj
 HHX
-qdp
+gqJ
+gqJ
+gqJ
+HHX
+ppN
 Qor
 joy
 qMD
@@ -71506,8 +71821,8 @@ oCP
 GJe
 GJe
 GJe
-GJe
-GJe
+LBF
+LBF
 toK
 toK
 toK
@@ -71527,11 +71842,11 @@ toK
 toK
 toK
 toK
-KUu
-oSw
-pfe
-lio
-KUu
+nKa
+apU
+Nrt
+VFG
+UGB
 ycj
 RAH
 aon
@@ -71763,8 +72078,8 @@ oCP
 GJe
 Msi
 XdC
-Xtd
-GJe
+bnY
+LBF
 toK
 toK
 toK
@@ -71784,11 +72099,11 @@ toK
 toK
 toK
 toK
-DYM
-CSV
-wbq
-Hee
-tXv
+QoT
+pHQ
+VTV
+UKD
+Cny
 DZF
 Syz
 fTT
@@ -72013,11 +72328,11 @@ QFb
 Oow
 hEP
 lRW
-axe
+dML
 Oov
-kxr
+RZF
 kTO
-SqT
+CBP
 pYs
 Npu
 fKS
@@ -72041,11 +72356,11 @@ toK
 toK
 toK
 toK
-DYM
-MAp
-bux
-ulE
-KUu
+QoT
+HRN
+LGe
+iJZ
+UGB
 MQB
 GKc
 uCq
@@ -72057,12 +72372,12 @@ Fix
 Fix
 aon
 iUz
-cIw
+DxK
 cno
 fhl
 EiW
 NDh
-qMk
+PQF
 toK
 toK
 toK
@@ -72277,7 +72592,7 @@ oCP
 MHy
 WSQ
 WSQ
-pDB
+uCF
 EjS
 toK
 toK
@@ -72298,11 +72613,11 @@ toK
 toK
 toK
 toK
-DYM
-dHu
-uJL
-egI
-KUu
+QoT
+JhQ
+jEs
+gfB
+UGB
 AVy
 vka
 AEY
@@ -72314,12 +72629,12 @@ vka
 oYw
 QVt
 OxI
-lbL
+WmJ
 qOB
 QOJ
 eel
-qMk
-qMk
+PQF
+PQF
 toK
 toK
 toK
@@ -72527,14 +72842,14 @@ Dsj
 Dsj
 dTB
 lPF
-YoN
+GPW
 vVC
 vxK
 Yjb
 MHy
 AFC
 WSQ
-CLF
+pcY
 EjS
 toK
 toK
@@ -72555,11 +72870,11 @@ toK
 toK
 toK
 toK
-KUu
-jCj
-itu
-Fsp
-KUu
+nKa
+eFT
+SHc
+dzE
+UGB
 Fix
 fvc
 keg
@@ -72571,7 +72886,7 @@ Ovb
 HFH
 hGs
 HFH
-qaz
+TKS
 HFH
 HFH
 eel
@@ -72812,24 +73127,24 @@ toK
 toK
 toK
 GLF
-KUu
-KUu
-qqH
-KUu
-KUu
+nKa
+nKa
+GIn
+nKa
+nKa
 gpn
-QOJ
+fnZ
 uJE
 uJE
-QOJ
+fnZ
 gpn
-aED
-QOJ
-HFH
+XwH
+fnZ
+wCB
 FuW
 dgb
-LkV
-idr
+SaL
+GOq
 HFH
 eel
 oQX
@@ -73049,7 +73364,7 @@ GJe
 vDe
 qmo
 gky
-GJe
+LBF
 toK
 toK
 toK
@@ -73082,14 +73397,14 @@ uyO
 fsW
 uyO
 gfk
-HFH
+wCB
 wnD
 zUH
 LkV
 hBC
 HFH
 eel
-qMk
+PQF
 toK
 toK
 toK
@@ -73302,11 +73617,11 @@ qMD
 ELw
 RNA
 gVn
-GJe
-GJe
-GJe
-GJe
-GJe
+LBF
+LBF
+LBF
+LBF
+LBF
 toK
 toK
 toK
@@ -73339,7 +73654,7 @@ zms
 Aje
 cXm
 okb
-HFH
+wCB
 gfO
 uqa
 omu
@@ -73559,7 +73874,7 @@ qMD
 glv
 SRL
 fOT
-mnr
+EgT
 WBG
 GsL
 GsL
@@ -73859,8 +74174,8 @@ Dnn
 ZDR
 vsJ
 HFH
-HFH
-qMk
+wCB
+PQF
 NVL
 toK
 toK
@@ -74073,7 +74388,7 @@ qMD
 FPd
 SRL
 fBi
-PAN
+ECt
 sew
 GsL
 SLo
@@ -74110,7 +74425,7 @@ Wrc
 Wrc
 Aje
 SCI
-HFH
+wCB
 DeW
 Dnn
 vkC
@@ -74330,10 +74645,10 @@ kep
 evJ
 owa
 yvo
-PAN
-PAN
-PAN
-PAN
+ECt
+ECt
+ECt
+ECt
 toK
 toK
 toK
@@ -74367,7 +74682,7 @@ Aje
 Aje
 Tbw
 SCI
-HFH
+wCB
 DeW
 WyX
 vkC
@@ -74587,7 +74902,7 @@ swd
 uBS
 mMH
 Fqf
-PAN
+ECt
 BNG
 WIL
 WIL
@@ -74624,7 +74939,7 @@ Cuq
 Cuq
 MXF
 SCI
-HFH
+wCB
 ZgC
 xnd
 eLk
@@ -74829,8 +75144,8 @@ toK
 VoJ
 toK
 NVL
-aAR
-aAR
+igH
+igH
 xJN
 Lfb
 Lfb
@@ -74886,8 +75201,8 @@ Dnn
 sQv
 Dnn
 FKf
-HFH
-HFH
+wCB
+wCB
 NVL
 toK
 toK
@@ -75087,7 +75402,7 @@ toK
 toK
 toK
 toK
-aAR
+igH
 OUC
 Bww
 ciA
@@ -75101,7 +75416,7 @@ Tka
 Tka
 Tka
 DwA
-mnr
+EgT
 YsL
 WIL
 mEC
@@ -75143,7 +75458,7 @@ aCy
 FSu
 DeW
 DeW
-HFH
+wCB
 toK
 toK
 toK
@@ -75344,12 +75659,12 @@ toK
 toK
 toK
 toK
-aAR
+igH
 jQB
 jQB
 jQB
 jQB
-aAR
+igH
 Jgk
 vQk
 Tka
@@ -75358,10 +75673,10 @@ CjP
 KmN
 pdL
 tQD
-PAN
-PAN
-PAN
-PAN
+ECt
+ECt
+ECt
+ECt
 toK
 toK
 toK
@@ -75395,12 +75710,12 @@ pyG
 Cuq
 bBp
 LJu
-HFH
+wCB
 TJg
 TJg
 TJg
 TJg
-HFH
+wCB
 toK
 toK
 toK
@@ -75601,21 +75916,21 @@ toK
 toK
 toK
 toK
-aAR
+igH
 toK
 toK
 toK
 toK
-aAR
-PAN
+igH
+ECt
 OqR
 OqR
 OqR
 OqR
 OqR
 OqR
-PAN
-PAN
+ECt
+ECt
 toK
 toK
 toK
@@ -75652,12 +75967,12 @@ uyO
 jSh
 uyO
 mWl
-HFH
+wCB
 toK
 toK
 toK
 toK
-HFH
+wCB
 toK
 toK
 toK


### PR DESCRIPTION
[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)

A new atmospherics layout with new piping. FTL Drive and Shield generator were paired together for the techie's convenience. Lastly, there's a containment area set aside when the new engine gas kicks in.

![atmo](https://cloud.githubusercontent.com/assets/22532898/25308340/0c0853be-276f-11e7-8d93-64dd78d5f49c.png)

All the things that were fixed have been documented in the map problems doc, found here: 
https://docs.google.com/document/d/1hMiZFH8sMWV0VFLk9Z2sQxSTmVD8EIGiBpI6FkGZQDA/edit

:cl: IndusRobot
add: Redesigned atmospherics on Aetherwhisp so it isn't as small
add: Added light boxes and one replacer to mitigate frequent electric storms
del: Removed teleporter machinery, it was only used for science
fix: The last batch of bugs on the doc
/:cl:
