### PR TITLE
Station Landmark 2: Someone else can map it.

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -301,3 +301,21 @@
 	ruin_landmarks -= src
 	ruin_template = null
 	. = ..()
+
+
+/obj/effect/landmark/station/New() //Notify admins and ghosts when a station is generated
+	. = ..()
+	name = "station"
+	poi_list |= src
+	var/msg = "A station has been generated at ([x],[y],[z] - (\
+	<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>\
+	JMP</a>)"
+
+	message_admins(msg)
+	log_game(msg)
+
+	notify_ghosts("A station has been generated.", source = src, action = NOTIFY_ORBIT)
+
+/obj/effect/landmark/station/Destroy()
+	poi_list -= src
+	. = ..()


### PR DESCRIPTION
🆑 ike709
tweak: Ghosts will now see a proper notification about stations being generated, rather than a pulse rifle prize notification.
/🆑

Does #632 properly. Replaced the prize pulse rifle with a normal pulse rifle and adds a landmark which notifies admins and ghosts (teleportation included) about stations being generated.

Remake of https://github.com/FTL13/FTL13/pull/689 because fastDMM didn't mapmerge.

I didn't map the landmarks, someone else can do that. But this is tested and working.