### PR TITLE
Adds Flora & Fauna to planet generation

### DIFF
--- a/code/datums/planet_loader/biome.dm
+++ b/code/datums/planet_loader/biome.dm
@@ -7,44 +7,54 @@
 	var/max_weight = 300
 	var/weight = 0
 	var/list/cells = list()
-	var/plant_density = 0
-	var/list/plant_types = /obj/structure/flora/grass/jungle
+	var/flora_density = 0
+	var/fauna_density = 0
+	var/list/flora_types = list(/obj/structure/flora/grass/jungle)
+	var/list/fauna_types = list(
+	/mob/living/carbon/monkey{faction = list("wildlife")} = 50,
+	/obj/item/clothing/mask/facehugger = 1,
+	/mob/living/simple_animal/hostile/poison/bees{faction = list("wildlife")} = 50	,
+	/mob/living/simple_animal/hostile/poison/giant_spider/nurse{faction = list("wildlife")} = 5,
+	/mob/living/simple_animal/hostile/bear{faction = list("wildlife")} = 5,
+	)
 
-/datum/biome/beach
-turf_type = /turf/open/floor/plating/asteroid/planet/sand
-plant_types = /obj/structure/flora/grass/jungle
-max_weight = 50
-plant_density = 10
+/datum/biome/desert
+	turf_type = /turf/open/floor/plating/asteroid/planet/sand
+	flora_types = list(/obj/structure/flora/ausbushes, /obj/structure/flora/ausbushes/palebush, /obj/structure/flora/ausbushes/stalkybush)
+	max_weight = 50
+	flora_density = 15
 
 /datum/biome/lake
-turf_type = /turf/open/floor/plating/asteroid/planet/water
-plant_types = /obj/structure/flora/grass/jungle
-max_weight = 150
-plant_density = 0
+	turf_type = /turf/open/floor/plating/asteroid/planet/water
+	flora_types = list(/obj/structure/flora/grass/jungle)
+	fauna_types = list(/mob/living/simple_animal/hostile/carp)
+	max_weight = 150
+	flora_density = 0
+	fauna_density = 0.2
 
 /datum/biome/plains
-turf_type = /turf/open/floor/plating/asteroid/planet/grass
-plant_types = /obj/structure/flora/grass/jungle
-max_weight = 100
-plant_density = 40
+	turf_type = /turf/open/floor/plating/asteroid/planet/grass
+	flora_types = list(/obj/structure/flora/grass/jungle,/obj/structure/flora/grass/jungle/b, /obj/structure/flora/tree/jungle, /obj/structure/flora/junglerocks, /obj/structure/flora/junglebush, /obj/structure/flora/junglebush/b, /obj/structure/flora/junglebush/c, /obj/structure/flora/junglebush/large, /obj/structure/flora/largerocks)
+	max_weight = 100
+	flora_density = 20
 
 /datum/biome/jungle
-		turf_type = /turf/open/floor/plating/asteroid/planet/grass
-		plant_types = /obj/structure/flora/grass/jungle
-		max_weight = 400
-		plant_density = 70
+	turf_type = /turf/open/floor/plating/asteroid/planet/grass
+	flora_types = list(/obj/structure/flora/grass/jungle,/obj/structure/flora/grass/jungle/b, /obj/structure/flora/tree/jungle, /obj/structure/flora/junglerocks, /obj/structure/flora/junglebush, /obj/structure/flora/junglebush/b, /obj/structure/flora/junglebush/c, /obj/structure/flora/junglebush/large, /obj/structure/flora/largerocks)
+	max_weight = 400
+	flora_density = 75
+	fauna_density = 4
 
 /datum/biome/snowy_plains
 	turf_type = /turf/open/floor/plating/asteroid/planet/snow
-	plant_types = /obj/structure/flora/grass/jungle
+	flora_types = list(/obj/structure/flora/tree/pine,/obj/structure/flora/tree/dead, /obj/structure/flora/grass, /obj/structure/flora/grass/brown, /obj/structure/flora/grass/green, /obj/structure/flora/grass/both, /obj/structure/flora/bush)
 	max_weight = 50
-	plant_density = 10
+	flora_density = 20
 
 /datum/biome/mountain
 	turf_type = /turf/closed/mineral/random
-	plant_types = /obj/structure/flora/grass/jungle
 	max_weight = 250
-	plant_density = 0
+	flora_density = 0
 
 /datum/biome_cell
 	var/center_x

--- a/code/datums/planet_loader/biome.dm
+++ b/code/datums/planet_loader/biome.dm
@@ -7,26 +7,44 @@
 	var/max_weight = 300
 	var/weight = 0
 	var/list/cells = list()
+	var/plant_density = 0
+	var/list/plant_types = /obj/structure/flora/grass/jungle
 
 /datum/biome/beach
-	turf_type = /turf/open/floor/plating/asteroid/planet/sand
-	max_weight = 100
+turf_type = /turf/open/floor/plating/asteroid/planet/sand
+plant_types = /obj/structure/flora/grass/jungle
+max_weight = 50
+plant_density = 10
 
 /datum/biome/lake
-	turf_type = /turf/open/floor/plating/asteroid/planet/water
-	max_weight = 200
+turf_type = /turf/open/floor/plating/asteroid/planet/water
+plant_types = /obj/structure/flora/grass/jungle
+max_weight = 150
+plant_density = 0
 
 /datum/biome/plains
-	turf_type = /turf/open/floor/plating/asteroid/planet/grass
-	max_weight = 500
+turf_type = /turf/open/floor/plating/asteroid/planet/grass
+plant_types = /obj/structure/flora/grass/jungle
+max_weight = 100
+plant_density = 40
+
+/datum/biome/jungle
+		turf_type = /turf/open/floor/plating/asteroid/planet/grass
+		plant_types = /obj/structure/flora/grass/jungle
+		max_weight = 400
+		plant_density = 70
 
 /datum/biome/snowy_plains
 	turf_type = /turf/open/floor/plating/asteroid/planet/snow
-	max_weight = 100
+	plant_types = /obj/structure/flora/grass/jungle
+	max_weight = 50
+	plant_density = 10
 
 /datum/biome/mountain
 	turf_type = /turf/closed/mineral/random
-	max_weight = 200
+	plant_types = /obj/structure/flora/grass/jungle
+	max_weight = 250
+	plant_density = 0
 
 /datum/biome_cell
 	var/center_x

--- a/code/datums/planet_loader/biome.dm
+++ b/code/datums/planet_loader/biome.dm
@@ -12,10 +12,6 @@
 	var/list/flora_types = list(/obj/structure/flora/grass/jungle)
 	var/list/fauna_types = list(
 	/mob/living/carbon/monkey{faction = list("wildlife")} = 50,
-	/obj/item/clothing/mask/facehugger = 1,
-	/mob/living/simple_animal/hostile/poison/bees{faction = list("wildlife")} = 50	,
-	/mob/living/simple_animal/hostile/poison/giant_spider/nurse{faction = list("wildlife")} = 5,
-	/mob/living/simple_animal/hostile/bear{faction = list("wildlife")} = 5,
 	)
 
 /datum/biome/desert
@@ -28,14 +24,14 @@
 	turf_type = /turf/open/floor/plating/asteroid/planet/water
 	flora_types = list(/obj/structure/flora/grass/jungle)
 	fauna_types = list(/mob/living/simple_animal/hostile/carp)
-	max_weight = 150
+	max_weight = 50
 	flora_density = 0
 	fauna_density = 0.2
 
 /datum/biome/plains
 	turf_type = /turf/open/floor/plating/asteroid/planet/grass
 	flora_types = list(/obj/structure/flora/grass/jungle,/obj/structure/flora/grass/jungle/b, /obj/structure/flora/tree/jungle, /obj/structure/flora/junglerocks, /obj/structure/flora/junglebush, /obj/structure/flora/junglebush/b, /obj/structure/flora/junglebush/c, /obj/structure/flora/junglebush/large, /obj/structure/flora/largerocks)
-	max_weight = 100
+	max_weight = 75
 	flora_density = 20
 
 /datum/biome/jungle

--- a/code/datums/planet_loader/earthlike.dm
+++ b/code/datums/planet_loader/earthlike.dm
@@ -10,7 +10,7 @@
 		cells += new /datum/biome_cell
 	var/list/unused_cells = cells.Copy()
 	var/possible_biomes = typesof(/datum/biome) - /datum/biome
-	
+
 	for(var/i in 1 to rand(5,10))
 		var/biometype = pick(possible_biomes)
 		var/datum/biome/B = new biometype
@@ -21,7 +21,7 @@
 		B.cells += cell
 		cell.biome = B
 		biomes[B] = B.weight
-	
+
 	while(unused_cells.len)
 		var/datum/biome/B = pickweight(biomes)
 		var/datum/biome_cell/closest_cell
@@ -41,7 +41,7 @@
 		closest_cell.biome = B
 /datum/planet_loader/earthlike/add_more_shit(z_level, var/datum/planet/PL)
 	// Generate voronoi cells using manhattan distance
-	
+
 	for(var/datum/sub_turf_block/STB in split_block(locate(1, 1, z_level), locate(world.maxx, world.maxy, z_level)))
 		for(var/turf/T in STB.return_list())
 			if(!istype(T, /turf/open/floor/plating/asteroid/planet/genturf))
@@ -59,4 +59,8 @@
 				var/datum/biome/B = closest.biome
 				T.ChangeTurf(B.turf_type)
 				B.turfs += T
+				if(B.plant_density && B.plant_types)
+					if(prob(B.plant_density))
+						if(istype(T,/turf/open))
+							new B.plant_types(T.loc)
 			CHECK_TICK

--- a/code/datums/planet_loader/earthlike.dm
+++ b/code/datums/planet_loader/earthlike.dm
@@ -59,8 +59,13 @@
 				var/datum/biome/B = closest.biome
 				T.ChangeTurf(B.turf_type)
 				B.turfs += T
-				if(B.plant_density && B.plant_types)
-					if(prob(B.plant_density))
-						if(istype(T,/turf/open))
-							new B.plant_types(T.loc)
+				if(istype(T,/turf/open))
+					if(B.flora_density && B.flora_types)
+						if(prob(B.flora_density))
+							var/obj/structure/flora = pick(B.flora_types)
+							new flora(T)
+					if(B.fauna_density && B.fauna_types)
+						if(prob(B.fauna_density))
+							var/fauna = pick(B.fauna_types)
+							new fauna(T)
 			CHECK_TICK

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -68,7 +68,11 @@
 
 /obj/structure/flora/tree/jungle
 	name = "tree"
+	icon = 'icons/obj/flora/jungletrees.dmi'
+	icon_state = "tree"
 	desc = "It's seriously hampering your view of the jungle."
+	pixel_x = -48
+	pixel_y = -16
 
 /obj/structure/flora/tree/jungle/New()
 	icon_state = "[icon_state][rand(1, 3)]"
@@ -299,13 +303,13 @@
 	desc = "A pile of rocks"
 
 /obj/structure/flora/rock/pile/New()
-	..()
 	icon_state = "[icon_state][rand(1,3)]"
+	..()
 
 //Jungle grass
 
 /obj/structure/flora/grass/jungle
-	name = "jungle grass"
+	name = "grass"
 	desc = "Thick alien flora."
 	icon = 'icons/obj/flora/jungleflora.dmi'
 	icon_state = "grassa"
@@ -319,15 +323,16 @@
 
 //Jungle rocks
 
-/obj/structure/flora/rock/jungle
-	icon_state = "pile of rocks"
-	desc = "A pile of rocks."
+/obj/structure/flora/junglerocks
+	name = "pile of rocks"
 	icon = 'icons/obj/flora/jungleflora.dmi'
+	icon_state = "rock"
+	desc = "A pile of rocks."
 	density = FALSE
 
-/obj/structure/flora/rock/jungle/New()
+/obj/structure/flora/junglerocks/New()
+	icon_state = "[icon_state][rand(1, 5)]"
 	..()
-	icon_state = "[icon_state][rand(1,5)]"
 
 //Jungle bushes
 
@@ -347,12 +352,20 @@
 	icon_state = "bushc"
 
 /obj/structure/flora/junglebush/large
-	icon_state = "bush"
 	icon = 'icons/obj/flora/largejungleflora.dmi'
+	icon_state = "bush"
 	pixel_x = -16
+	pixel_y = -16
 	layer = ABOVE_ALL_MOB_LAYER
 
-/obj/structure/flora/rock/pile/largejungle
+/obj/structure/flora/largerocks
 	name = "rocks"
 	icon = 'icons/obj/flora/largejungleflora.dmi'
+	icon_state = "rocks"
+	pixel_x = -16
+	pixel_y = -24
 	density = FALSE
+
+/obj/structure/flora/largerocks/New()
+	icon_state = "[icon_state][rand(1, 3)]"
+	..()


### PR DESCRIPTION
:cl: Qustinnus
add: Adds the Jungle biome
add: Adds the generating of trees, rocks, shrubbery and grass 
add: Adds the generating of mobs. (Currently only some random crap mobs that seemed fitting)
fix: Fixes the icon states the original spriter made on the sprites jungle plant objects
tweak: Changes the weight of the biomes. Jungle is the most common biome with Mountain being the second.
/:cl:


**DO MERGE RIGHT NOW OR I'LL LITERALY DESTROY YOUR ASSHOLE VIVALAS AND/OR MONSTER**

_Disclaimer: This PR was made by me, so everything will be shit and broken._

**The PR**
This PR adds the basic spawning of plants and animals. It does this by giving each biome the following variables:

For flora:
Plant_density = Chance for a plant to spawn on a turf. Jungle has this on 75 currently
Plant_types = Types of plants that spawn in said biome

For fauna:
Fauna_density = Chance for an animal to spawn on a turf. Jungle currently has this on 4
Fauna_types = The types of animals that spawn in said biome. There's also a weight connected to them to decide the rarity of each animal.


It's a fairly basic system, and probably inefficient. But it looks nice and works well as a placeholder. If anything breaks please @ me on discord
