### PR TITLE
SM Rebalancing for subsystem change

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -2,7 +2,7 @@
 //Please do not bother them with bugs from this port, however, as it has been modified quite a bit.
 //Modifications include removing the world-ending full supermatter variation, and leaving only the shard.
 
-#define NITROGEN_RETARDATION_FACTOR 2        //Higher == N2 slows reaction more
+#define NITROGEN_RETARDATION_FACTOR 3        //Higher == N2 slows reaction more
 #define THERMAL_RELEASE_MODIFIER 5                //Higher == less heat released during reaction
 #define PLASMA_RELEASE_MODIFIER 750                //Higher == less plasma released by reaction
 #define OXYGEN_RELEASE_MODIFIER 325        //Higher == less oxygen released at high temperature/power
@@ -38,6 +38,8 @@
 	var/emergency_point = 500
 	var/emergency_alert = "CRYSTAL DELAMINATION IMMINENT."
 	var/explosion_point = 900
+	var/tick_count = 0
+	var/tick_interval = 1 //How many ticks to skip
 
 	var/emergency_issued = 0
 
@@ -88,6 +90,12 @@
 	qdel(src)
 
 /obj/machinery/power/supermatter_shard/process_atmos()
+	if(tick_count == tick_interval && tick_interval != 0) //If tick_interval is 0 just ignore this block
+		tick_count = 0
+		return
+	else if(tick_interval != 0)
+		tick_count++
+	
 	var/turf/L = loc
 
 	if(isnull(L))		// We have a null turf...something is wrong, stop processing this entity.
@@ -150,7 +158,7 @@
 
 	damage_archived = damage
 	if(takes_damage)
-		damage = max( damage + ( (removed.temperature - 800) / 300 ) , 0 )
+		damage = max( damage + ( (removed.temperature - 800) / 150 ) , 0 )
 	//Ok, 100% oxygen atmosphere = best reaction
 	//Maxes out at 100% oxygen pressure
 	var/removed_nitrogen = 0
@@ -208,7 +216,7 @@
 		var/rads = (power / 10) * sqrt( 1 / max(get_dist(l, src),1) )
 		l.rad_act(rads)
 
-	power -= (power/500)**3
+	power -= (power/400)**3
 
 	return 1
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -150,7 +150,7 @@
 
 	damage_archived = damage
 	if(takes_damage)
-		damage = max( damage + ( (removed.temperature - 800) / 150 ) , 0 )
+		damage = max( damage + ( (removed.temperature - 800) / 300 ) , 0 )
 	//Ok, 100% oxygen atmosphere = best reaction
 	//Maxes out at 100% oxygen pressure
 	var/removed_nitrogen = 0


### PR DESCRIPTION
Because it seems the tickrate is faster on SSair.

Made n2 reaction slowdown higher because it's a shit gas and should have *some* use.
Only runs every other air tick now.
Emitter power gets used slightly faster.

This may be overtuning, I'll test it more when people dont fuck it up every round

:cl: ninjanomnom
tweak: SM Rebalance
/:cl:
