### PR TITLE
More battle bridge area fixes

### DIFF
--- a/_maps/map_files/SpaceSHIP/SpaceSHIP.dmm
+++ b/_maps/map_files/SpaceSHIP/SpaceSHIP.dmm
@@ -216,6 +216,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/medical/genetics)
+"aBZ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "aCj" = (
 /turf/open/floor/plasteel{
 	icon_state = "white"
@@ -862,6 +871,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"ceE" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "cfj" = (
 /obj/item/weapon/stock_parts/subspace/amplifier,
 /obj/item/weapon/stock_parts/subspace/amplifier,
@@ -1176,12 +1192,6 @@
 /obj/item/device/multitool,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
-"cHb" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "cJK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 8
@@ -1577,24 +1587,6 @@
 	dir = 4
 	},
 /area/shuttle/ftl/assembly/robotics)
-"dlF" = (
-/obj/machinery/button/door{
-	id = "battlebridge";
-	name = "Secondary Bridge Blast Doors";
-	pixel_x = 7;
-	pixel_y = 6;
-	req_access_txt = "42"
-	},
-/obj/structure/table/reinforced,
-/obj/structure/viewscreen,
-/obj/structure/viewscreen_controller{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "dmg" = (
 /obj/item/weapon/book/manual/wiki/security_space_law,
 /obj/structure/table/wood,
@@ -1838,11 +1830,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"dGO" = (
-/turf/closed/wall/r_wall,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "dJQ" = (
 /turf/open/floor/engine,
 /area/shuttle/ftl/cargo/mining)
@@ -1999,16 +1986,6 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"efP" = (
-/obj/machinery/camera{
-	c_tag = "Starboard External";
-	dir = 4
-	},
-/obj/machinery/computer/pmanagement,
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "egr" = (
 /obj/effect/landmark/start{
 	name = "Ship Engineer";
@@ -3115,23 +3092,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"gtO" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/preopen{
-	id = "battlebridge";
-	layer = 2.9;
-	name = "secondary bridge blast doors"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "guC" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -3169,15 +3129,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
-"gBx" = (
-/obj/machinery/computer/ftl_navigation{
-	name = "Auxiliary Navigation";
-	secondary = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "gDa" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	tag = "icon-intact (EAST)";
@@ -3564,6 +3515,24 @@
 /obj/machinery/recharger,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/heads)
+"hwz" = (
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera{
+	c_tag = "Battle Bridge";
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "hxQ" = (
 /obj/machinery/conveyor_switch{
 	id = "munitions"
@@ -3792,15 +3761,6 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/bar)
-"hMu" = (
-/obj/machinery/computer/ftl_weapons{
-	name = "Auxiliary Tacitcal Console";
-	secondary = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "hNA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4039,16 +3999,6 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"ike" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "ikz" = (
 /obj/machinery/clonepod{
 	connected = null;
@@ -4342,6 +4292,18 @@
 	dir = 8
 	},
 /area/shuttle/ftl/cargo/office)
+"iNF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
 "iQr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -4815,6 +4777,16 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
+"jEd" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/computer/pmanagement,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "jGm" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5001,6 +4973,12 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
+"kfh" = (
+/obj/machinery/computer/communications,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "kgt" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
@@ -5530,6 +5508,31 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/armory)
+"lcE" = (
+/obj/structure/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/power/apc/priority{
+	auto_name = 1;
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = -8
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "leo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -6024,19 +6027,6 @@
 /mob/living/simple_animal/pet/cat/Runtime,
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/ftl/medical/cmo)
-"mut" = (
-/obj/structure/chair/bridge{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "mvH" = (
 /obj/machinery/door/airlock/external{
 	id_tag = null;
@@ -6180,6 +6170,23 @@
 	},
 /turf/open/floor/plasteel/whiteblue/side,
 /area/shuttle/ftl/medical/medbay_lobby)
+"mNZ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "battlebridge";
+	layer = 2.9;
+	name = "secondary bridge blast doors"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "mOV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -6570,6 +6577,14 @@
 "nzl" = (
 /turf/closed/wall,
 /area/shuttle/ftl/cargo/office)
+"nzR" = (
+/obj/structure/chair/bridge{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "nBj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -6838,34 +6853,6 @@
 "nVF" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/bar)
-"nVY" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 2
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 2
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "nWz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7120,6 +7107,23 @@
 	dir = 2
 	},
 /area/shuttle/ftl/telecomms/computer)
+"otD" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "battlebridge";
+	layer = 2.9;
+	name = "secondary bridge blast doors"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "oul" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
@@ -7690,24 +7694,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"pAi" = (
-/obj/item/device/radio/intercom{
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/item/device/radio/intercom{
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "pAw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 4
@@ -8114,17 +8100,6 @@
 	dir = 2
 	},
 /area/shuttle/ftl/telecomms/computer)
-"qmW" = (
-/obj/machinery/light/small,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "qnU" = (
 /obj/structure/noticeboard{
 	pixel_y = 32
@@ -8138,6 +8113,16 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hydroponics)
+"qtw" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
 "qtS" = (
 /obj/machinery/computer/mech_bay_power_console,
 /obj/machinery/airalarm{
@@ -8186,6 +8171,16 @@
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engine_smes)
+"qxH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "qyy" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -8336,37 +8331,6 @@
 	},
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/ftl/medical/cmo)
-"qNt" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 2
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 2
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/bridge{
-	name = "Battle-Bridge"
-	},
-/turf/open/floor/plating,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "qPc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 4
@@ -8866,6 +8830,17 @@
 	dir = 1
 	},
 /area/shuttle/ftl/engine/break_room)
+"rNi" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "rNr" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -9103,16 +9078,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"sjs" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "skU" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -9234,6 +9199,15 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
+"stu" = (
+/obj/machinery/computer/ftl_weapons{
+	name = "Auxiliary Tacitcal Console";
+	secondary = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "suM" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	tag = "icon-intact (NORTHEAST)";
@@ -9371,29 +9345,6 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating/airless,
 /area/shuttle/ftl/engine/engine_smes)
-"sCb" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/preopen{
-	id = "battlebridge";
-	layer = 2.9;
-	name = "secondary bridge blast doors"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "sDI" = (
 /obj/structure/table/glass,
 /obj/item/weapon/grenade/chem_grenade,
@@ -10277,6 +10228,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
+"ugZ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 2
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "uhj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/extinguisher_cabinet{
@@ -10344,6 +10320,23 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
+"uyf" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "battlebridge";
+	layer = 2.9;
+	name = "secondary bridge blast doors"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "uzo" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -11916,6 +11909,11 @@
 "xXx" = (
 /turf/closed/wall,
 /area/shuttle/ftl/maintenance/security)
+"xXE" = (
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "xZs" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
@@ -13226,26 +13224,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"ArZ" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/snacks/cakeslice/plain,
-/obj/item/weapon/book/manual/ftl_wiki/bo_guide{
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/obj/item/weapon/book/manual/ftl_wiki/bo_guide{
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "AsB" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -13531,6 +13509,24 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
+"AXk" = (
+/obj/machinery/button/door{
+	id = "battlebridge";
+	name = "Secondary Bridge Blast Doors";
+	pixel_x = 7;
+	pixel_y = 6;
+	req_access_txt = "42"
+	},
+/obj/structure/table/reinforced,
+/obj/structure/viewscreen,
+/obj/structure/viewscreen_controller{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "AXu" = (
 /obj/machinery/light{
 	dir = 1
@@ -13673,23 +13669,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge/eva)
-"Bpb" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/preopen{
-	id = "battlebridge";
-	layer = 2.9;
-	name = "secondary bridge blast doors"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "Bpe" = (
 /obj/effect/landmark/latejoin,
 /obj/structure/chair{
@@ -13981,6 +13960,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
+"BQy" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "BQC" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	icon_state = "intact";
@@ -15766,6 +15755,14 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engine_smes)
+"FIF" = (
+/obj/structure/chair/comfy/captain{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "FKW" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/light{
@@ -16394,34 +16391,6 @@
 	dir = 5
 	},
 /area/shuttle/ftl/cargo/mining)
-"Hhe" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/power/apc/priority{
-	auto_name = 1;
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = -8
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "HhE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -16479,6 +16448,12 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
+"Hqq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "HqT" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -17623,13 +17598,6 @@
 	},
 /turf/open/floor/plasteel/darkwarning,
 /area/shuttle/ftl/turret_protected/ai)
-"KnK" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "Kos" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -17669,6 +17637,24 @@
 	dir = 1
 	},
 /area/shuttle/ftl/engine/engineering)
+"Kvx" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 2
+	},
+/obj/machinery/door/airlock/bridge{
+	name = "Battle-Bridge";
+	req_one_access_txt = "42"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "KvI" = (
 /obj/effect/landmark/start{
 	name = "Scientist";
@@ -17966,6 +17952,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge)
+"LkO" = (
+/obj/machinery/computer/crew,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "Lmw" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
@@ -18484,23 +18476,6 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/hos)
-"Mjv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/preopen{
-	id = "battlebridge";
-	layer = 2.9;
-	name = "secondary bridge blast doors"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "Mjw" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -19322,11 +19297,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/office)
-"Odq" = (
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "Ods" = (
 /obj/machinery/door/airlock/external{
 	name = "EVA airlock"
@@ -19525,26 +19495,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/munitions/loading)
-"Otg" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/preopen{
-	id = "battlebridge";
-	layer = 2.9;
-	name = "secondary bridge blast doors"
-	},
-/obj/structure/fireaxecabinet{
-	pixel_y = -32
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "OtE" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/disposal)
@@ -19766,6 +19716,28 @@
 	dir = 4
 	},
 /area/shuttle/ftl/hallway/primary/starboard)
+"OQX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
+"OSP" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "OUZ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
@@ -21067,6 +21039,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge)
+"RCx" = (
+/obj/machinery/computer/ftl_navigation{
+	name = "Auxiliary Navigation";
+	secondary = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "REb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -21374,16 +21355,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/cmo)
-"Svo" = (
-/obj/machinery/computer/crew,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "SxW" = (
 /obj/machinery/conveyor{
 	id = "CargoMunitions";
@@ -22581,6 +22552,22 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/brig)
+"Vgq" = (
+/obj/structure/chair/bridge{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "Vkq" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -23334,6 +23321,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"WEu" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/snacks/cakeslice/plain,
+/obj/item/weapon/book/manual/ftl_wiki/bo_guide{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/obj/item/weapon/book/manual/ftl_wiki/bo_guide{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "WFz" = (
 /obj/machinery/sleeper{
 	dir = 4;
@@ -23594,16 +23601,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"XlZ" = (
-/obj/machinery/computer/communications,
-/obj/machinery/camera{
-	c_tag = "Bridge North";
-	dir = 9
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "Xmh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -23747,17 +23744,6 @@
 	icon_state = "L10"
 	},
 /area/shuttle/ftl/bridge)
-"XAn" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/chair/comfy/captain{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "XBo" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/munitions/cannon)
@@ -24468,6 +24454,29 @@
 	dir = 8
 	},
 /area/shuttle/ftl/hydroponics)
+"ZyD" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "battlebridge";
+	layer = 2.9;
+	name = "secondary bridge blast doors"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "ZBD" = (
 /obj/structure/chair/stool/bar,
 /obj/structure/disposalpipe/segment,
@@ -24675,14 +24684,6 @@
 	dir = 1
 	},
 /area/shuttle/ftl/medical/medbay)
-"ZVx" = (
-/obj/structure/chair/bridge{
-	dir = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "ZWB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -59477,12 +59478,12 @@ toK
 toK
 toK
 toK
-toK
-toK
-toK
-toK
-Uux
-jyi
+OSP
+OSP
+OSP
+OSP
+OSP
+iYx
 rVA
 HAq
 Len
@@ -59734,12 +59735,12 @@ toK
 toK
 toK
 toK
-toK
-toK
-toK
-toK
-pXc
-iYx
+otD
+stu
+Vgq
+lcE
+OSP
+jyi
 rVA
 uKn
 EIr
@@ -59991,13 +59992,13 @@ toK
 toK
 toK
 toK
-toK
-toK
-toK
-toK
-pXc
-jyi
-rVA
+ZyD
+WEu
+BQy
+ugZ
+Kvx
+OUZ
+OQX
 uKn
 EIr
 hqi
@@ -60246,14 +60247,14 @@ toK
 toK
 toK
 toK
-Kky
-Kky
-Kky
-Kky
-Kky
 toK
-pXc
-EFV
+toK
+otD
+RCx
+FIF
+hwz
+OSP
+jyi
 rVA
 uKn
 EIr
@@ -60503,14 +60504,14 @@ toK
 toK
 toK
 toK
-Kky
-Kky
-dGO
-dGO
-dGO
-dGO
-dGO
-jyi
+toK
+toK
+otD
+AXk
+xXE
+qxH
+OSP
+EFV
 uEc
 uKn
 QSR
@@ -60759,17 +60760,17 @@ toK
 toK
 toK
 toK
-Kky
-Kky
-Kky
-Mjv
-hMu
-mut
-Hhe
-dGO
-jyi
-uEc
-ypb
+toK
+toK
+toK
+otD
+LkO
+nzR
+rNi
+Hqq
+sQz
+iNF
+qtw
 QSR
 QSR
 QSR
@@ -61016,14 +61017,14 @@ toK
 toK
 toK
 toK
-Kky
-Kky
-Kky
-sCb
-ArZ
-sjs
-nVY
-qNt
+toK
+toK
+toK
+otD
+kfh
+aBZ
+jEd
+OSP
 jyi
 uEc
 uKn
@@ -61273,14 +61274,14 @@ toK
 toK
 toK
 toK
-Kky
-Kky
-Kky
-Mjv
-gBx
-XAn
-pAi
-dGO
+toK
+toK
+toK
+mNZ
+uyf
+OSP
+ceE
+OSP
 jyi
 uEc
 HAq
@@ -61530,14 +61531,14 @@ toK
 toK
 toK
 toK
-Kky
-Kky
-Kky
-Mjv
-dlF
-Odq
-qmW
-dGO
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+pXc
 jyi
 rVA
 uKn
@@ -61787,14 +61788,14 @@ toK
 toK
 toK
 toK
-Kky
-Kky
-Kky
-Mjv
-efP
-ZVx
-ike
-dGO
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Uux
 jyi
 rVA
 uKn
@@ -62044,14 +62045,14 @@ toK
 toK
 toK
 toK
-Kky
-Kky
-Kky
-Otg
-cHb
-XlZ
-Svo
-dGO
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Uux
 jyi
 rVA
 kFR
@@ -62301,14 +62302,14 @@ toK
 toK
 toK
 toK
-Kky
-Kky
-Kky
-Bpb
-gtO
-dGO
-KnK
-dGO
+toK
+toK
+toK
+toK
+toK
+toK
+toK
+Uux
 haZ
 tin
 soP
@@ -62558,11 +62559,11 @@ toK
 toK
 toK
 toK
-Kky
-Kky
-Kky
-Kky
-Kky
+toK
+toK
+toK
+toK
+toK
 toK
 toK
 pXc

--- a/_maps/map_files/Trailblazer/Trailblazer.dmm
+++ b/_maps/map_files/Trailblazer/Trailblazer.dmm
@@ -130,18 +130,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/atmos)
-"akV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "all" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -914,17 +902,6 @@
 	},
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos/equipment)
-"bQj" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/preopen{
-	id = "munitions";
-	name = "munitions blast door"
-	},
-/turf/open/floor/plating,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "bQs" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -994,6 +971,15 @@
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/medical/chemistry)
+"cbS" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "cdn" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1458,17 +1444,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay)
-"dkh" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "dlV" = (
 /obj/machinery/flasher{
 	id = "Cell 2";
@@ -1545,6 +1520,18 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engine_smes)
+"drT" = (
+/obj/structure/table/wood,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "dsN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2820,6 +2807,15 @@
 	},
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge)
+"fXH" = (
+/obj/machinery/computer/ftl_weapons{
+	name = "Auxiliary Tacitcal Console";
+	secondary = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "fYf" = (
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -3084,6 +3080,21 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
+"gyu" = (
+/obj/machinery/door/airlock/bridge{
+	name = "Battle-Bridge"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "gBt" = (
 /obj/structure/table,
 /obj/item/device/radio/off,
@@ -3385,6 +3396,21 @@
 	},
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/atmos)
+"hbs" = (
+/obj/machinery/door/airlock/bridge{
+	name = "Battle-Bridge"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "hbF" = (
 /obj/machinery/button/door{
 	id = "miningpodbay";
@@ -3454,18 +3480,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay)
-"hfn" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/preopen{
-	id = "battlebridge";
-	layer = 2.9;
-	name = "secondary bridge blast doors"
-	},
-/turf/open/floor/plating,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "hhR" = (
 /obj/effect/landmark/start{
 	name = "Chemist";
@@ -3861,6 +3875,13 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
+"hPO" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "hRD" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/armory)
@@ -4363,6 +4384,17 @@
 	dir = 10
 	},
 /area/shuttle/ftl/hallway/primary/fore)
+"iSs" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "munitions";
+	name = "munitions blast door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "iUc" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/hor)
@@ -4495,14 +4527,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"jjf" = (
-/obj/structure/chair/bridge{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "jjl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -6329,27 +6353,6 @@
 "nmE" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"nmI" = (
-/obj/structure/chair/bridge{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "nod" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -6465,18 +6468,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/central)
-"nzz" = (
-/obj/structure/chair/bridge{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "nAy" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/closet/firecloset,
@@ -7303,6 +7294,12 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
+"phy" = (
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "pkA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/black,
@@ -7557,13 +7554,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
-"pEU" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "pHP" = (
 /obj/machinery/telecomms/broadcaster/preset_left/birdstation,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -7876,6 +7866,19 @@
 	},
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/port)
+"qpk" = (
+/obj/machinery/button/door{
+	id = "battlebridge";
+	name = "Secondary Bridge Blast Doors";
+	pixel_x = 7;
+	pixel_y = 6;
+	req_access_txt = "42"
+	},
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "qqw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
@@ -8628,6 +8631,16 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions/loading)
+"rNj" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "battlebridge";
+	layer = 2.9;
+	name = "secondary bridge blast doors"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "rOV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -9143,19 +9156,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/turret_protected/ai_upload)
-"sKr" = (
-/obj/machinery/button/door{
-	id = "battlebridge";
-	name = "Secondary Bridge Blast Doors";
-	pixel_x = 7;
-	pixel_y = 6;
-	req_access_txt = "42"
-	},
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "sKE" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/cargo/storage)
@@ -10267,6 +10267,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
+"uVQ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "uWW" = (
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j2";
@@ -10585,6 +10592,18 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/lab)
+"vEf" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "vGo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
@@ -10903,6 +10922,14 @@
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
+"wjw" = (
+/obj/structure/chair/bridge{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "wko" = (
 /obj/structure/table,
 /obj/item/clothing/ears/earmuffs,
@@ -11599,21 +11626,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/medical/medbay_lobby)
-"xTX" = (
-/obj/machinery/door/airlock/bridge{
-	name = "Battle-Bridge"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "xXn" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Tech Storage";
@@ -13496,6 +13508,12 @@
 	layer = 2
 	},
 /area/shuttle/ftl/subshuttle/pod_1)
+"BCR" = (
+/obj/machinery/computer/communications,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "BEf" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel{
@@ -13577,6 +13595,11 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/starboard)
+"BHV" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "BKa" = (
 /obj/structure/chair,
 /obj/machinery/light/small{
@@ -15992,12 +16015,6 @@
 	dir = 4
 	},
 /area/shuttle/ftl/medical/medbay)
-"GLA" = (
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "GLC" = (
 /obj/vehicle/atv,
 /turf/open/floor/plasteel/delivery,
@@ -16791,6 +16808,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/security/main)
+"IOc" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "IOp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17326,6 +17356,18 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
+"JIf" = (
+/obj/structure/chair/bridge{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "JIS" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -17560,18 +17602,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"KkS" = (
-/obj/structure/table/wood,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "KnD" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -17971,16 +18001,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"LdX" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "battlebridge";
-	layer = 2.9;
-	name = "secondary bridge blast doors"
-	},
-/turf/closed/wall/r_wall,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "Lek" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -17995,6 +18015,23 @@
 	dir = 10
 	},
 /area/shuttle/ftl/medical/medbay)
+"Lep" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "LgV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -18368,22 +18405,6 @@
 	},
 /turf/open/floor/plasteel/whiteblue,
 /area/shuttle/ftl/medical/medbay_lobby)
-"MiS" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/sign/securearea{
-	pixel_x = 32;
-	pixel_y = 32
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "battlebridge";
-	layer = 2.9;
-	name = "secondary bridge blast doors"
-	},
-/turf/open/floor/plating,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "MjY" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -18553,25 +18574,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bridge)
-"MxL" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/computer/pmanagement,
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "MxS" = (
 /obj/structure/chair{
 	dir = 1
@@ -18614,6 +18616,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
+"MEI" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/sign/securearea{
+	pixel_x = 32;
+	pixel_y = 32
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "battlebridge";
+	layer = 2.9;
+	name = "secondary bridge blast doors"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "MHe" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -18716,6 +18734,17 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/engine/engine_smes)
+"MQk" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "MUq" = (
 /obj/machinery/pipedispenser,
 /obj/machinery/camera{
@@ -18781,12 +18810,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/turret_protected/ai)
-"Niu" = (
-/obj/machinery/computer/communications,
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "Nkn" = (
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel/whiteblue/side{
@@ -19322,6 +19345,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
+"Onz" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "battlebridge";
+	layer = 2.9;
+	name = "secondary bridge blast doors"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "OnZ" = (
 /turf/open/floor/wood,
 /area/shuttle/ftl/security/vacantoffice)
@@ -19363,13 +19398,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/shuttle/ftl/crew_quarters/toilet)
-"OwE" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "OwL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -19643,6 +19671,25 @@
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/cargo/storage)
+"Pfp" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/computer/pmanagement,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "Pjp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -20803,6 +20850,27 @@
 	},
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/hallway/primary/port)
+"RwA" = (
+/obj/structure/chair/bridge{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "RyQ" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -21145,15 +21213,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Swz" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "munitions";
-	name = "munitions blast door"
-	},
-/turf/closed/wall/r_wall,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "SAn" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 6
@@ -21248,6 +21307,17 @@
 /obj/machinery/ftl_drive,
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/secure_construction)
+"SMI" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/bridge{
+	name = "Battle-Bridge"
+	})
 "SQh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -22189,21 +22259,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/hallway/primary/port)
-"Uwi" = (
-/obj/machinery/door/airlock/bridge{
-	name = "Battle-Bridge"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "Uxs" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/hatch{
@@ -23106,23 +23161,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engine_smes)
-"WeL" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "Wfq" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/black,
@@ -24778,17 +24816,6 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engine_smes)
-"ZqN" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "ZqQ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -24889,19 +24916,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/medical/surgery)
-"ZFx" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/bridge{
-	name = "Battle-Bridge"
-	})
 "ZGy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/requests_console{
@@ -62089,15 +62103,15 @@ ZYN
 KWF
 KWF
 jwi
-Swz
-bQj
-eqM
+cbS
+iSs
+BHV
 YrI
 AKP
 jgM
-eqM
-hfn
-LdX
+BHV
+Onz
+rNj
 BqZ
 jnb
 uCw
@@ -62346,15 +62360,15 @@ dMP
 aAR
 Atg
 ybV
-MxL
-nzz
-pEU
+Pfp
+JIf
+uVQ
 ZkF
 QPn
 LER
-hfn
-GaG
-nmI
+Onz
+fXH
+RwA
 BqZ
 GyX
 HHG
@@ -62603,15 +62617,15 @@ RIh
 SgS
 DpW
 ybV
-KkS
-WeL
-pEU
+drT
+Lep
+uVQ
 IGA
 gaD
 Vds
-OwE
-sKr
-dkh
+hPO
+qpk
+SMI
 oGR
 cKp
 YSB
@@ -62860,15 +62874,15 @@ zGl
 MMF
 OkP
 ybV
-GLA
-ZqN
-xTX
+phy
+MQk
+gyu
 tyt
 nFc
 sHD
-Uwi
-akV
-ZFx
+hbs
+vEf
+IOc
 oGR
 PQu
 Gfx
@@ -63117,15 +63131,15 @@ eZn
 naS
 ZYO
 uSh
-Niu
-jjf
-pEU
+BCR
+wjw
+uVQ
 IGA
 DzK
 zkU
-MiS
-GaG
-jjf
+MEI
+fXH
+wjw
 oGR
 dLu
 UJM
@@ -63374,15 +63388,15 @@ iHT
 rkp
 Yba
 Uec
-pEU
-pEU
-eqM
+uVQ
+uVQ
+BHV
 YrI
 AKP
 jgM
-eqM
-hfn
-hfn
+BHV
+Onz
+Onz
 jxC
 jxC
 jxC


### PR DESCRIPTION
[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)

Fixes mapping error with battle bridges getting left behind, Astraeus and Trailblazer edition. 
This is in preparation when we switch back to one of the better maps. 
Also cleaned up the Astraeus interior. There were some hanging light frames and extra cameras. 

:cl: IndusRobot
fix: SpaceSHIP battle-bridge area doesn't get left behind
fix: Trailblazer battle-bridge area doesn't get left behind
add: Rearranged SpaceSHIP battle-bridge's interior contents
/:cl:
