### PR TITLE
Bugfix for #705 - Runtimes in ships.dm

### DIFF
--- a/code/controllers/subsystem/ships.dm
+++ b/code/controllers/subsystem/ships.dm
@@ -127,6 +127,8 @@ var/global/list/ftl_weapons_consoles = list()
 			ship_attack(S.attacking_target,S)
 
 /datum/subsystem/ship/proc/ship_attack(var/datum/starship/S,var/datum/starship/attacker)
+	if(isnull(S)) // fix for runtime
+		return
 	damage_ship(pick(S.components),pick(get_attacks(S)),attacker)
 
 /datum/subsystem/ship/proc/attack_player(var/datum/starship/S,var/datum/ship_attack/attack_data)
@@ -174,24 +176,29 @@ var/global/list/ftl_weapons_consoles = list()
 		broadcast_message("<span class=notice>[faction2prefix(attacking_ship)] ship ([attacking_ship.name]) firing on [faction2prefix(S)] ship ([S.name]).",null,S)
 	if((!attacking_ship && S.planet != SSstarmap.current_planet) || (attacking_ship && attacking_ship.planet != S.planet))
 		spawn(10) //a bit of a delay wouldn't hurt, especially since we now have a cool af laser sound
-			broadcast_message("<span class=notice>Shot missed! [faction2prefix(S)] ship ([S.name]) out of range!</span>",error_sound,S)
+			if(istype(S)) // fix for runtime (ship might have ceased to exist during the spawn)
+				broadcast_message("<span class=notice>Shot missed! [faction2prefix(S)] ship ([S.name]) out of range!</span>",error_sound,S)
 		return
 	if(prob(S.evasion_chance * attack_data.evasion_mod))
 		spawn(10)
-			broadcast_message("<span class=notice>Shot missed! [faction2prefix(S)] ship ([S.name]) evaded!</span>",error_sound,S)
+			if(istype(S)) // fix for runtime (ship might have ceased to exist during the spawn)
+				broadcast_message("<span class=notice>Shot missed! [faction2prefix(S)] ship ([S.name]) evaded!</span>",error_sound,S)
 		return
 	else
 		spawn(10)
-			broadcast_message("<span class=notice>Shot hit! ([S.name])</span>",success_sound,S)
+			if(istype(S)) // fix for runtime (ship might have ceased to exist during the spawn)
+				broadcast_message("<span class=notice>Shot hit! ([S.name])</span>",success_sound,S)
 	if(S.shield_strength >= 1 && !attack_data.shield_bust)
 		S.shield_strength = max(S.shield_strength - attack_data.hull_damage, 0)
 		S.next_recharge = world.time + S.recharge_rate
 		if(S.shield_strength <= 0)
 			spawn(10)
-				broadcast_message("<span class=notice>Shot hit [faction2prefix(S)] shields. [faction2prefix(S)] ship ([S.name]) shields lowered!</span>",notice_sound,S)
+				if(istype(S)) // fix for runtime (ship might have ceased to exist during the spawn)
+					broadcast_message("<span class=notice>Shot hit [faction2prefix(S)] shields. [faction2prefix(S)] ship ([S.name]) shields lowered!</span>",notice_sound,S)
 		else
 			spawn(10)
-				broadcast_message("<span class=notice>Shot hit [faction2prefix(S)] shields. [faction2prefix(S)] ship shields at [S.shield_strength / initial(S.shield_strength) * 100]%!</span>",notice_sound,S)
+				if(istype(S)) // fix for runtime (ship might have ceased to exist during the spawn)
+					broadcast_message("<span class=notice>Shot hit [faction2prefix(S)] shields. [faction2prefix(S)] ship shields at [S.shield_strength / initial(S.shield_strength) * 100]%!</span>",notice_sound,S)
 		return
 	if(S.hull_integrity > 0)
 		S.hull_integrity = max(S.hull_integrity - attack_data.hull_damage,0)
@@ -200,15 +207,18 @@ var/global/list/ftl_weapons_consoles = list()
 		if(C.health <= 0)
 			if(C.active)
 				spawn(10)
-					broadcast_message("<span class=notice>Shot hit [faction2prefix(S)] hull ([S.name]). [faction2prefix(S)] ship's [C.name] destroyed at ([C.x_loc],[C.y_loc]). [faction2prefix(S)] ship hull integrity at [S.hull_integrity].</span>",notice_sound,S)
+					if(istype(S)) // fix for runtime (ship might have ceased to exist during the spawn)
+						broadcast_message("<span class=notice>Shot hit [faction2prefix(S)] hull ([S.name]). [faction2prefix(S)] ship's [C.name] destroyed at ([C.x_loc],[C.y_loc]). [faction2prefix(S)] ship hull integrity at [S.hull_integrity].</span>",notice_sound,S)
 			else
 				spawn(10)
-					broadcast_message("<span class=notice>Shot hit [faction2prefix(S)] hull ([S.name]). [faction2prefix(S)] ship's [C.name] was hit at ([C.x_loc],[C.y_loc]) but was already destroyed. [faction2prefix(S)] ship hull integrity at [S.hull_integrity].</span>",notice_sound,S)
+					if(istype(S)) // fix for runtime (ship might have ceased to exist during the spawn)
+						broadcast_message("<span class=notice>Shot hit [faction2prefix(S)] hull ([S.name]). [faction2prefix(S)] ship's [C.name] was hit at ([C.x_loc],[C.y_loc]) but was already destroyed. [faction2prefix(S)] ship hull integrity at [S.hull_integrity].</span>",notice_sound,S)
 
 			C.active = 0
 		else
 			spawn(10)
-				broadcast_message("<span class=notice>Shot hit [faction2prefix(S)] hull ([S.name]). [faction2prefix(S)] ship's [C.name] damaged at ([C.x_loc],[C.y_loc]). [faction2prefix(S)] ship hull integrity at [S.hull_integrity].</span>",notice_sound,S)
+				if(istype(S)) // fix for runtime (ship might have ceased to exist during the spawn)
+					broadcast_message("<span class=notice>Shot hit [faction2prefix(S)] hull ([S.name]). [faction2prefix(S)] ship's [C.name] damaged at ([C.x_loc],[C.y_loc]). [faction2prefix(S)] ship hull integrity at [S.hull_integrity].</span>",notice_sound,S)
 
 	if(S.hull_integrity <= 0) destroy_ship(S)
 
@@ -308,6 +318,8 @@ var/global/list/ftl_weapons_consoles = list()
 
 
 /datum/subsystem/ship/proc/process_ftl(var/datum/starship/S)
+	if(isnull(S)) // fix for runtime: cannot read null.name
+		return
 	if(!S.is_jumping)
 		return
 

--- a/code/datums/ship.dm
+++ b/code/datums/ship.dm
@@ -298,9 +298,9 @@ var/next_ship_id
 /datum/ship_ai/standard_combat/fire(datum/starship/ship)
 	if(!ship.system || ship.attacking_target || ship.attacking_player || SSstarmap.in_transit || SSstarmap.in_transit_planet )
 		return
-	
+
 	var/list/possible_targets = list()
-	
+
 	for(var/datum/starship/O in ship.system.ships) //TODO: Add different AI algorithms for finding and assigning targets, as well as other behavior
 		if(ship.faction == O.faction || ship == O)
 			continue
@@ -399,6 +399,9 @@ var/next_ship_id
 	cname = "MISSION_FLEE"
 
 /datum/ship_ai/flee/fire(datum/starship/ship)
+	if(!ship.system)
+		return // if the ship is somehow not in a system, there's no adjacent system at all to escape to!
+
 	ship.flagship = null
 	var/datum/star_system/escape_system = pick(ship.system.adjacent_systems(ship.ftl_range))
 


### PR DESCRIPTION
Fixes #705.
No changelog entry provided, this change is going to be invisible to players.

This is a patch fix to prevent several instances of trying to access vars of nulls -- the deeper issue of passing in null values might deserve deeper investigation.

Also, for several spawns, checks have been added that the thing we went to blow up exists to blow up (whoops!).