### PR TITLE
Bugfix for #707 - fix runtime on item_attack.dm related to missing attack verbs

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -87,7 +87,7 @@
 
 /mob/living/proc/send_item_attack_message(obj/item/I, mob/living/user, hit_area)
 	var/message_verb = "attacked"
-	if(I.attack_verb.len)
+	if(I.attack_verb && I.attack_verb.len)
 		message_verb = "[pick(I.attack_verb)]"
 	else if(!I.force)
 		return 0
@@ -110,4 +110,4 @@
 		visible_message("<span class='warning'>[I] bounces harmlessly off of [src].</span>",\
 					"<span class='warning'>[I] bounces harmlessly off of [src]!</span>")
 	else
-		return ..()
+		return ..()


### PR DESCRIPTION
Fixes #707. The attack_verb list might be null, so check for its existence first. Simple enough.