### PR TITLE
Bugfix for #708 - fix runtime in cart.dm

### DIFF
--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -483,20 +483,23 @@ Code:
 
 			menu += "<BR><B>Supply shuttle</B><BR>"
 			menu += "Location: "
-			switch(SSshuttle.supply.mode)
-				if(SHUTTLE_CALL)
-					menu += "Moving to "
-					if(SSshuttle.supply.z != ZLEVEL_STATION)
-						menu += "station"
+			if(SSshuttle.supply)
+				switch(SSshuttle.supply.mode)
+					if(SHUTTLE_CALL)
+						menu += "Moving to "
+						if(SSshuttle.supply.z != ZLEVEL_STATION)
+							menu += "station"
+						else
+							menu += "centcomm"
+						menu += " ([SSshuttle.supply.timeLeft(600)] Mins)"
 					else
-						menu += "centcomm"
-					menu += " ([SSshuttle.supply.timeLeft(600)] Mins)"
-				else
-					menu += "At "
-					if(SSshuttle.supply.z != ZLEVEL_STATION)
-						menu += "centcomm"
-					else
-						menu += "station"
+						menu += "At "
+						if(SSshuttle.supply.z != ZLEVEL_STATION)
+							menu += "centcomm"
+						else
+							menu += "station"
+			else
+				menu += "Unavailable"
 			menu += "<BR>Current approved orders: <BR><ol>"
 			for(var/S in SSshuttle.shoppinglist)
 				var/datum/supply_order/SO = S


### PR DESCRIPTION
Fixes #708. This one might actually be visible so I'll provide a changelog.
Basically if for some reason there's no supply shuttle assigned to the shuttle system, instead of causing the cart program to runtime and die, here's an attempt to fail gracefully with a shrug.

:cl:
fix: If the supply shuttle's whereabouts are unknown, now the PDA program says so
/:cl:
