### PR TITLE
Makes pipe filter and mixer turn back on after power outage

### DIFF
--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -4,6 +4,7 @@
 	density = 0
 	can_unwrench = 1
 	var/on = 0
+	var/on_memory = 0 //Remembers what state it should be in based on user input even if power goes out
 	var/target_pressure = ONE_ATMOSPHERE
 	var/filter_type = ""
 	var/frequency = 0
@@ -48,6 +49,8 @@
 	..()
 	if(stat & NOPOWER)
 		on = 0
+	else
+		on = on_memory
 	if(old_stat != stat)
 		update_icon()
 
@@ -126,6 +129,7 @@
 	switch(action)
 		if("power")
 			on = !on
+			on_memory = on
 			investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", "atmos")
 			. = TRUE
 		if("pressure")

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -6,6 +6,8 @@
 	can_unwrench = 1
 
 	var/on = 0
+	var/on_memory = 0 //Remembers what state it should be in based on user input even if power goes out
+
 
 	var/target_pressure = ONE_ATMOSPHERE
 	var/node1_concentration = 0.5
@@ -40,6 +42,8 @@
 	..()
 	if(stat & NOPOWER)
 		on = 0
+	else
+		on = on_memory
 	if(old_stat != stat)
 		update_icon()
 
@@ -138,6 +142,7 @@
 	switch(action)
 		if("power")
 			on = !on
+			on_memory = on
 			investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", "atmos")
 			. = TRUE
 		if("pressure")


### PR DESCRIPTION
:cl: ninjanomnom
tweak: Pipe filters and mixers turn back on once they have power if they were on before
/:cl:

Fixes #767 