### PR TITLE
[Aetherwhisp] Adds a hydrogen chamber to atmos

### DIFF
--- a/_maps/map_files/Aetherwhisp/Aetherwhisp.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp.dmm
@@ -2429,16 +2429,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/meeting_room)
-"eLk" = (
-/obj/structure/table/wood,
-/obj/item/device/flashlight/lamp,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Library"
-	})
 "eLp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -5652,6 +5642,19 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
 /area/shuttle/ftl/atmos/equipment)
+"jUT" = (
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/weapon/coin/iron,
+/obj/item/weapon/storage/box/lights/mixed,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "jWr" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -7569,14 +7572,6 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
-"mZI" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/cargo/storage)
 "mZS" = (
 /obj/machinery/light{
 	dir = 8
@@ -8934,6 +8929,16 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions)
+"psd" = (
+/obj/structure/rack,
+/obj/item/weapon/aiModule/core/freeformcore,
+/obj/item/weapon/aiModule/reset,
+/obj/item/weapon/aiModule/reset/purge{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel/circuit,
+/area/shuttle/ftl/turret_protected/ai)
 "ptw" = (
 /obj/machinery/computer/secure_data,
 /turf/open/floor/carpet,
@@ -11344,13 +11349,6 @@
 /obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
-"sIC" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/closet/l3closet,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/bar)
 "sJI" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -11802,6 +11800,17 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
+"tAz" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/obj/item/device/camera_film,
+/obj/item/device/flashlight/lamp,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Library"
+	})
 "tBr" = (
 /obj/machinery/button/door{
 	id = "execute_shutters";
@@ -11879,6 +11888,12 @@
 	initial_gas_mix = "n2=500;TEMP=80"
 	},
 /area/shuttle/ftl/research/server)
+"tHa" = (
+/obj/structure/closet/crate,
+/obj/item/weapon/coin/iron,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
 "tHy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13072,6 +13087,18 @@
 	},
 /turf/closed/wall/shuttle,
 /area/shuttle/ftl/cargo/mining)
+"vFi" = (
+/obj/structure/closet/crate/secure/loot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/item/device/camera_film,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/open/floor/plasteel/bot,
+/area/shuttle/ftl/cargo/mining)
 "vFO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13914,6 +13941,24 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engineering)
+"xoC" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/rack,
+/obj/item/weapon/aiModule/core/full/asimov,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/weapon/aiModule/core/full/corp{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel/circuit,
+/area/shuttle/ftl/turret_protected/ai)
 "xsf" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -15048,11 +15093,6 @@
 /obj/machinery/vending/cola,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
-"zMz" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/bar)
 "zNr" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 2;
@@ -19664,21 +19704,6 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engine_smes)
-"Hvh" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/rack,
-/obj/item/weapon/aiModule/core/full/corp,
-/obj/item/weapon/aiModule/core/full/asimov,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/circuit,
-/area/shuttle/ftl/turret_protected/ai)
 "Hvp" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -21140,12 +21165,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
-"KiY" = (
-/obj/structure/rack,
-/obj/item/weapon/aiModule/core/freeformcore,
-/obj/item/weapon/aiModule/reset,
-/turf/open/floor/plasteel/circuit,
-/area/shuttle/ftl/turret_protected/ai)
 "Kky" = (
 /turf/open/space,
 /area/space)
@@ -23664,17 +23683,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"OjL" = (
-/obj/structure/closet/crate/secure/loot,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel/bot,
-/area/shuttle/ftl/cargo/mining)
 "OkM" = (
 /obj/structure/table/glass,
 /obj/item/clothing/mask/gas,
@@ -24495,18 +24503,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/meeting_room)
-"PGS" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/weapon/storage/box/lights/mixed,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
 "PHE" = (
 /obj/machinery/door/window{
 	dir = 4;
@@ -25501,6 +25497,15 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engineering)
+"Riv" = (
+/obj/structure/closet/crate,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 2
+	},
+/obj/item/device/camera_film,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/storage)
 "RiV" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -27895,6 +27900,14 @@
 /mob/living/simple_animal/parrot/Poly,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/chiefs_office)
+"UXS" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/closet/l3closet,
+/obj/item/weapon/coin/iron,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/bar)
 "Vam" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -52690,7 +52703,7 @@ toK
 VgA
 Ayi
 tEA
-PGS
+jUT
 qkK
 qkK
 zPR
@@ -58142,8 +58155,8 @@ vHV
 apk
 oNY
 mSc
-KiY
-Hvh
+psd
+xoC
 vHV
 rXw
 toK
@@ -61948,7 +61961,7 @@ YGo
 RVZ
 dXt
 uhL
-mZI
+Riv
 sbH
 xEp
 DGU
@@ -63485,7 +63498,7 @@ toK
 nIC
 hPA
 xAM
-OjL
+vFi
 fDu
 wfy
 UFB
@@ -66088,7 +66101,7 @@ oAG
 xIW
 STt
 oAG
-zMz
+tHa
 eel
 CwJ
 UrZ
@@ -66101,7 +66114,7 @@ xWp
 xON
 tjG
 wxL
-sIC
+UXS
 teq
 KBz
 Lwp
@@ -75102,7 +75115,7 @@ SCI
 wCB
 ZgC
 xnd
-eLk
+tAz
 Dnn
 HzE
 TJg

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp.dmm
@@ -285,6 +285,12 @@
 /area/shuttle/ftl/crew_quarters/theatre{
 	name = "Library"
 	})
+"aDl" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/captain)
 "aDx" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -873,6 +879,17 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/captain)
+"bUB" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance";
+	req_access_txt = "0";
+	req_one_access_txt = "0"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "bWM" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -992,6 +1009,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
+"cgD" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "hydrogen_sensor"
+	},
+/obj/machinery/portable_atmospherics/canister/hydrogen,
+/turf/open/floor/engine/hydrogen,
+/area/shuttle/ftl/atmos)
 "chT" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -1933,15 +1961,6 @@
 "eaI" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/telecomms/server)
-"eaR" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "ebR" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -2141,6 +2160,16 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engineering)
+"esW" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "eto" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2360,13 +2389,6 @@
 /area/shuttle/ftl/security/brig{
 	name = "Departures Checkpoint"
 	})
-"eHf" = (
-/obj/structure/cryofeed/right,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/shuttle/ftl/crew_quarters/sleep)
 "eHQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -3599,10 +3621,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"gIB" = (
-/obj/structure/table,
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
 "gIP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -4492,6 +4510,18 @@
 "igH" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/assembly/chargebay)
+"iiQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/crew_quarters/heads)
 "ijO" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -4616,17 +4646,6 @@
 	},
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
-"iuL" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/air_sensor{
-	frequency = 1441;
-	id_tag = "hydrogen_sensor"
-	},
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/engine,
-/area/shuttle/ftl/atmos)
 "ixD" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hydroponics)
@@ -4721,30 +4740,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"iFS" = (
-/obj/machinery/camera/motion{
-	c_tag = "Armory";
-	dir = 4;
-	network = list("SS13","Brig")
-	},
-/obj/machinery/ai_status_display{
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/obj/structure/rack,
-/obj/item/ammo_box/magazine/sniper_rounds/haemorrhage,
-/obj/item/ammo_box/magazine/sniper_rounds/penetrator,
-/obj/item/ammo_box/magazine/sniper_rounds/soporific,
-/obj/item/weapon/gun/projectile/automatic/sniper_rifle,
-/obj/machinery/door/window/southleft{
-	dir = 4;
-	name = "Armory";
-	req_access_txt = "3"
-	},
-/turf/open/floor/plasteel/darkwarning{
-	dir = 8
-	},
-/area/shuttle/ftl/security/armory)
 "iGm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
@@ -4881,6 +4876,18 @@
 	dir = 1
 	},
 /area/shuttle/ftl/engine/engineering)
+"iOX" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "iPP" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -5570,6 +5577,21 @@
 /obj/machinery/computer/rdconsole/robotics,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
+"jTT" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/crew_quarters/sleep)
 "jUl" = (
 /obj/item/chair{
 	dir = 8
@@ -6318,6 +6340,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"kZM" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "kZN" = (
 /obj/structure/rack{
 	dir = 8;
@@ -6347,6 +6381,22 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/lab)
+"lgt" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/crew_quarters/heads)
 "lgE" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -6429,13 +6479,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/cargo/mining)
-"lss" = (
-/obj/structure/table/wood,
-/obj/machinery/recharger,
-/obj/item/weapon/hand_tele,
-/obj/item/weapon/melee/chainofcommand,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/captain)
 "lvd" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/assembly/robotics)
@@ -6645,15 +6688,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos/equipment)
-"lKP" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "lLE" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /turf/open/floor/plasteel,
@@ -7339,19 +7373,6 @@
 "mIw" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/nuke_storage)
-"mIz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/crew_quarters/heads)
 "mJx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7521,20 +7542,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
-"mWb" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
 "mWl" = (
 /turf/open/space,
 /turf/closed/wall/shuttle{
@@ -7861,19 +7868,6 @@
 "nAx" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"nCY" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "nDf" = (
 /obj/machinery/r_n_d/circuit_imprinter,
 /obj/structure/sign/poster{
@@ -7964,26 +7958,6 @@
 /area/shuttle/ftl/security/brig{
 	name = "Departures Checkpoint"
 	})
-"nKG" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 8;
-	external_pressure_bound = 0;
-	frequency = 1441;
-	id_tag = "hydrogen_out";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	on = 1;
-	pressure_checks = 2;
-	pump_direction = 0
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/atmos)
 "nLk" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -8310,6 +8284,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/entry)
+"oyp" = (
+/obj/machinery/power/apc{
+	auto_name = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/turf/open/floor/plating,
+/area/shuttle/ftl/janitor)
 "oAE" = (
 /obj/machinery/computer/cargo/request,
 /obj/machinery/camera{
@@ -8505,20 +8492,6 @@
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
-"oOj" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
 "oOF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -8614,15 +8587,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"oUl" = (
-/obj/item/weapon/bedsheet/captain,
-/obj/structure/bed,
-/obj/machinery/ai_status_display{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/captain)
 "oVq" = (
 /obj/structure/sink{
 	dir = 8;
@@ -9129,18 +9093,6 @@
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/telecomms/server)
-"pFB" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "pFR" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -9843,6 +9795,16 @@
 	},
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
+"qBg" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "qCj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -10195,15 +10157,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"rgU" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
 "rhn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
@@ -10881,6 +10834,16 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/subshuttle/pod_1)
+"sgq" = (
+/obj/machinery/computer/communications,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/captain)
 "sgv" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/storage/tech)
@@ -10890,6 +10853,12 @@
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/medical/virology)
+"sgy" = (
+/obj/structure/table,
+/obj/item/weapon/mop,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/turf/open/floor/plating,
+/area/shuttle/ftl/janitor)
 "shC" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -11388,13 +11357,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"sPa" = (
-/obj/structure/cryofeed,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/shuttle/ftl/crew_quarters/sleep)
 "sPc" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
@@ -11945,6 +11907,19 @@
 "tHS" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/bridge)
+"tIf" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
 "tIn" = (
 /obj/structure/table,
 /obj/item/weapon/stock_parts/matter_bin,
@@ -12098,20 +12073,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/entry)
-"tRl" = (
-/obj/machinery/power/apc{
-	auto_name = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/item/weapon/mop,
-/obj/item/weapon/reagent_containers/glass/bucket,
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
 "tRm" = (
 /obj/machinery/ftl_shieldgen,
 /turf/open/floor/engine,
@@ -12829,6 +12790,30 @@
 /area/shuttle/ftl/crew_quarters/theatre{
 	name = "Library"
 	})
+"vkF" = (
+/obj/machinery/camera/motion{
+	c_tag = "Armory High Security";
+	dir = 4;
+	network = list("SS13","Brig")
+	},
+/obj/machinery/ai_status_display{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/structure/rack,
+/obj/item/ammo_box/magazine/sniper_rounds/haemorrhage,
+/obj/item/ammo_box/magazine/sniper_rounds/penetrator,
+/obj/item/ammo_box/magazine/sniper_rounds/soporific,
+/obj/item/weapon/gun/projectile/automatic/sniper_rifle,
+/obj/machinery/door/window/southleft{
+	dir = 4;
+	name = "Armory";
+	req_access_txt = "3"
+	},
+/turf/open/floor/plasteel/darkwarning{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
 "vkQ" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel,
@@ -13136,12 +13121,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"vHL" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
 "vHV" = (
 /obj/machinery/porta_turret/ai{
 	dir = 1
@@ -13186,22 +13165,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos/equipment)
-"vMm" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Security Equipment";
-	dir = 4;
-	network = list("SS13","Brig")
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/structure/closet/secure_closet/lethalshots,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
 "vNA" = (
 /obj/machinery/light{
 	dir = 2
@@ -13300,13 +13263,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"vRF" = (
-/obj/structure/displaycase/captain,
-/obj/machinery/newscaster{
-	pixel_y = 30
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/captain)
 "vTW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13563,17 +13519,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/security/main)
-"wyy" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_y = 32
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/captain)
 "wAj" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/darkbrown,
@@ -13585,20 +13530,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
-"wCA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/machinery/camera{
-	c_tag = "Virology";
-	dir = 6
-	},
-/obj/structure/reagent_dispensers/virusfood{
-	pixel_x = 0;
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/white,
-/area/shuttle/ftl/medical/virology)
 "wCB" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/theatre{
@@ -14269,6 +14200,16 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/meeting_room)
+"xON" = (
+/obj/machinery/camera{
+	c_tag = "Starboard Primary Hallway 5";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
 "xPb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 2
@@ -14332,6 +14273,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
+"xWp" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
 "xXo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14503,16 +14462,6 @@
 /obj/item/weapon/reagent_containers/food/snacks/grown/harebell,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"yvh" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/crew_quarters/heads)
 "yvo" = (
 /obj/structure/chair{
 	dir = 1
@@ -14766,15 +14715,6 @@
 	icon_state = "filter_off";
 	on = 1;
 	tag = "icon-filter_off (WEST)"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos)
-"yVX" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
@@ -15536,15 +15476,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engineering)
-"Ath" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
 "AtH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -16333,10 +16264,6 @@
 /obj/item/weapon/storage/belt/utility,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/secondary/construction)
-"BCe" = (
-/obj/machinery/computer/communications,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/captain)
 "BCy" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -16593,6 +16520,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
+"CiY" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "Cjn" = (
 /obj/structure/closet/wardrobe/cargotech,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -17250,23 +17192,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/nuke_storage)
-"DkG" = (
-/obj/machinery/camera/motion{
-	c_tag = "Armory Maintenance Area";
-	dir = 8;
-	network = list("SS13","Brig")
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
 "Dly" = (
 /obj/machinery/meter,
 /obj/structure/window/reinforced{
@@ -17397,6 +17322,21 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
+"DyS" = (
+/obj/structure/window/reinforced{
+	dir = 2
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8;
+	frequency = 1441;
+	id = "hydrogen_in";
+	pixel_y = 1
+	},
+/turf/open/floor/engine/hydrogen,
+/area/shuttle/ftl/atmos)
 "Dzl" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
@@ -17766,6 +17706,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos/equipment)
+"EcC" = (
+/obj/machinery/camera/motion{
+	c_tag = "Armory Maintenance Area";
+	dir = 8;
+	network = list("SS13","Brig")
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "Edd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -19040,6 +18998,21 @@
 	dir = 2
 	},
 /area/shuttle/ftl/subshuttle/pod_1)
+"GsS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/camera{
+	c_tag = "Virology";
+	dir = 6
+	},
+/obj/structure/reagent_dispensers/virusfood{
+	density = 0;
+	pixel_x = 0;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/white,
+/area/shuttle/ftl/medical/virology)
 "GvO" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -19738,21 +19711,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/security/detectives_office)
-"Hyt" = (
-/obj/structure/window/reinforced{
-	dir = 2
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 8;
-	frequency = 1441;
-	id = "hydrogen_in";
-	pixel_y = 1
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/atmos)
 "HyL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -20156,6 +20114,12 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/chiefs_office)
+"IcL" = (
+/obj/machinery/vending/boozeomat{
+	req_access_txt = "0"
+	},
+/turf/closed/wall/shuttle,
+/area/shuttle/ftl/cargo/mining)
 "Idm" = (
 /obj/machinery/vending/medical,
 /obj/machinery/status_display{
@@ -20326,6 +20290,16 @@
 /obj/item/device/radio/beacon,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/exit)
+"IHy" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "IIy" = (
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/virology)
@@ -21200,6 +21174,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"Kmn" = (
+/obj/structure/displaycase/captain,
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 0;
+	pixel_y = 30
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/captain)
 "KmN" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel,
@@ -21791,10 +21773,6 @@
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"LhB" = (
-/obj/machinery/vending/boozeomat,
-/turf/closed/wall/shuttle,
-/area/shuttle/ftl/cargo/mining)
 "Lim" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -21918,6 +21896,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"Lon" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "Lot" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -22152,16 +22140,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"LJm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 5";
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/starboard)
 "LJu" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -22347,14 +22325,6 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Mbd" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
 "MbN" = (
 /obj/machinery/computer/telecomms/monitor{
 	network = "tcommsat"
@@ -23480,6 +23450,18 @@
 	},
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
+"NYn" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
 "NYo" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -24718,18 +24700,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"PUd" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/sleep)
 "PUL" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -24739,6 +24709,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
+"PVo" = (
+/obj/structure/table/wood,
+/obj/machinery/recharger,
+/obj/item/weapon/hand_tele,
+/obj/item/weapon/melee/chainofcommand,
+/obj/machinery/ai_status_display{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/captain)
 "PXj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -26457,6 +26438,22 @@
 /area/shuttle/ftl/security/brig{
 	name = "Departures Checkpoint"
 	})
+"SHo" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Armory Low Security";
+	dir = 4;
+	network = list("SS13","Brig")
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/obj/structure/closet/secure_closet/lethalshots,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "SKd" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -26608,6 +26605,21 @@
 	dir = 2
 	},
 /area/shuttle/ftl/subshuttle/pod_1)
+"SXX" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance";
+	req_access_txt = "0";
+	req_one_access_txt = "0"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "SYy" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -28002,6 +28014,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
+"Vjv" = (
+/obj/structure/chair/stool/bar,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
 "VjA" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/cable{
@@ -28157,6 +28176,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"Vyt" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8;
+	external_pressure_bound = 0;
+	frequency = 1441;
+	id_tag = "hydrogen_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	on = 1;
+	pressure_checks = 2;
+	pump_direction = 0
+	},
+/turf/open/floor/engine/hydrogen,
+/area/shuttle/ftl/atmos)
 "VyV" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -28559,6 +28598,13 @@
 	},
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
+"Wcg" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 1;
+	filter_type = "hydrogen"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
 "WcQ" = (
 /mob/living/simple_animal/pet/fox/Renault,
 /turf/open/floor/carpet,
@@ -29643,6 +29689,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
+"XXM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "XYf" = (
 /obj/item/device/radio/intercom{
 	pixel_x = 0;
@@ -29822,13 +29874,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"YrB" = (
-/obj/structure/cryofeed/right,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/shuttle/ftl/crew_quarters/sleep)
 "YsL" = (
 /obj/structure/shuttle/engine/propulsion/burst{
 	tag = "icon-propulsion (NORTH)";
@@ -30210,6 +30255,16 @@
 	},
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
+"YUd" = (
+/obj/item/weapon/bedsheet/captain,
+/obj/structure/bed,
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 22
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/captain)
 "YVD" = (
 /obj/machinery/camera{
 	c_tag = "Genetics";
@@ -51871,7 +51926,7 @@ EDx
 Cde
 Cde
 Cde
-Mbd
+bUB
 Cde
 Cde
 SeP
@@ -52128,7 +52183,7 @@ Cde
 Cde
 QfX
 wTn
-ShW
+XXM
 IAv
 Cde
 GyI
@@ -52378,16 +52433,16 @@ toK
 VgA
 ShW
 fMD
-Ath
-rgU
-rgU
-oOj
-rgU
-DkG
-rgU
-rgU
-rgU
-mWb
+iOX
+Lon
+Lon
+CiY
+Lon
+EcC
+Lon
+kZM
+Lon
+SXX
 LTR
 uld
 Pbr
@@ -52899,7 +52954,7 @@ fRe
 Qxz
 fgN
 Hvp
-iFS
+vkF
 TBL
 fgN
 ELw
@@ -53150,7 +53205,7 @@ qkK
 vig
 wxU
 FaN
-vMm
+SHo
 NrF
 mnd
 hXD
@@ -56540,7 +56595,7 @@ rkN
 PmA
 pLc
 sPc
-vHL
+Wcg
 DAx
 sPc
 cTP
@@ -56795,15 +56850,15 @@ NbF
 NGC
 jub
 mbw
-lKP
+qBg
 xwt
-yVX
+IHy
 pQT
 DMm
 bLV
 YEU
 rbv
-eaR
+esW
 vEb
 Lim
 toK
@@ -57052,9 +57107,9 @@ SDP
 wGT
 DOT
 miT
-nKG
-iuL
-Hyt
+Vyt
+cgD
+DyS
 JQL
 vKd
 ZkE
@@ -58562,8 +58617,8 @@ SRJ
 ipF
 bpf
 sPn
-mIz
-yvh
+iiQ
+lgt
 bpf
 Onv
 hvr
@@ -58586,7 +58641,7 @@ Ykp
 exG
 hlX
 ioo
-tRl
+oyp
 kWH
 IRr
 iPP
@@ -59098,7 +59153,7 @@ XoS
 HQp
 Ksn
 exG
-gIB
+sgy
 iQM
 tyy
 kYu
@@ -60126,8 +60181,8 @@ elB
 RXd
 cvE
 RXd
-eHf
-YrB
+Iye
+Iye
 Iye
 TpE
 tNs
@@ -60616,7 +60671,7 @@ vVC
 vxK
 oCP
 Kaw
-BCe
+sgq
 bUj
 POW
 mBM
@@ -61156,7 +61211,7 @@ OmI
 RXd
 Ajg
 CwQ
-PUd
+jTT
 iIh
 OOH
 EBW
@@ -61387,7 +61442,7 @@ mVf
 Xjz
 oCP
 Kaw
-wyy
+aDl
 WcQ
 qPa
 APf
@@ -61644,7 +61699,7 @@ vVC
 vxK
 oCP
 Kaw
-vRF
+Kmn
 Kwd
 qPa
 OYL
@@ -62158,8 +62213,8 @@ vVC
 vxK
 Yjb
 Kaw
-lss
-oUl
+PVo
+YUd
 Fhs
 YNz
 Kaw
@@ -62182,7 +62237,7 @@ eel
 eel
 eel
 TpE
-sPa
+VLP
 BmT
 VLP
 TpE
@@ -65761,11 +65816,11 @@ NLj
 yjW
 EGA
 Jyj
-IhP
+xSM
 izw
 OIR
 EGA
-cOG
+EGA
 pDt
 NLj
 toK
@@ -66022,7 +66077,7 @@ moM
 uBE
 CKn
 EGA
-EGA
+cOG
 Wts
 NLj
 toK
@@ -66042,8 +66097,8 @@ rKR
 Pmm
 gLt
 JnI
-zZi
-LJm
+xWp
+xON
 tjG
 wxL
 sIC
@@ -66556,8 +66611,8 @@ EZQ
 xZo
 CwJ
 OOH
-nCY
-GVv
+KsI
+Umf
 tjG
 oGZ
 nwM
@@ -66565,7 +66620,7 @@ ZxA
 eel
 sFj
 ZSy
-wCA
+GsS
 kIV
 Tqq
 kpl
@@ -67046,7 +67101,7 @@ ijO
 Fra
 KIY
 Apf
-xSM
+IhP
 IhP
 HMr
 gKS
@@ -67287,7 +67342,7 @@ Neg
 TFo
 hzw
 jOj
-LhB
+IcL
 sRb
 rRf
 TFo
@@ -68097,8 +68152,8 @@ lOc
 lOc
 lOc
 lOc
-pFB
-KsI
+NYn
+jDU
 Umf
 gQn
 dRi
@@ -69640,8 +69695,8 @@ OBL
 irL
 lOc
 OOH
-KsI
-Mae
+tIf
+Vjv
 kpW
 nAx
 eHZ
@@ -71181,8 +71236,8 @@ HTE
 ody
 ody
 oZB
-OOH
-KsI
+tNs
+jDU
 KwT
 eOt
 HRi

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -149,6 +149,10 @@
 	name = "air floor"
 	initial_gas_mix = "o2=2644;n2=10580;TEMP=293.15"
 
+/turf/open/floor/engine/hydrogen
+	name = "hydrogen floor"
+	initial_gas_mix = "hydrogen=70000;TEMP=293.15"
+
 
 
 /turf/open/floor/engine/cult


### PR DESCRIPTION
[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)

Adds hydrogen gas to the Aetherwhisp atmospherics. Also adds the hydrogen engine turf. Ninjanomnom's previous PR added the turf but it was closed. 

Lastly, cleans up some mapping issues. These can be found on the map problems doc under Round 6. 

:cl: IndusRobot
add: [Aetherwhisp] Added a hydrogen chamber to atmospherics. 
add: [Aetherwhisp] Added a water vapor canister to the custodial closet
fix: [Aetherwhisp] Changed density of virus food dispenser so it didn't block the tile
fix: [Aetherwhisp] Removed bartender access to the booze-o-mat on the mining shuttle
/:cl:

Fixes #761