### PR TITLE
Fix items spawned in security officer backpack

### DIFF
--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -215,13 +215,13 @@ var/list/sec_departments = list("engineering", "supply", "medical", "science")
 	suit = /obj/item/clothing/suit/toggle/service/security
 	shoes = /obj/item/clothing/shoes/jackboots
 	l_pocket = /obj/item/weapon/restraints/handcuffs
-	r_pocket = /obj/item/device/assembly/flash/handheld	
+	r_pocket = /obj/item/device/assembly/flash/handheld
 	backpack_contents = list(/obj/item/weapon/melee/baton/loaded=1,\
 		/obj/item/weapon/gun/energy/gun/advtaser=1,\
 		/obj/item/ammo_box/magazine/m10mm=2,\
-		/obj/item/clothing/head/helmet/sec,\
-		/obj/item/clothing/suit/armor/vest/alt,\
-		/obj/item/weapon/gun/projectile/automatic/pistol)				
+		/obj/item/clothing/head/helmet/sec=1,\
+		/obj/item/clothing/suit/armor/vest/alt=1,\
+		/obj/item/weapon/gun/projectile/automatic/pistol=1)
 
 	backpack = /obj/item/weapon/storage/backpack/security
 	satchel = /obj/item/weapon/storage/backpack/satchel_sec

--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -216,11 +216,11 @@ var/list/sec_departments = list("engineering", "supply", "medical", "science")
 	shoes = /obj/item/clothing/shoes/jackboots
 	l_pocket = /obj/item/weapon/restraints/handcuffs
 	r_pocket = /obj/item/device/assembly/flash/handheld
-	suit_store = /obj/item/weapon/gun/projectile/automatic/pistol
 	backpack_contents = list(/obj/item/weapon/melee/baton/loaded=1,\
 		/obj/item/weapon/gun/energy/gun/advtaser=1,\
 		/obj/item/ammo_box/magazine/m10mm=2,\
-		/obj/item/clothing/head/helmet/sec=1)
+		/obj/item/clothing/head/helmet/sec=1,\
+		/obj/item/weapon/gun/projectile/automatic/pistol=1)
 
 	backpack = /obj/item/weapon/storage/backpack/security
 	satchel = /obj/item/weapon/storage/backpack/satchel_sec

--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -216,12 +216,11 @@ var/list/sec_departments = list("engineering", "supply", "medical", "science")
 	shoes = /obj/item/clothing/shoes/jackboots
 	l_pocket = /obj/item/weapon/restraints/handcuffs
 	r_pocket = /obj/item/device/assembly/flash/handheld
+	suit_store = /obj/item/weapon/gun/projectile/automatic/pistol
 	backpack_contents = list(/obj/item/weapon/melee/baton/loaded=1,\
 		/obj/item/weapon/gun/energy/gun/advtaser=1,\
 		/obj/item/ammo_box/magazine/m10mm=2,\
-		/obj/item/clothing/head/helmet/sec=1,\
-		/obj/item/clothing/suit/armor/vest/alt=1,\
-		/obj/item/weapon/gun/projectile/automatic/pistol=1)
+		/obj/item/clothing/head/helmet/sec=1)
 
 	backpack = /obj/item/weapon/storage/backpack/security
 	satchel = /obj/item/weapon/storage/backpack/satchel_sec

--- a/ftl13.dme
+++ b/ftl13.dme
@@ -1333,7 +1333,6 @@
 #include "code\modules\mob\mob_movement.dm"
 #include "code\modules\mob\mob_transformation_simple.dm"
 #include "code\modules\mob\say.dm"
-#include "code\modules\mob\say_readme.dm"
 #include "code\modules\mob\status_procs.dm"
 #include "code\modules\mob\transform_procs.dm"
 #include "code\modules\mob\update_icons.dm"

--- a/ftl13.dme
+++ b/ftl13.dme
@@ -1333,6 +1333,7 @@
 #include "code\modules\mob\mob_movement.dm"
 #include "code\modules\mob\mob_transformation_simple.dm"
 #include "code\modules\mob\say.dm"
+#include "code\modules\mob\say_readme.dm"
 #include "code\modules\mob\status_procs.dm"
 #include "code\modules\mob\transform_procs.dm"
 #include "code\modules\mob\update_icons.dm"


### PR DESCRIPTION
Fixes https://github.com/FTL13/FTL13/issues/747 
security officers now spawn with all the items listed there, no fuss. Kinda silly to spawn with ammo for a gun you dont have.

[Changelogs]: 
:cl: NINXE
fix: Security now spawns with a gun (for ye BOOLETS!), and a helmet.
/:cl:
