### PR TITLE
Fixed using munition console at range

### DIFF
--- a/code/game/machinery/computer/ftl_munitions.dm
+++ b/code/game/machinery/computer/ftl_munitions.dm
@@ -24,6 +24,8 @@
 		cannons += B
 
 /obj/machinery/computer/munitions_console/attack_hand(mob/user)
+	if(..())
+		return
 	var/dat = "<B>Munitions Control Computer</B><HR>"
 	dat += "<BR>"
 	dat += "<B>Connected MAC Cannons:</B>"
@@ -69,7 +71,8 @@
 	popup.open(0)
 
 /obj/machinery/computer/munitions_console/Topic(href,href_list)
-	..()
+	if(..())
+		return
 	if(href_list["dispense"])
 		var/obj/machinery/ammo_rack/M = locate(href_list["dispense"])
 		M.dispense_ammo()


### PR DESCRIPTION
Fixes https://github.com/FTL13/FTL13/issues/752
I dont know if line 27 and 28 actually does anything, but that makes it the same as the other consoles.
:cl: NINXE
fix: Can no longer use Munition Console at range
/:cl:
