### PR TITLE
[Aetherwhisp] Another brig layout

### DIFF
--- a/_maps/map_files/Aetherwhisp/Aetherwhisp.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp.dmm
@@ -53,12 +53,28 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"ahM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
+"aiU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/armory)
+/area/shuttle/ftl/security/masteratarms)
+"alz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "alG" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plasteel,
@@ -79,10 +95,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"amd" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/medbay)
 "amg" = (
 /turf/closed/wall,
 /area/shuttle/ftl/engine/break_room)
@@ -322,6 +334,12 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/chiefs_office)
+"aMT" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/darkwarning{
+	dir = 10
+	},
+/area/shuttle/ftl/security/armory)
 "aNq" = (
 /obj/machinery/computer/robotics,
 /obj/structure/cable{
@@ -378,12 +396,34 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/telecomms/computer)
-"aUl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 2
+"aSy" = (
+/obj/machinery/door/poddoor{
+	id = "armory_blast";
+	name = "Security Equipment"
 	},
-/turf/open/floor/plasteel/black,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 9
+	},
 /area/shuttle/ftl/security/main)
+"aTX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/armory)
 "aUC" = (
 /obj/machinery/computer/upload/ai,
 /turf/open/floor/plasteel/circuit,
@@ -401,21 +441,12 @@
 /obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
-"aZC" = (
-/obj/machinery/computer/card/minor/hos,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"aXO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/hos)
+/area/shuttle/ftl/security/main)
 "aZM" = (
 /obj/machinery/ammo_rack/full/shield_piercing,
 /turf/open/floor/plasteel/darkwarning/side{
@@ -882,17 +913,6 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/captain)
-"bUB" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
 "bWM" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -968,18 +988,6 @@
 /obj/structure/filingcabinet/chestdrawer/wheeled,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"cch" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
 "cco" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -1117,6 +1125,26 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/exit)
+"cuz" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "brig_enter_shutters"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hos_shutters";
+	layer = 2
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "brig_enter_shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/hos)
 "cvE" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1165,16 +1193,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/tool_storage)
-"cCn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/masteratarms)
 "cCM" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -1199,21 +1217,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/nuke_storage)
-"cDw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "cKD" = (
 /obj/machinery/light{
 	dir = 4
@@ -1247,40 +1250,22 @@
 /obj/structure/chair/bridge,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
-"cQe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+"cSq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/brig)
-"cQE" = (
-/obj/structure/table,
-/obj/item/toy/sword{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/weapon/grenade/barrier{
-	pixel_x = -4
-	},
-/obj/item/weapon/grenade/barrier,
-/obj/item/weapon/grenade/barrier{
-	pixel_x = 4
-	},
-/obj/item/device/assembly/signaler,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
 "cTy" = (
 /obj/machinery/computer/med_data/laptop,
 /obj/structure/table,
@@ -1372,6 +1357,16 @@
 	dir = 4
 	},
 /area/shuttle/ftl/hydroponics)
+"cXj" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "cXm" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light{
@@ -1440,6 +1435,11 @@
 /obj/item/weapon/storage/firstaid/regular,
 /turf/open/floor/plasteel/shuttle/yellow,
 /area/shuttle/ftl/subshuttle/pod_3)
+"ddm" = (
+/obj/structure/rack,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "deZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -1458,17 +1458,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
-"dfP" = (
-/obj/machinery/flasher{
-	id = "Holding_Pen";
-	pixel_x = 28
-	},
-/obj/structure/rack,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/glasses/sunglasses/blindfold,
-/obj/item/clothing/mask/muzzle,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 "dgb" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -1516,6 +1505,23 @@
 	dir = 8
 	},
 /area/shuttle/ftl/hydroponics)
+"dkO" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 2
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_x = 3
+	},
+/obj/item/weapon/lighter,
+/obj/item/device/flashlight/lamp,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
 "dnt" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/papersack,
@@ -1593,6 +1599,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
+"dth" = (
+/obj/item/weapon/storage/fancy/donut_box,
+/obj/structure/table,
+/obj/item/weapon/storage/box/teargas{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/box/flashbangs{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/weapon/reagent_containers/glass/bottle/morphine,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/sign/poster{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "dtp" = (
 /turf/closed/wall/shuttle{
 	dir = 2;
@@ -1727,18 +1753,6 @@
 /area/shuttle/ftl/security/brig{
 	name = "Departures Checkpoint"
 	})
-"dDw" = (
-/obj/item/weapon/paper_bin,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/obj/structure/table,
-/obj/item/weapon/folder/red,
-/obj/machinery/recharger,
-/obj/item/weapon/pen/red,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "dFN" = (
 /obj/effect/landmark/start{
 	name = "Janitor";
@@ -1819,20 +1833,6 @@
 /obj/machinery/hologram/holopad,
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
-"dRn" = (
-/obj/structure/table,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/folder/red,
-/obj/item/weapon/pen,
-/obj/item/weapon/restraints/handcuffs,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/masteratarms)
 "dRq" = (
 /obj/machinery/door/airlock{
 	name = "Unit 2"
@@ -2179,6 +2179,14 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engineering)
+"esw" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
 "esW" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -2273,6 +2281,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/toilet)
+"ewe" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/security/wooden_tv,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/obj/machinery/camera{
+	c_tag = "Detective's Office";
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
 "ewB" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -2330,6 +2350,19 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
+"ezQ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "eAy" = (
 /obj/structure/table,
 /obj/item/weapon/paper_bin,
@@ -2480,6 +2513,23 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/toilet)
+"ePB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "eQO" = (
 /obj/structure/table/glass,
 /obj/item/device/paicard{
@@ -2519,6 +2569,16 @@
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
+"eTr" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/obj/structure/table/wood,
+/obj/item/device/flashlight/lamp,
+/obj/item/weapon/reagent_containers/food/snacks/cakeslice/plain,
+/obj/item/weapon/gun/projectile/revolver/russian,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "eVZ" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -2538,10 +2598,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"eXv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/armory)
 "far" = (
 /obj/machinery/camera{
 	c_tag = "Vacant Office"
@@ -2575,6 +2631,49 @@
 /obj/item/weapon/pen,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
+"ffD" = (
+/obj/machinery/button/door{
+	id = "warden_shutters";
+	name = "Desk Shutters";
+	pixel_x = 6;
+	pixel_y = -26;
+	req_access_txt = "0"
+	},
+/obj/machinery/button/door{
+	id = "brig_enter_shutters";
+	name = "Brig Lockdown";
+	pixel_x = 6;
+	pixel_y = -38;
+	req_access_txt = "0"
+	},
+/obj/machinery/button/door{
+	id = "warden_shutters_ext";
+	name = "Space Shutters";
+	pixel_x = -6;
+	pixel_y = -26;
+	req_access_txt = "0"
+	},
+/obj/machinery/button/door{
+	id = "armory_blast";
+	name = "Armory Blast Doors";
+	pixel_x = -6;
+	pixel_y = -38;
+	req_access_txt = "0"
+	},
+/obj/structure/closet/secure_closet/masteratarms,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/light{
+	dir = 2
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/masteratarms)
 "fgF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
@@ -2691,14 +2790,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
-"fmJ" = (
-/obj/structure/filingcabinet,
-/obj/machinery/camera{
-	c_tag = "Detective's Office";
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
 "fmY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
@@ -2820,25 +2911,28 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"fyL" = (
-/obj/structure/table,
-/obj/item/device/radio,
-/obj/item/device/sensor_device,
-/obj/item/weapon/hand_labeler{
-	pixel_x = 5
-	},
-/obj/item/device/assembly/signaler,
-/obj/structure/sign/poster{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/masteratarms)
 "fzq" = (
 /obj/structure/sign/poster{
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
+"fzZ" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/closet/bombcloset,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
+"fAy" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "fBa" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2905,6 +2999,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"fHg" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "detective_shutters";
+	layer = 2
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "brig_enter_shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/detectives_office)
 "fHO" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -2986,101 +3097,18 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engine_smes)
-"fMC" = (
-/obj/structure/closet/secure_closet/detective,
-/obj/item/device/camera/detective,
-/obj/machinery/light_switch{
-	pixel_x = -8;
-	pixel_y = -22
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
 "fMD" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"fNc" = (
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
 "fOT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/entry)
-"fQZ" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 0;
-	pixel_y = 30
-	},
-/obj/structure/closet/wardrobe/red,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
-"fRe" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/rack,
-/obj/item/ammo_box/magazine/wt550m9/wtap{
-	pixel_x = 8;
-	pixel_y = -8
-	},
-/obj/item/ammo_box/magazine/wt550m9/wtap{
-	pixel_x = 8;
-	pixel_y = -8
-	},
-/obj/item/ammo_box/magazine/wt550m9/wtap{
-	pixel_x = 8;
-	pixel_y = -8
-	},
-/obj/item/ammo_box/magazine/wt550m9/wtap{
-	pixel_x = 8;
-	pixel_y = -8
-	},
-/obj/item/ammo_box/magazine/wt550m9/wtap{
-	pixel_x = 8;
-	pixel_y = -8
-	},
-/obj/item/ammo_box/magazine/wt550m9/wtap{
-	pixel_x = 8;
-	pixel_y = -8
-	},
-/obj/item/weapon/gun/projectile/automatic/wt550{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/gun/projectile/automatic/wt550,
-/obj/item/weapon/gun/projectile/automatic/wt550{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
 "fRJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -3153,6 +3181,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"fYU" = (
+/obj/machinery/washing_machine,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"fZH" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "gaN" = (
 /obj/structure/closet/firecloset/full,
 /obj/machinery/firealarm{
@@ -3207,18 +3251,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/brig)
-"gec" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos/equipment)
 "geK" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -3534,6 +3566,15 @@
 /obj/structure/filingcabinet/security,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/crew_quarters/heads)
+"gvB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/masteratarms)
 "gyc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -3648,6 +3689,46 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"gJW" = (
+/obj/structure/rack,
+/obj/item/ammo_box/magazine/wt550m9/wtap{
+	pixel_x = 8;
+	pixel_y = -8
+	},
+/obj/item/ammo_box/magazine/wt550m9/wtap{
+	pixel_x = 8;
+	pixel_y = -8
+	},
+/obj/item/ammo_box/magazine/wt550m9/wtap{
+	pixel_x = 8;
+	pixel_y = -8
+	},
+/obj/item/ammo_box/magazine/wt550m9/wtap{
+	pixel_x = 8;
+	pixel_y = -8
+	},
+/obj/item/ammo_box/magazine/wt550m9/wtap{
+	pixel_x = 8;
+	pixel_y = -8
+	},
+/obj/item/ammo_box/magazine/wt550m9/wtap{
+	pixel_x = 8;
+	pixel_y = -8
+	},
+/obj/item/weapon/gun/projectile/automatic/wt550{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/gun/projectile/automatic/wt550,
+/obj/item/weapon/gun/projectile/automatic/wt550{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "gKx" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3765,19 +3846,6 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/ftl/subshuttle/pod_1)
-"gSG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "gTz" = (
 /obj/machinery/r_n_d/server/core,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -3928,19 +3996,6 @@
 	},
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
-"hcM" = (
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
-/obj/machinery/camera{
-	c_tag = "Port Primary Hallway 1";
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
 "hdd" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/black,
@@ -4075,6 +4130,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
+"hqQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "hqW" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -4090,6 +4155,19 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
+"hro" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "hrx" = (
 /turf/open/floor/plasteel/warning/corner{
 	dir = 1
@@ -4154,6 +4232,20 @@
 /area/shuttle/ftl/bridge/meeting_room{
 	name = "Teleporter"
 	})
+"hzo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/darkwarning{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
 "hzw" = (
 /turf/closed/wall/shuttle{
 	icon_state = "swall1"
@@ -4246,6 +4338,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/research/lab)
+"hFL" = (
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "hGl" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -4319,17 +4414,6 @@
 	},
 /turf/open/floor/engine/air,
 /area/shuttle/ftl/atmos)
-"hQD" = (
-/obj/machinery/mass_driver{
-	dir = 1;
-	id = "exec_driver"
-	},
-/obj/structure/window/reinforced{
-	dir = 2
-	},
-/obj/item/device/gps,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "hRo" = (
 /obj/structure/shuttle/engine/propulsion{
 	icon_state = "propulsion";
@@ -4363,19 +4447,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"hTG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
 "hUM" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/machine/mac_barrel{
@@ -4394,14 +4465,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
-"hXD" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/machinery/recharger,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
 "hYr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4432,20 +4495,35 @@
 	mouse_over_pointer = 0;
 	name = "Battle Bridge"
 	})
-"iaW" = (
-/obj/machinery/door_timer{
-	id = "Cell 3";
-	pixel_x = 0;
-	pixel_y = -32
+"hZE" = (
+/obj/item/clothing/head/hardhat/cakehat,
+/obj/structure/closet/crate,
+/obj/item/clothing/shoes/sandal,
+/obj/item/weapon/card/id{
+	desc = "A plastic card with a sticker.";
+	icon_state = "gold";
+	name = "captain's spare ID";
+	pixel_x = -4;
+	pixel_y = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/weapon/card/id{
+	desc = "A plastic card with a sticker.";
+	icon_state = "emag";
+	name = "cryptographic sequencer";
+	pixel_x = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 4;
+	name = "4maintenance loot spawner"
 	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
+/obj/item/weapon/storage/pill_bottle/dice,
+/obj/item/weapon/paint/blue,
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "ibr" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -4513,6 +4591,17 @@
 "igH" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/assembly/chargebay)
+"iit" = (
+/obj/structure/rack,
+/obj/item/weapon/gun/energy/ionrifle,
+/obj/item/clothing/suit/armor/laserproof,
+/obj/structure/window/reinforced{
+	dir = 2
+	},
+/turf/open/floor/plasteel/darkwarning{
+	dir = 9
+	},
+/area/shuttle/ftl/security/armory)
 "iiQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -4778,20 +4867,6 @@
 /obj/item/weapon/reagent_containers/food/snacks/cakeslice/plain,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"iGW" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
 "iHA" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -4879,6 +4954,18 @@
 	dir = 1
 	},
 /area/shuttle/ftl/engine/engineering)
+"iNF" = (
+/obj/structure/closet/secure_closet/armory2,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/darkwarning{
+	dir = 4
+	},
+/area/shuttle/ftl/security/armory)
 "iOX" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -4933,39 +5020,6 @@
 	dir = 2
 	},
 /area/shuttle/ftl/subshuttle/pod_2)
-"iRQ" = (
-/obj/item/clothing/head/hardhat/cakehat,
-/obj/structure/closet/crate,
-/obj/item/clothing/shoes/sandal,
-/obj/item/weapon/card/id{
-	desc = "A plastic card with a sticker.";
-	icon_state = "gold";
-	name = "captain's spare ID";
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/weapon/card/id{
-	desc = "A plastic card with a sticker.";
-	icon_state = "emag";
-	name = "cryptographic sequencer";
-	pixel_x = 2
-	},
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 4;
-	name = "4maintenance loot spawner"
-	},
-/obj/item/weapon/storage/pill_bottle/dice,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/item/weapon/paint/blue,
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
 "iSN" = (
 /obj/machinery/power/apc/priority{
 	auto_name = 1;
@@ -5140,22 +5194,6 @@
 	},
 /turf/open/floor/plasteel/darkwarning,
 /area/shuttle/ftl/munitions)
-"jgR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/effect/landmark/start{
-	name = "Security Officer";
-	shuttle_abstract_movable = 1
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 "jjj" = (
 /obj/machinery/power/apc{
 	auto_name = 1;
@@ -5183,23 +5221,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/brig)
-"jnp" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
 "jnP" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -5328,19 +5349,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
-"jzj" = (
-/obj/machinery/door_timer{
-	id = "Cell 2";
-	pixel_y = -32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "jAP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 1
@@ -5410,14 +5418,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"jKo" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "8;7"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "jLo" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -5458,18 +5458,6 @@
 	dir = 2
 	},
 /area/shuttle/ftl/munitions)
-"jNR" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "jOj" = (
 /obj/machinery/door/airlock/shuttle,
 /obj/structure/cable{
@@ -5716,28 +5704,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/toilet)
-"kaL" = (
-/obj/structure/closet/secure_closet/armory2,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/ftl/security/armory)
-"kbC" = (
-/obj/machinery/door_timer{
-	id = "Cell 1";
-	pixel_y = -32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "kbF" = (
 /turf/open/space,
 /turf/closed/wall/shuttle{
@@ -5877,6 +5843,23 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
+"knO" = (
+/obj/structure/rack,
+/obj/item/weapon/gun/projectile/shotgun/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/gun/projectile/shotgun/riot,
+/obj/item/weapon/gun/projectile/shotgun/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/machinery/ai_status_display{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "kok" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -6030,27 +6013,6 @@
 /obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos/equipment)
-"kDN" = (
-/obj/machinery/door/poddoor{
-	id = "armory_blast";
-	name = "Security Equipment"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 9
-	},
-/area/shuttle/ftl/security/main)
 "kFZ" = (
 /obj/structure/closet/l3closet,
 /obj/machinery/firealarm{
@@ -6222,6 +6184,25 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
+"kSn" = (
+/obj/machinery/computer/secure_data,
+/obj/item/device/radio/intercom{
+	override = 0;
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/machinery/light_switch{
+	pixel_x = -8;
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "kSr" = (
 /obj/machinery/door/window/brigdoor{
 	id = "Cell 1";
@@ -6322,16 +6303,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"kZg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "kZt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -6344,18 +6315,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"kZM" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
 "kZN" = (
 /obj/structure/rack{
 	dir = 8;
@@ -6419,32 +6378,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions/cannon)
-"lhZ" = (
-/obj/machinery/door/window/brigdoor{
-	dir = 4;
-	icon_state = "rightsecure";
-	id = "Holding_pen";
-	name = "Holding Pen";
-	req_access_txt = "2";
-	tag = "icon-rightsecure (NORTH)"
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig";
-	dir = 2;
-	network = list("SS13","Brig")
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -8;
-	pixel_y = 22
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 "llm" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
@@ -6483,6 +6416,20 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/cargo/mining)
+"ltp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "lvd" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/assembly/robotics)
@@ -6590,26 +6537,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"lED" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/effect/landmark/start{
-	name = "Security Officer";
-	shuttle_abstract_movable = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "lFd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
@@ -6632,20 +6559,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"lGF" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"lJv" = (
+/obj/structure/table/wood,
+/obj/item/device/flashlight/lamp,
+/obj/machinery/button/door{
+	id = "hos_shutters";
+	name = "Security Shutters Control";
+	override = 0;
+	pixel_x = 24;
+	pixel_y = 28;
+	req_access_txt = "0";
+	specialfunctions = 1
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/hos)
 "lJL" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable{
@@ -6702,6 +6629,23 @@
 	mouse_over_pointer = 0;
 	name = "Battle Bridge"
 	})
+"lOj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/structure/closet/wardrobe/red,
+/obj/machinery/newscaster/security_unit{
+	pixel_x = -28;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "lOy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -6748,6 +6692,28 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/crew_quarters/heads)
+"lQB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "lQD" = (
 /obj/machinery/door/poddoor{
 	id = "weapon_k_1";
@@ -6793,6 +6759,13 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engineering)
+"lVO" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "lVS" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -6827,44 +6800,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/chiefs_office)
-"lYb" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
-"lYp" = (
-/obj/item/weapon/storage/toolbox/emergency{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/light_switch{
-	pixel_x = 8;
-	pixel_y = 22
-	},
-/obj/structure/table,
-/obj/item/weapon/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/weapon/storage/firstaid/regular,
-/obj/item/weapon/storage/box/bodybags,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/weapon/hand_labeler{
-	pixel_x = 5
-	},
-/obj/item/weapon/reagent_containers/spray/cleaner,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "lYt" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip{
@@ -6944,6 +6879,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
+"meV" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "warden_shutters_ext";
+	layer = 2
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "brig_enter_shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/masteratarms)
 "mgw" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/computer/atmos_alert{
@@ -6986,13 +6949,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/shuttle/ftl/atmos)
-"mjL" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 25
-	},
-/obj/structure/closet/secure_closet/masteratarms,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/masteratarms)
 "mjX" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -7046,18 +7002,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/break_room)
-"mnd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 2
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
 "mnA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -7168,15 +7112,6 @@
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
-"msG" = (
-/obj/structure/table/wood,
-/obj/item/weapon/storage/box/evidence,
-/obj/item/device/taperecorder,
-/obj/item/weapon/hand_labeler{
-	pixel_x = 5
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
 "msW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 4
@@ -7236,22 +7171,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"mux" = (
-/obj/machinery/camera{
-	c_tag = "Security Office West";
-	dir = 8;
-	network = list("SS13","Brig")
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 25
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "muV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 1
@@ -7292,17 +7211,39 @@
 "mxR" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/storage)
+"mxX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = "90Curve"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/mob/living/simple_animal/bot/secbot{
+	arrest_type = 1;
+	health = 45;
+	icon_state = "secbot1";
+	idcheck = 1;
+	name = "Sergeant-at-Armsky";
+	on = 1;
+	weaponscheck = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "myf" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Starboard Airlock"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/central)
-"myl" = (
-/obj/structure/table,
-/obj/item/weapon/reagent_containers/food/snacks/grilledcheese,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
 "myD" = (
@@ -7585,22 +7526,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/locker)
-"mXf" = (
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/sleep)
-"mYA" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Detective";
-	shuttle_abstract_movable = 1
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
 "mZS" = (
 /obj/machinery/light{
 	dir = 8
@@ -7630,6 +7555,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos/equipment)
+"naz" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/shuttle/ftl/engine/engineering)
 "naO" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Locker Room Maintenance";
@@ -7669,6 +7600,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
+"nec" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "nfC" = (
 /obj/machinery/door/poddoor{
 	id = "armory_blast";
@@ -7716,6 +7662,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
+"nhM" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 0;
+	pixel_y = 30
+	},
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/glass/bottle/epinephrine,
+/obj/item/weapon/reagent_containers/glass/bottle/charcoal,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/weapon/restraints/handcuffs,
+/obj/item/weapon/reagent_containers/syringe,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "nhV" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -7727,22 +7687,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"njh" = (
-/obj/item/device/radio/intercom{
-	pixel_x = -32
-	},
-/obj/structure/rack,
-/obj/item/weapon/gun/projectile/shotgun/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/gun/projectile/shotgun/riot,
-/obj/item/weapon/gun/projectile/shotgun/riot{
-	pixel_x = 3;
-	pixel_y = -3
+"niY" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
+/area/shuttle/ftl/security/brig)
 "nkA" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -7779,6 +7733,19 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
+"nlR" = (
+/obj/structure/table,
+/obj/item/weapon/paper_bin,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/recharger,
+/obj/item/weapon/restraints/handcuffs,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/masteratarms)
 "nmy" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -7792,14 +7759,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/engine/engineering)
-"nnz" = (
-/obj/machinery/door/airlock/security{
-	mouse_over_pointer = 0;
-	name = "Security Equipment";
-	req_access_txt = "1"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/masteratarms)
 "noU" = (
 /obj/machinery/camera{
 	c_tag = "Cryogenics";
@@ -8000,6 +7959,22 @@
 /obj/item/weapon/pen/blue,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/crew_quarters/heads)
+"nRp" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "nSk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -8072,18 +8047,6 @@
 /area/shuttle/ftl/bridge/meeting_room{
 	name = "Teleporter"
 	})
-"ock" = (
-/obj/machinery/firealarm{
-	pixel_y = -26
-	},
-/obj/machinery/light_switch{
-	override = 0;
-	pixel_x = 16;
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/hos)
 "ocC" = (
 /obj/machinery/computer/munitions_console,
 /obj/machinery/newscaster{
@@ -8107,6 +8070,14 @@
 /obj/machinery/computer/pmanagement,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
+"odk" = (
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 8
+	},
+/area/shuttle/ftl/crew_quarters/sleep)
 "ody" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/starboard)
@@ -8242,6 +8213,18 @@
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
+"oqX" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "osZ" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -8717,6 +8700,16 @@
 	icon_state = "bot"
 	},
 /area/shuttle/ftl/engine/engineering)
+"pcP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/effect/landmark/start{
+	name = "Security Officer";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "pcY" = (
 /obj/machinery/vending/assist,
 /turf/open/floor/plasteel,
@@ -8793,18 +8786,6 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"pgZ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 "pjZ" = (
 /obj/machinery/suit_storage_unit/mining/eva,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -8848,6 +8829,21 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/atmos/equipment)
+"pmZ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "FTL Drive";
+	req_access_txt = "0";
+	req_one_access_txt = "34;15"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/engine/engineering)
 "pnC" = (
 /obj/item/chair{
 	dir = 4
@@ -8858,18 +8854,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
-"pon" = (
-/obj/item/toy/foamblade,
-/obj/item/device/healthanalyzer,
-/obj/item/device/multitool,
-/obj/structure/closet/crate/medical,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/device/flashlight,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
 "ppN" = (
 /obj/machinery/door/airlock/research{
 	name = "Science Junction";
@@ -8949,23 +8933,6 @@
 /obj/machinery/computer/secure_data,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/security/detectives_office)
-"pvL" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/filingcabinet/chestdrawer/wheeled,
-/obj/machinery/camera{
-	c_tag = "Warden's Office";
-	dir = 8;
-	network = list("SS13","Brig")
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 22
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/masteratarms)
 "pvW" = (
 /obj/structure/closet/wardrobe/chemistry_white{
 	pixel_x = -3
@@ -8990,6 +8957,18 @@
 	},
 /turf/closed/wall,
 /area/shuttle/ftl/engine/tool_storage)
+"pwH" = (
+/obj/structure/table,
+/obj/item/device/radio,
+/obj/item/device/sensor_device,
+/obj/item/weapon/hand_labeler{
+	pixel_x = 5
+	},
+/obj/item/weapon/folder/red,
+/obj/item/device/assembly/signaler,
+/obj/item/weapon/pen,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/masteratarms)
 "pxB" = (
 /obj/machinery/computer/communications,
 /turf/open/floor/plasteel/black,
@@ -9022,20 +9001,6 @@
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"pzA" = (
-/obj/item/device/radio/intercom{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/structure/table,
-/obj/item/weapon/storage/box/firingpins,
-/turf/open/floor/plasteel/darkwarning{
-	dir = 6
-	},
-/area/shuttle/ftl/security/armory)
-"pzB" = (
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 "pzE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -9063,6 +9028,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/crew_quarters/captain)
+"pAr" = (
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/obj/machinery/light_switch{
+	override = 0;
+	pixel_x = 16;
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/hos)
 "pBo" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -9076,13 +9053,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"pCY" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/poster{
-	pixel_x = -32
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
 "pDt" = (
 /obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel/black,
@@ -9104,19 +9074,6 @@
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/telecomms/server)
-"pFR" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/shutters{
-	id = "warden_shutters_ext";
-	name = "shutters"
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/security/masteratarms)
 "pGh" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
@@ -9133,38 +9090,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/hor)
-"pHL" = (
-/obj/machinery/computer/secure_data,
-/obj/machinery/button/door{
-	id = "warden_shutters";
-	name = "Desk Shutters";
-	pixel_x = -26;
-	pixel_y = 6;
-	req_access_txt = "0"
-	},
-/obj/machinery/button/door{
-	id = "brig_enter_shutters";
-	name = "Brig Lockdown";
-	pixel_x = -26;
-	pixel_y = -6;
-	req_access_txt = "0"
-	},
-/obj/machinery/button/door{
-	id = "warden_shutters_ext";
-	name = "Space Shutters";
-	pixel_x = -38;
-	pixel_y = 6;
-	req_access_txt = "0"
-	},
-/obj/machinery/button/door{
-	id = "armory_blast";
-	name = "Armory Blast Doors";
-	pixel_x = -38;
-	pixel_y = -6;
-	req_access_txt = "0"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/masteratarms)
 "pHP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9208,22 +9133,18 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/chemistry)
+"pJa" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 8
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/armory)
 "pJm" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/clothing/suit/hooded/wintercoat,
 /obj/item/clothing/shoes/winterboots,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/locker)
-"pKy" = (
-/obj/machinery/computer/security,
-/obj/machinery/computer/security/telescreen{
-	name = "Brig Monitoring";
-	network = list("Brig");
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/masteratarms)
 "pLc" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -9348,18 +9269,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
-"pUB" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/turf/open/floor/plasteel/darkwarning{
-	dir = 1
-	},
-/area/shuttle/ftl/security/armory)
 "pUT" = (
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
@@ -9436,6 +9345,18 @@
 	},
 /turf/open/floor/plasteel/darkbrown,
 /area/shuttle/ftl/cargo/office)
+"qaJ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "permabrig_shutters";
+	layer = 2
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "brig_enter_shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/masteratarms)
 "qbE" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -9515,6 +9436,25 @@
 /obj/item/clothing/glasses/meson/engine/tray,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos/equipment)
+"qhi" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/mob/living/simple_animal/bot/ed209,
+/turf/open/floor/plasteel/darkwarning{
+	dir = 4
+	},
+/area/shuttle/ftl/security/armory)
 "qjs" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -9568,6 +9508,37 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
+"qll" = (
+/obj/machinery/button/flasher{
+	id = "Holding_Pen";
+	pixel_x = 26;
+	pixel_y = 6;
+	req_access_txt = "1"
+	},
+/obj/structure/filingcabinet/chestdrawer/wheeled,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/machinery/button/door{
+	id = "permabrig_shutters";
+	name = "Permabrig Shutters Control";
+	override = 0;
+	pixel_x = 26;
+	pixel_y = -6;
+	req_access_txt = "0";
+	specialfunctions = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/masteratarms)
 "qmo" = (
 /obj/item/weapon/dice/d6,
 /obj/structure/table,
@@ -9629,6 +9600,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"qox" = (
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/food/snacks/cakeslice/plain,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
 "qpk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -9661,16 +9637,6 @@
 /obj/machinery/vending/snack,
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"qrN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 8;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
 "qtj" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Server Room";
@@ -9828,6 +9794,44 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
+"qDB" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
+"qEi" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/landmark/start{
+	name = "Security Officer";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "qEj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
@@ -9866,10 +9870,6 @@
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"qFE" = (
-/obj/structure/closet/secure_closet/armory3,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
 "qFJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -10023,12 +10023,6 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
-"qVy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 2
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/security/armory)
 "qXr" = (
 /obj/structure/chair{
 	dir = 4
@@ -10128,6 +10122,20 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/office)
+"rdS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/security{
+	name = "Detective's Office";
+	req_access_txt = "41"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/detectives_office)
 "rea" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -10147,6 +10155,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/chargebay)
+"rel" = (
+/obj/structure/closet/secure_closet{
+	name = "contraband locker";
+	req_access_txt = "3"
+	},
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/obj/effect/spawner/lootdrop/armory_contraband{
+	loot = list(/obj/item/weapon/gun/projectile/automatic/pistol = 5, /obj/item/weapon/gun/projectile/shotgun/automatic/combat = 5, /obj/item/weapon/gun/projectile/revolver/mateba, /obj/item/weapon/gun/projectile/automatic/pistol/deagle, /obj/item/weapon/storage/box/syndie_kit/throwing_weapons = 3)
+	},
+/obj/structure/window/reinforced{
+	dir = 2
+	},
+/turf/open/floor/plasteel/darkwarning{
+	dir = 5
+	},
+/area/shuttle/ftl/security/armory)
+"rfT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/masteratarms)
 "rfU" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -10279,6 +10312,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"rnK" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 2
+	},
+/obj/machinery/door_timer{
+	id = "Cell 3";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/machinery/light{
+	dir = 2
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "roH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
@@ -10303,15 +10350,6 @@
 /obj/item/clothing/glasses/meson,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
-"rqa" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 2
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 "rqY" = (
 /obj/machinery/vending/cart,
 /turf/open/floor/plasteel/black,
@@ -10362,20 +10400,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"rzw" = (
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "rzF" = (
 /obj/effect/landmark/start{
 	name = "Medical Doctor";
@@ -10395,6 +10419,13 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
+"rAK" = (
+/obj/machinery/door/poddoor{
+	id = "exec_blast"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/masteratarms)
 "rBY" = (
 /obj/machinery/power/apc{
 	auto_name = 1;
@@ -10426,26 +10457,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/entry)
-"rDz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+"rDS" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "rDZ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -10519,6 +10545,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"rHg" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "rHs" = (
 /obj/machinery/light{
 	dir = 4
@@ -10630,10 +10674,6 @@
 /obj/machinery/cryopod/right,
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/crew_quarters/sleep)
-"rNZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/security/hos)
 "rOF" = (
 /obj/machinery/light{
 	dir = 8
@@ -10734,6 +10774,19 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"rUJ" = (
+/obj/structure/table,
+/obj/item/weapon/storage/box/chemimp{
+	pixel_x = 6
+	},
+/obj/item/weapon/storage/box/trackimp{
+	pixel_x = -3
+	},
+/obj/item/weapon/storage/lockbox/loyalty,
+/turf/open/floor/plasteel/darkwarning{
+	dir = 2
+	},
+/area/shuttle/ftl/security/armory)
 "rVR" = (
 /turf/open/floor/plasteel/warning/corner{
 	dir = 4
@@ -10787,6 +10840,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/hor)
+"sbj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Security Officer";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "sbx" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 1
@@ -10893,6 +10956,24 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hydroponics)
+"sjl" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance";
+	req_access_txt = "0";
+	req_one_access_txt = "0"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "sjz" = (
 /obj/machinery/light{
 	dir = 8
@@ -10935,6 +11016,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"skq" = (
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/food/snacks/cakeslice/plain,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "slM" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4;
@@ -11073,17 +11159,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/kitchen)
-"sth" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "stq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 1
@@ -11144,6 +11219,13 @@
 	dir = 4
 	},
 /area/shuttle/ftl/space)
+"swI" = (
+/obj/structure/table,
+/obj/item/weapon/storage/box/firingpins,
+/turf/open/floor/plasteel/darkwarning{
+	dir = 6
+	},
+/area/shuttle/ftl/security/armory)
 "sxx" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
@@ -11416,21 +11498,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"sQX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "sRb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -11535,6 +11602,23 @@
 /obj/item/clothing/shoes/winterboots,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/locker)
+"tbr" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "tdj" = (
 /obj/machinery/button/door{
 	dir = 2;
@@ -11595,6 +11679,23 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/engine/engineering)
+"tfT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"tiu" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/obj/item/device/radio/intercom{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "tiA" = (
 /obj/machinery/airalarm{
 	pixel_y = 22
@@ -11638,15 +11739,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
-"tlt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "tmh" = (
 /obj/machinery/door/window/eastright{
 	base_state = "left";
@@ -11725,19 +11817,6 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/atmos/equipment)
-"tsB" = (
-/obj/structure/bed,
-/obj/item/weapon/bedsheet,
-/obj/item/device/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
-	name = "Prison Intercom (General)";
-	pixel_x = 0;
-	pixel_y = -28;
-	prison_radio = 1
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 "txu" = (
 /obj/effect/landmark/start{
 	name = "Executive Officer";
@@ -11802,6 +11881,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
+"tzi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "tAz" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
@@ -11813,22 +11898,6 @@
 /area/shuttle/ftl/crew_quarters/theatre{
 	name = "Library"
 	})
-"tBr" = (
-/obj/machinery/button/door{
-	id = "execute_shutters";
-	name = "Security Shutters Control";
-	override = 0;
-	pixel_x = -24;
-	pixel_y = 28;
-	req_access_txt = "0";
-	specialfunctions = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/computer/secure_data,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 "tBC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 2
@@ -11982,20 +12051,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/chargebay)
-"tJX" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "tLK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -12027,6 +12082,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
+"tOd" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "tOD" = (
 /obj/machinery/ai_status_display{
 	pixel_x = 32;
@@ -12142,6 +12210,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
+"tVS" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 2
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "tWh" = (
 /obj/machinery/door/airlock/glass{
 	name = "Port Airlock"
@@ -12170,6 +12250,28 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/storage)
+"tZA" = (
+/obj/structure/rack,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/storage/toolbox/emergency{
+	pixel_x = -2;
+	pixel_y = -3
+	},
+/obj/structure/sign/poster{
+	pixel_y = 32
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25;
+	pixel_y = 32
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/masteratarms)
 "tZI" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -12222,20 +12324,6 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engineering)
-"ucO" = (
-/obj/item/weapon/storage/book/bible,
-/obj/structure/table,
-/obj/item/weapon/storage/box/hug/medical{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/weapon/storage/box/prisoner,
-/obj/item/weapon/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 "udt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -12243,18 +12331,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"uel" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 1
+"udU" = (
+/obj/structure/table/wood,
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 22
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+/obj/item/device/radio,
+/obj/item/weapon/storage/fancy/cigarettes/cigpack_carp,
+/obj/item/clothing/glasses/sunglasses,
+/obj/machinery/button/door{
+	id = "detective_shutters";
+	name = "Space Shutters";
+	pixel_x = -6;
+	pixel_y = 26;
+	req_access_txt = "0"
 	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/armory)
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
 "ueM" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12329,12 +12424,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
-"ujl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 2
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/hos)
 "ukH" = (
 /obj/machinery/ai_status_display{
 	pixel_x = -32;
@@ -12343,21 +12432,6 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/exit)
-"uld" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
 "uny" = (
 /obj/machinery/ai_status_display{
 	pixel_x = 0;
@@ -12534,15 +12608,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engineering)
-"uCB" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/shutters{
-	id = "execute_shutters";
-	name = "shutters"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/security/brig)
 "uCF" = (
 /obj/item/device/multitool{
 	pixel_x = 4
@@ -12679,6 +12744,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos/equipment)
+"uRG" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/closet/l3closet/security,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "uRQ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -12807,30 +12879,6 @@
 /area/shuttle/ftl/crew_quarters/theatre{
 	name = "Library"
 	})
-"vkF" = (
-/obj/machinery/camera/motion{
-	c_tag = "Armory High Security";
-	dir = 4;
-	network = list("SS13","Brig")
-	},
-/obj/machinery/ai_status_display{
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/obj/structure/rack,
-/obj/item/ammo_box/magazine/sniper_rounds/haemorrhage,
-/obj/item/ammo_box/magazine/sniper_rounds/penetrator,
-/obj/item/ammo_box/magazine/sniper_rounds/soporific,
-/obj/item/weapon/gun/projectile/automatic/sniper_rifle,
-/obj/machinery/door/window/southleft{
-	dir = 4;
-	name = "Armory";
-	req_access_txt = "3"
-	},
-/turf/open/floor/plasteel/darkwarning{
-	dir = 8
-	},
-/area/shuttle/ftl/security/armory)
 "vkQ" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel,
@@ -12848,22 +12896,6 @@
 /obj/machinery/vending/sovietsoda,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"vot" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/effect/landmark/start{
-	name = "Warden"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/masteratarms)
 "vpd" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -12879,28 +12911,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"vqu" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/chair{
-	dir = 8
-	},
-/obj/item/device/electropack,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
-"vsg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/darkwarning{
-	dir = 1
-	},
-/area/shuttle/ftl/security/armory)
 "vsr" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -12945,24 +12955,6 @@
 /area/shuttle/ftl/crew_quarters/theatre{
 	name = "Library"
 	})
-"vus" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	mouse_over_pointer = 0;
-	name = "Execution Chamber";
-	req_access_txt = "1"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "vwf" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -13152,6 +13144,10 @@
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
+"vIt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/detectives_office)
 "vIL" = (
 /obj/structure/table/wood,
 /turf/open/floor/plating,
@@ -13209,6 +13205,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
+"vNW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/masteratarms)
 "vOh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13367,10 +13369,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"vWI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/security/armory)
 "vXg" = (
 /obj/structure/grille,
 /obj/structure/window/shuttle,
@@ -13411,6 +13409,28 @@
 /obj/machinery/computer/crew,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
+"wgC" = (
+/obj/structure/closet/secure_closet/armory3,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
+"wiw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 2
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "wjT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -13494,6 +13514,16 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
+"wur" = (
+/obj/machinery/door_timer{
+	id = "Cell 1";
+	pixel_y = -32
+	},
+/obj/machinery/light{
+	dir = 2
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "wxL" = (
 /obj/structure/closet/crate/medical,
 /obj/item/weapon/tank/internals/emergency_oxygen,
@@ -13511,43 +13541,22 @@
 /obj/item/weapon/storage/firstaid/regular,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
-"wxU" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/vest{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/armor/vest{
-	pixel_y = 0
-	},
-/obj/item/clothing/suit/armor/vest{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet{
-	layer = 3.00001;
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet{
-	layer = 3.00001
-	},
-/obj/item/clothing/head/helmet{
-	layer = 3.00001;
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/ftl/security/main)
 "wAj" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/darkbrown,
 /area/shuttle/ftl/cargo/office)
+"wBk" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/obj/item/device/radio{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "wCc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13643,15 +13652,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"wLr" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
 "wLG" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
@@ -13788,6 +13788,15 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
+"wVJ" = (
+/obj/structure/table,
+/obj/machinery/camera{
+	c_tag = "Armory Low Security";
+	dir = 9;
+	network = list("SS13","Brig")
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "wWn" = (
 /obj/machinery/hologram/holopad,
 /turf/open/floor/plasteel,
@@ -13841,6 +13850,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
+"xbC" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "xcz" = (
 /obj/item/weapon/reagent_containers/food/snacks/grilledcheese{
 	pixel_y = 6
@@ -13919,6 +13932,9 @@
 /obj/machinery/computer/card/minor/ce,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/chiefs_office)
+"xmb" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/masteratarms)
 "xmD" = (
 /obj/structure/closet/crate,
 /obj/item/weapon/storage/box/lights/mixed,
@@ -14028,6 +14044,21 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
+"xuW" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Warden"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/masteratarms)
 "xvx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -14262,6 +14293,32 @@
 	dir = 8
 	},
 /area/shuttle/ftl/munitions)
+"xQG" = (
+/obj/structure/table,
+/obj/item/toy/sword{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/weapon/grenade/barrier{
+	pixel_x = -4
+	},
+/obj/item/weapon/grenade/barrier,
+/obj/item/weapon/grenade/barrier{
+	pixel_x = 4
+	},
+/obj/item/device/assembly/signaler,
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "xQO" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/locker)
@@ -14317,6 +14374,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
+"xWi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "xWp" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -14374,6 +14438,15 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/secondary/construction)
+"xZP" = (
+/obj/machinery/computer/med_data/laptop,
+/obj/structure/table,
+/obj/machinery/ai_status_display{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "ycj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -14393,27 +14466,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"yfw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+"yia" = (
+/obj/structure/sign/poster{
+	pixel_x = -32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
+"yic" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Clown"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"yiQ" = (
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
-/obj/structure/sign/poster{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/darkwarning{
-	dir = 5
-	},
-/area/shuttle/ftl/security/armory)
 "yjy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 2
@@ -14436,6 +14510,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
+"yoP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
 "ypj" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -14539,6 +14623,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/entry)
+"ywN" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Port Airlock"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "ywS" = (
 /obj/structure/chair{
 	dir = 4
@@ -14614,6 +14715,17 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/break_room)
+"yDx" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/sink{
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/chair,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "yEw" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Research Director";
@@ -14818,6 +14930,11 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/meeting_room)
+"yYR" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/hos)
 "yZi" = (
 /obj/structure/table,
 /obj/item/weapon/kitchen/rollingpin,
@@ -14877,20 +14994,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
-"zfg" = (
-/obj/item/device/radio/intercom{
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/obj/machinery/vending/snack,
-/obj/machinery/light{
-	dir = 2
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "zht" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -14924,6 +15027,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/hor)
+"zjD" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "zlm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -14986,6 +15102,26 @@
 "zvq" = (
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
+"zwk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/masteratarms)
 "zxX" = (
 /obj/structure/closet/firecloset/full,
 /obj/structure/cable{
@@ -15083,6 +15219,50 @@
 	},
 /turf/open/floor/plasteel/warning/side,
 /area/shuttle/ftl/research/xenobiology)
+"zJH" = (
+/obj/structure/table/wood,
+/obj/item/weapon/storage/box/evidence,
+/obj/item/device/taperecorder,
+/obj/item/weapon/hand_labeler{
+	pixel_x = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
+"zJU" = (
+/obj/structure/closet/secure_closet/detective,
+/obj/item/device/camera/detective,
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
+"zLp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 2
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/masteratarms)
 "zLB" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Locker Room Maintenance";
@@ -15176,15 +15356,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"zPR" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/security/main)
 "zRB" = (
 /obj/machinery/button/door{
 	id = "rnd_shutters";
@@ -15216,6 +15387,22 @@
 	mouse_over_pointer = 0;
 	name = "Battle Bridge"
 	})
+"zUz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 2
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
 "zUH" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -15348,18 +15535,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
-"Aaf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/item/device/radio{
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
 "Aah" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -15379,32 +15554,38 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"Aem" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"AcO" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_command{
+	name = "Head of Security";
+	req_access_txt = "31"
 	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/hos)
+"Ahx" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
 /obj/structure/cable{
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "Aje" = (
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/ftl/subshuttle/pod_3)
@@ -15478,6 +15659,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/toilet)
+"Aqv" = (
+/obj/item/weapon/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 0
+	},
+/obj/item/weapon/storage/book/bible,
+/obj/structure/table,
+/obj/item/weapon/storage/box/hug/medical{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/box/prisoner,
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/masteratarms)
 "AqQ" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -15781,6 +15976,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/exit)
+"AOo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Port Airlock"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "AOs" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -15821,12 +16026,41 @@
 /obj/structure/closet/secure_closet/captains,
 /turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/captain)
+"APg" = (
+/obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing{
+	pixel_x = 8
+	},
+/obj/structure/table/wood,
+/obj/item/device/pda{
+	desc = "The prized possession of any greedy assistant. Too bad the slick surface has rubbed off.";
+	icon_state = "pda-clown";
+	name = "dusty clown pda"
+	},
+/obj/item/weapon/dice/d20{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/weapon/dice{
+	pixel_x = -8;
+	pixel_y = -4
+	},
+/obj/item/device/paicard,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "AQa" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
+"ASd" = (
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/machinery/vending/snack,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "ASx" = (
 /obj/machinery/door/airlock/command{
 	name = "Bridge";
@@ -15880,10 +16114,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/exit)
-"ATH" = (
-/obj/structure/table,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/central)
 "AUt" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -16117,18 +16347,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
-"BlS" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -22;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/masteratarms)
 "BmT" = (
 /obj/structure/cryofeed,
 /obj/machinery/status_display{
@@ -16266,6 +16484,23 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
+"BuX" = (
+/obj/structure/sign/poster{
+	pixel_y = -32
+	},
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"BvJ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hos_shutters";
+	layer = 2
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/hos)
 "Bww" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 2
@@ -16408,6 +16643,22 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/cargo/office)
+"BPk" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "warden_shutters_ext";
+	layer = 2
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "brig_enter_shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/masteratarms)
 "BPx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -16434,6 +16685,25 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/bar)
+"BRI" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "BSo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
@@ -16444,6 +16714,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/toilet)
+"BSC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "brig_enter_shutters"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance";
+	req_access_txt = "0";
+	req_one_access_txt = "38;41"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/brig)
 "BTp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -16464,6 +16748,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
+"BUF" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/flasher{
+	id = "Holding_Pen";
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/masteratarms)
+"BWe" = (
+/obj/machinery/computer/secure_data,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/masteratarms)
 "BXZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -16481,6 +16779,22 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
+"BZU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "CbN" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -16541,10 +16855,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"CgR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/security/brig)
 "ChJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -16579,27 +16889,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"ChQ" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Detective";
+	shuttle_abstract_movable = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
 "CiB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"CiY" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
 "Cjn" = (
 /obj/structure/closet/wardrobe/cargotech,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -16683,13 +16996,15 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"CqH" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 1
+"Crt" = (
+/obj/structure/bed,
+/obj/machinery/camera{
+	c_tag = "Permabrig";
+	dir = 8;
+	network = list("SS13","Brig")
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/masteratarms)
 "Ctf" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/cafeteria,
@@ -16783,22 +17098,6 @@
 "CyX" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/maintenance/engineering)
-"CAn" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/engineering{
-	name = "FTL Drive";
-	req_access_txt = "0";
-	req_one_access_txt = "34;15"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/engine/engineering)
 "CAN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -16843,24 +17142,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engineering)
-"CEd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 2
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/hos)
 "CFj" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -17080,6 +17361,30 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
+"CXI" = (
+/obj/item/weapon/book/manual/detective,
+/obj/structure/rack,
+/obj/item/weapon/storage/secure/briefcase,
+/obj/item/weapon/storage/briefcase{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/weapon/paper/courtroom{
+	name = "paper- 'A Crash Course in Legal SOP"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/obj/machinery/camera{
+	c_tag = "Security Office East";
+	dir = 4;
+	network = list("SS13","Brig")
+	},
+/obj/structure/sign/poster{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "CYE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -17233,30 +17538,6 @@
 /area/shuttle/ftl/crew_quarters/theatre{
 	name = "Library"
 	})
-"Dnv" = (
-/obj/structure/table/wood,
-/obj/item/device/flashlight/lamp,
-/obj/machinery/button/door{
-	id = "hos_shutters";
-	name = "Security Shutters Control";
-	override = 0;
-	pixel_x = 24;
-	pixel_y = 28;
-	req_access_txt = "0";
-	specialfunctions = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/hos)
-"DnX" = (
-/obj/structure/table,
-/obj/item/weapon/storage/book/bible,
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 "DnZ" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -17279,17 +17560,9 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"Dtf" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/engine/engineering)
+"Dtz" = (
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/masteratarms)
 "Duu" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -17342,6 +17615,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/exit)
+"Dyd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "DyA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 1
@@ -17363,14 +17648,6 @@
 	},
 /turf/open/floor/engine/hydrogen,
 /area/shuttle/ftl/atmos)
-"Dzl" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/security/wooden_tv,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
 "DzW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 1
@@ -17439,28 +17716,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
-"DHP" = (
-/obj/machinery/door/airlock/security{
-	name = "Warden's Office";
-	req_access_txt = "3"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/masteratarms)
-"DJV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+"DIl" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/plasteel/white,
+/area/shuttle/ftl/medical/medbay)
+"DJN" = (
+/obj/structure/chair/office/dark{
 	dir = 2
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/masteratarms)
@@ -17592,6 +17867,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
+"DPq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 2
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/hos)
 "DPz" = (
 /obj/machinery/vending/clothing,
 /obj/machinery/firealarm{
@@ -17612,24 +17893,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
-"DQJ" = (
-/obj/structure/table,
-/obj/item/weapon/storage/box/chemimp{
-	pixel_x = 6
-	},
-/obj/item/weapon/storage/box/trackimp{
-	pixel_x = -3
-	},
-/obj/item/weapon/storage/lockbox/loyalty,
-/obj/machinery/light_switch{
-	override = 0;
-	pixel_x = 22;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/darkwarning{
-	dir = 4
-	},
-/area/shuttle/ftl/security/armory)
 "DQS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -17670,6 +17933,35 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
+"DUY" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/obj/item/clothing/mask/muzzle,
+/obj/item/device/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
+	name = "Prison Intercom (General)";
+	pixel_x = 0;
+	pixel_y = -28;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/masteratarms)
+"DVX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "DWa" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -17691,6 +17983,17 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
+"DYs" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "DYv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 1
@@ -17956,6 +18259,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
+"Exb" = (
+/obj/structure/window/reinforced{
+	dir = 2
+	},
+/obj/machinery/mass_driver{
+	dir = 1;
+	id = "exec_driver"
+	},
+/obj/item/device/gps,
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/masteratarms)
+"Exx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "EzJ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -17999,6 +18325,13 @@
 "ECt" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/hallway/secondary/entry)
+"EDp" = (
+/obj/structure/closet/secure_closet/lethalshots,
+/obj/machinery/light{
+	dir = 2
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "EDx" = (
 /obj/structure/chair{
 	dir = 1
@@ -18049,6 +18382,30 @@
 "EGA" = (
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
+"EHP" = (
+/obj/structure/rack,
+/obj/item/ammo_box/magazine/sniper_rounds/haemorrhage,
+/obj/item/ammo_box/magazine/sniper_rounds/penetrator,
+/obj/item/ammo_box/magazine/sniper_rounds/soporific,
+/obj/item/weapon/gun/projectile/automatic/sniper_rifle,
+/obj/machinery/ai_status_display{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/door/window/southleft{
+	dir = 2;
+	name = "Armory";
+	req_access_txt = "3"
+	},
+/obj/machinery/camera/motion{
+	c_tag = "Armory High Security";
+	dir = 6;
+	network = list("SS13","Brig")
+	},
+/turf/open/floor/plasteel/darkwarning{
+	dir = 1
+	},
+/area/shuttle/ftl/security/armory)
 "EHW" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel,
@@ -18061,6 +18418,16 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
+"EJa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Port Primary Hallway 1";
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "EKq" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -18181,21 +18548,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/atmos/equipment)
-"EZc" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
 "EZq" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -18206,6 +18558,19 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/shuttle/ftl/space)
+"EZE" = (
+/obj/machinery/button/flasher{
+	id = "brigentry";
+	pixel_x = -6;
+	pixel_y = -22;
+	req_access_txt = "1"
+	},
+/obj/machinery/vending/security,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 25
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "EZQ" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/secondary/construction)
@@ -18234,16 +18599,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engine_smes)
-"FaN" = (
-/obj/structure/sign/poster{
-	pixel_x = -32
-	},
-/obj/structure/window/reinforced{
-	dir = 2
-	},
-/obj/structure/closet/bombcloset,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
 "Fbt" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -18270,6 +18625,24 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"Fgx" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 2
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/hos)
 "Fgy" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -18552,6 +18925,16 @@
 	},
 /turf/open/floor/plasteel/blue,
 /area/shuttle/ftl/medical/genetics)
+"FwZ" = (
+/obj/machinery/light/small{
+	dir = 2
+	},
+/obj/structure/fireaxecabinet{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos/equipment)
 "Fyy" = (
 /obj/structure/closet/crate,
 /obj/item/weapon/storage/toolbox/emergency,
@@ -18591,6 +18974,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
+"FBk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "FBs" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -18905,6 +19298,22 @@
 /obj/structure/closet/jcloset,
 /turf/open/floor/plating,
 /area/shuttle/ftl/janitor)
+"Gco" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Armory";
+	req_access_txt = "3"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/armory)
 "Ggj" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/mechanical,
@@ -18934,6 +19343,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"GgA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/folder/red,
+/obj/machinery/recharger,
+/obj/item/weapon/pen/red,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
+"Giy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "Glz" = (
 /obj/structure/closet/wardrobe/white/medical,
 /turf/open/floor/plasteel/white,
@@ -19046,30 +19480,6 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/engine/engineering)
-"GwC" = (
-/obj/machinery/camera{
-	c_tag = "Security Office East";
-	dir = 2;
-	network = list("SS13","Brig")
-	},
-/obj/item/device/radio/intercom{
-	pixel_x = 0;
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/landmark{
-	name = "lightsout"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "Gyv" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -19099,23 +19509,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 10;
 	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"Gzd" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Port Airlock"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
@@ -19274,6 +19667,50 @@
 /area/shuttle/ftl/crew_quarters/theatre{
 	name = "Library"
 	})
+"GOC" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 2
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
+"GOQ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/chair,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
+"GPn" = (
+/obj/machinery/door_timer{
+	id = "Cell 2";
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "GPW" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
@@ -19294,6 +19731,16 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/lab)
+"GRW" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "GSF" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -19369,21 +19816,6 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
-"GWQ" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/hologram/holopad,
-/obj/effect/landmark/start{
-	name = "Security Officer";
-	shuttle_abstract_movable = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "GXx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 4
@@ -19481,19 +19913,22 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/subshuttle/pod_3)
-"Hfv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"Hfp" = (
+/obj/structure/rack,
+/obj/item/weapon/gun/energy/gun/advtaser{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+/obj/item/weapon/gun/energy/gun/advtaser,
+/obj/item/weapon/gun/energy/gun/advtaser{
+	pixel_x = 3;
+	pixel_y = -3
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
+/area/shuttle/ftl/security/main)
 "HfP" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -19610,17 +20045,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/medbay)
-"Hnk" = (
-/obj/machinery/camera{
-	c_tag = "Janitor's Closet";
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/janitor)
 "HpA" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -19663,6 +20087,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engine_smes)
+"HrR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "HtO" = (
 /turf/open/floor/plasteel{
 	icon_state = "white"
@@ -19685,38 +20115,6 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engine_smes)
-"Hvp" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet{
-	name = "contraband locker";
-	req_access_txt = "3"
-	},
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
-/obj/effect/spawner/lootdrop/armory_contraband{
-	loot = list(/obj/item/weapon/gun/projectile/automatic/pistol = 5, /obj/item/weapon/gun/projectile/shotgun/automatic/combat = 5, /obj/item/weapon/gun/projectile/revolver/mateba, /obj/item/weapon/gun/projectile/automatic/pistol/deagle, /obj/item/weapon/storage/box/syndie_kit/throwing_weapons = 3)
-	},
-/turf/open/floor/plasteel/darkwarning{
-	dir = 9
-	},
-/area/shuttle/ftl/security/armory)
-"HwG" = (
-/obj/machinery/door/airlock/security{
-	name = "Detective's Office";
-	req_access_txt = "41"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/security/detectives_office)
 "HyL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -19840,6 +20238,42 @@
 	dir = 8
 	},
 /area/shuttle/ftl/engine/break_room)
+"HEv" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/vest{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/armor/vest{
+	pixel_y = 0
+	},
+/obj/item/clothing/suit/armor/vest{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet{
+	layer = 3.00001;
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet{
+	layer = 3.00001
+	},
+/obj/item/clothing/head/helmet{
+	layer = 3.00001;
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 25
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/security/main)
 "HFH" = (
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/theatre{
@@ -20068,20 +20502,6 @@
 "HUV" = (
 /turf/open/floor/plasteel/delivery,
 /area/shuttle/ftl/cargo/office)
-"HWr" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "warden_shutters";
-	layer = 2
-	},
-/obj/machinery/door/window/eastleft{
-	dir = 2;
-	name = "Brig Desk";
-	req_access_txt = "1"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/shuttle/ftl/security/masteratarms)
 "HWJ" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator";
@@ -20228,16 +20648,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/atmos/equipment)
-"IuD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "IuX" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -20251,6 +20661,15 @@
 /obj/structure/cryofeed/right,
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/crew_quarters/sleep)
+"IyO" = (
+/obj/machinery/computer/card/minor/hos,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/hos)
 "IAv" = (
 /obj/machinery/space_heater,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -20276,20 +20695,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/ftl/subshuttle/pod_1)
-"IDy" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Armory";
-	req_access_txt = "3"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/armory)
 "IEY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -20424,6 +20829,26 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
+"IRE" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 2
+	},
+/obj/machinery/button/door{
+	id = "exec_blast";
+	name = "Execution Blast Door";
+	pixel_x = -26;
+	pixel_y = 6;
+	req_access_txt = "1"
+	},
+/obj/machinery/button/massdriver{
+	id = "exec_driver";
+	pixel_x = -26;
+	pixel_y = -6;
+	req_one_access_txt = "1"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/masteratarms)
 "ISm" = (
 /obj/effect/landmark/start{
 	name = "Ship Engineer";
@@ -20518,6 +20943,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
+"Jbo" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 2
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "JbE" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -20525,19 +20961,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos/equipment)
-"JcD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
 "Jdi" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria,
@@ -20574,19 +20997,6 @@
 /area/shuttle/ftl/security/brig{
 	name = "Departures Checkpoint"
 	})
-"JkU" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/structure/chair,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
 "JlD" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -20634,6 +21044,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos/equipment)
+"Jod" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/machinery/light_switch{
+	pixel_x = -8;
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "Jol" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
@@ -20641,20 +21062,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/engineering)
+"JqS" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "warden_shutters_ext";
+	layer = 2
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "brig_enter_shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/masteratarms)
 "JsC" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/storage)
-"JsX" = (
-/obj/machinery/button/flasher{
-	id = "brigentry";
-	pixel_x = -6;
-	pixel_y = -22;
-	req_access_txt = "1"
-	},
-/obj/machinery/vending/security,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "Juc" = (
 /obj/machinery/light{
 	dir = 8
@@ -20710,6 +21137,15 @@
 	},
 /turf/open/floor/plasteel/blue,
 /area/shuttle/ftl/medical/genetics)
+"JwG" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = "90Curve"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/armory)
 "JwP" = (
 /obj/structure/rack{
 	dir = 1
@@ -20755,6 +21191,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
+"JCm" = (
+/obj/structure/rack,
+/turf/open/floor/plasteel/darkwarning{
+	dir = 4
+	},
+/area/shuttle/ftl/security/armory)
 "JCW" = (
 /obj/item/weapon/storage/firstaid/fire,
 /obj/structure/table,
@@ -20846,6 +21288,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
+"JII" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 2
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/masteratarms)
 "JJz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -20864,6 +21312,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
+"JKx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Port Airlock"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "JLk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
@@ -21070,23 +21528,6 @@
 "Kaw" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/captain)
-"Kbu" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
 "KdR" = (
 /obj/item/clothing/under/burial,
 /obj/structure/closet/crate,
@@ -21106,13 +21547,6 @@
 /obj/item/clothing/under/burial,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
-"Kek" = (
-/obj/structure/window/reinforced{
-	dir = 2
-	},
-/obj/structure/closet/l3closet/security,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
 "Kgt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -21167,15 +21601,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/chargebay)
-"Kmh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/sign/poster{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
 "Kmn" = (
 /obj/structure/displaycase/captain,
 /obj/machinery/newscaster/security_unit{
@@ -21330,21 +21755,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"Kxh" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_command{
-	name = "Head of Security";
-	req_access_txt = "31"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/hos)
 "KxO" = (
 /obj/structure/mirror{
 	pixel_x = 0;
@@ -21407,6 +21817,24 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
+"KEX" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "KFq" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -21424,21 +21852,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/exit)
-"KGh" = (
-/obj/structure/table,
-/obj/machinery/newscaster{
-	pixel_x = 30
-	},
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
-/obj/machinery/computer/security/wooden_tv{
-	density = 0;
-	pixel_x = 3;
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "KHq" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -21594,18 +22007,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/crew_quarters/heads)
-"KTk" = (
-/mob/living/simple_animal/bot/secbot{
-	arrest_type = 1;
-	health = 45;
-	icon_state = "secbot1";
-	idcheck = 1;
-	name = "Sergeant-at-Armsky";
-	on = 1;
-	weaponscheck = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
 "KUu" = (
 /turf/closed/wall,
 /area/shuttle/ftl/security/brig)
@@ -21662,6 +22063,16 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/bridge/eva)
+"KXA" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Security Officer";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "KYA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -21697,22 +22108,6 @@
 "KZS" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/medical/genetics)
-"LbO" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Security Officer";
-	shuttle_abstract_movable = 1
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 "LdU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -21765,17 +22160,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"LfI" = (
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/white,
-/area/shuttle/ftl/medical/medbay)
 "LgU" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
+"LgX" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "warden_shutters";
+	layer = 2
+	},
+/obj/machinery/door/window/eastright{
+	dir = 2;
+	name = "Brig Desk";
+	req_access_txt = "2"
+	},
+/obj/item/device/radio{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/masteratarms)
 "Lim" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -21813,6 +22219,14 @@
 	mouse_over_pointer = 0;
 	name = "Battle Bridge"
 	})
+"LjA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "Lkb" = (
 /turf/open/floor/plasteel{
 	icon_state = "white"
@@ -21871,25 +22285,6 @@
 /area/shuttle/ftl/crew_quarters/theatre{
 	name = "Library"
 	})
-"Lnk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 2
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/start{
-	name = "Security Officer";
-	shuttle_abstract_movable = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "LnQ" = (
 /obj/machinery/door/airlock/glass{
 	name = "Port Airlock"
@@ -22178,18 +22573,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/xenobiology)
-"LLH" = (
-/obj/structure/rack,
-/obj/machinery/power/apc{
-	auto_name = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/ftl/security/armory)
 "LLN" = (
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
@@ -22252,18 +22635,27 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engineering)
-"LTR" = (
+"LUj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 2
+/obj/machinery/camera{
+	c_tag = "Security Office West";
+	dir = 9;
+	network = list("SS13","Brig")
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "LVz" = (
 /obj/structure/filingcabinet/security,
 /obj/item/weapon/folder/documents,
@@ -22306,6 +22698,21 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
+"LZj" = (
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 30
+	},
+/obj/machinery/photocopier{
+	pixel_y = 3
+	},
+/obj/machinery/computer/security/telescreen{
+	name = "Brig Monitoring";
+	network = list("Brig");
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/masteratarms)
 "Mae" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -22357,30 +22764,6 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"MkE" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/door/window/eastright{
-	dir = 8;
-	name = "Mass Driver Access";
-	req_access_txt = "1"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 2
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 "MlG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 4
@@ -22394,6 +22777,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/toilet)
+"Moy" = (
+/obj/machinery/door/airlock/security{
+	name = "Master At Arms' Office";
+	req_access_txt = "3"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/masteratarms)
 "Mpq" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -22408,6 +22807,15 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/research/xenobiology)
+"MpA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "Mqb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 4
@@ -22526,15 +22934,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"MFN" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/darkwarning{
-	dir = 1
-	},
-/area/shuttle/ftl/security/armory)
 "MHy" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -22675,31 +23074,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"MRk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+"MRp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
 /turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
+/area/shuttle/ftl/security/brig)
 "MSr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 2
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/munitions)
-"MSU" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/newscaster{
-	pixel_x = 30
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 "MTt" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 8
@@ -22717,13 +23104,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"MUe" = (
-/obj/structure/table/wood,
-/obj/item/device/radio,
-/obj/item/weapon/storage/fancy/cigarettes/cigpack_carp,
-/obj/item/clothing/glasses/sunglasses,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
+"MTT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "MUF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -22882,30 +23273,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
-"Njb" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
 "NjG" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -22934,6 +23301,23 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/shuttle/ftl/bridge)
+"Nkq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "Now" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -23117,17 +23501,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/chargebay)
-"NxH" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/ai_status_display{
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
 "Nye" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -23205,6 +23578,18 @@
 	},
 /turf/open/floor/engine,
 /area/shuttle/ftl/engine/engineering)
+"NGm" = (
+/obj/machinery/suit_storage_unit/security,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/turf/open/floor/plasteel/darkwarning{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
 "NGC" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 8;
@@ -23353,6 +23738,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
+"NRC" = (
+/obj/item/toy/foamblade,
+/obj/item/device/healthanalyzer,
+/obj/item/device/multitool,
+/obj/structure/closet/crate/medical,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/device/flashlight,
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "NSy" = (
 /obj/machinery/monkey_recycler,
 /turf/open/floor/plasteel{
@@ -23557,12 +23951,6 @@
 	mouse_over_pointer = 0;
 	name = "Battle Bridge"
 	})
-"OcO" = (
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
 "OdU" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/door/airlock/hatch{
@@ -23711,27 +24099,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/office)
-"OnW" = (
-/obj/machinery/button/door{
-	id = "permabrig_shutters";
-	name = "Permabrig Shutters Control";
-	override = 0;
-	pixel_x = 26;
-	pixel_y = -28;
-	req_access_txt = "0";
-	specialfunctions = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 "Ool" = (
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/locker)
@@ -23830,23 +24197,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/virology)
-"OuN" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 2
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "Ovb" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/plasteel,
@@ -23960,6 +24310,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"OFB" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance";
+	req_access_txt = "0";
+	req_one_access_txt = "0"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "OIa" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -24086,6 +24450,14 @@
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/turret_protected/ai)
+"OYG" = (
+/obj/machinery/door/airlock/security{
+	mouse_over_pointer = 0;
+	name = "Security Equipment";
+	req_access_txt = "1"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "OYL" = (
 /obj/machinery/suit_storage_unit/captain,
 /obj/machinery/camera{
@@ -24214,12 +24586,51 @@
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/security)
+"Pia" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/effect/landmark/start{
+	name = "Security Officer";
+	shuttle_abstract_movable = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "Pjt" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},
 /area/shuttle/ftl/cargo/mining)
+"PjD" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/light_switch{
+	pixel_x = 8;
+	pixel_y = 22
+	},
+/obj/structure/table,
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/box/bodybags,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/weapon/hand_labeler{
+	pixel_x = 5
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "PkC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -24651,6 +25062,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
+"PUS" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/med_data/laptop,
+/obj/item/device/radio/intercom{
+	pixel_x = -32
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 8
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
 "PVo" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
@@ -24705,15 +25133,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
-"PYj" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/obj/structure/table/wood,
-/obj/item/device/flashlight/lamp,
-/obj/item/weapon/gun/projectile/revolver/russian,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
 "QbW" = (
 /obj/structure/table/glass,
 /obj/item/device/radio,
@@ -24941,19 +25360,6 @@
 /obj/item/device/assembly/signaler,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos/equipment)
-"QuL" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
 "QuZ" = (
 /obj/structure/window/reinforced{
 	dir = 2
@@ -25011,19 +25417,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos/equipment)
-"Qxz" = (
-/obj/structure/rack,
-/obj/item/weapon/gun/energy/gun/advtaser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/gun/energy/gun/advtaser,
-/obj/item/weapon/gun/energy/gun/advtaser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
 "QxK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -25259,6 +25652,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
+"QTB" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "QUJ" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/emergency,
@@ -25474,6 +25877,18 @@
 /obj/machinery/suit_storage_unit/cmo,
 /turf/open/floor/plasteel/cmo,
 /area/shuttle/ftl/medical/cmo)
+"Rlv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/armory)
 "Rms" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -25642,16 +26057,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge/meeting_room)
-"Rxb" = (
-/obj/machinery/light{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/mob/living/simple_animal/bot/ed209,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/ftl/security/armory)
 "RzX" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -25669,20 +26074,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/secondary/exit)
-"RAR" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
 "RBc" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -25697,23 +26088,6 @@
 	mouse_over_pointer = 0;
 	name = "Battle Bridge"
 	})
-"RCD" = (
-/obj/item/weapon/storage/fancy/donut_box,
-/obj/structure/window/reinforced{
-	dir = 2
-	},
-/obj/structure/table,
-/obj/item/weapon/storage/box/teargas{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/storage/box/flashbangs{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/weapon/reagent_containers/glass/bottle/morphine,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
 "RCP" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -25833,15 +26207,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"RNU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/computer/med_data/laptop,
-/obj/structure/table,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "RPy" = (
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plasteel,
@@ -25876,6 +26241,12 @@
 	},
 /turf/open/floor/plasteel/darkbrown,
 /area/shuttle/ftl/cargo/office)
+"RTI" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/masteratarms)
 "RTM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -25938,13 +26309,6 @@
 "RXd" = (
 /turf/closed/wall,
 /area/shuttle/ftl/crew_quarters/toilet)
-"RYp" = (
-/obj/machinery/computer/prisoner,
-/obj/item/device/radio/intercom{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/masteratarms)
 "RYr" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -26100,13 +26464,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/starboard)
-"SeP" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/structure/chair,
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
 "SfN" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -26387,22 +26744,6 @@
 /area/shuttle/ftl/security/brig{
 	name = "Departures Checkpoint"
 	})
-"SHo" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Armory Low Security";
-	dir = 4;
-	network = list("SS13","Brig")
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/structure/closet/secure_closet/lethalshots,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
 "SKd" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor/preopen{
@@ -26467,6 +26808,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
+"SMn" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/security)
 "SRm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -26501,16 +26849,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"STp" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 30
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
 "STt" = (
 /turf/open/floor/plasteel/darkwarning{
 	dir = 2
@@ -26554,21 +26892,6 @@
 	dir = 2
 	},
 /area/shuttle/ftl/subshuttle/pod_1)
-"SXX" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
 "SYy" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -26851,6 +27174,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/virology)
+"TsL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/masteratarms)
 "Txm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 1
@@ -26899,17 +27228,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/central)
-"TBL" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/rack,
-/obj/item/weapon/gun/energy/ionrifle,
-/obj/item/clothing/suit/armor/laserproof,
-/turf/open/floor/plasteel/darkwarning{
-	dir = 10
-	},
-/area/shuttle/ftl/security/armory)
 "TBO" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -27003,18 +27321,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"THp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "THT" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -27160,49 +27466,20 @@
 	icon_state = "delivery"
 	},
 /area/shuttle/ftl/engine/engineering)
-"TPs" = (
-/obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing,
-/obj/structure/table/wood,
-/obj/item/device/pda{
-	desc = "The prized possession of any greedy assistant. Too bad the slick surface has rubbed off.";
-	icon_state = "pda-clown";
-	name = "dusty clown pda"
-	},
-/obj/item/device/paicard,
-/obj/item/weapon/dice/d20,
-/obj/item/weapon/dice,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
 "TPG" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet,
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/brig)
-"TQm" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/shutters{
-	id = "warden_shutters_ext";
-	name = "shutters"
+"TPK" = (
+/obj/structure/table,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/security/masteratarms)
+/obj/item/weapon/pen,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
 "TQF" = (
 /obj/machinery/door/airlock/shuttle,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -27283,6 +27560,14 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
+"TXF" = (
+/obj/structure/filingcabinet,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
 "TZj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -27325,6 +27610,20 @@
 	},
 /turf/open/floor/plasteel/circuit,
 /area/shuttle/ftl/telecomms/server)
+"Ucv" = (
+/obj/structure/window/reinforced{
+	dir = 2
+	},
+/obj/item/chair{
+	dir = 8
+	},
+/obj/item/device/electropack,
+/obj/machinery/ai_status_display{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/masteratarms)
 "Uec" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -27345,6 +27644,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"Uhq" = (
+/obj/machinery/door/airlock/glass_security{
+	name = "Execution Chamber";
+	req_one_access_txt = "3"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/masteratarms)
 "UiN" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -27356,16 +27665,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
 /area/shuttle/ftl/atmos)
-"UkR" = (
-/obj/machinery/photocopier{
-	pixel_y = 3
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/masteratarms)
 "Ulg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2
@@ -27421,6 +27720,24 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/ftl/crew_quarters/kitchen)
+"Uop" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "Uov" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/firealarm{
@@ -27449,6 +27766,27 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/secondary/exit)
+"UpO" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 2
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "UpP" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
@@ -27553,43 +27891,16 @@
 	mouse_over_pointer = 0;
 	name = "Battle Bridge"
 	})
-"UCX" = (
-/obj/machinery/recharger,
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "warden_shutters";
-	layer = 2
+"UEP" = (
+/obj/machinery/computer/security,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/obj/machinery/door/window/eastright{
-	dir = 2;
-	name = "Brig Desk";
-	req_access_txt = "2"
-	},
-/obj/item/device/radio{
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/device/assembly/signaler,
-/turf/open/floor/plating,
-/area/shuttle/ftl/security/masteratarms)
-"UDM" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 0;
-	pixel_y = 30
-	},
-/obj/structure/table,
-/obj/item/weapon/reagent_containers/glass/bottle/epinephrine,
-/obj/item/weapon/reagent_containers/glass/bottle/charcoal,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/weapon/restraints/handcuffs,
-/obj/item/weapon/reagent_containers/syringe,
 /turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
+/area/shuttle/ftl/security/masteratarms)
 "UFa" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2
@@ -27649,19 +27960,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/research/lab)
-"UJO" = (
-/obj/structure/table/wood,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey{
-	pixel_x = 3
-	},
-/obj/item/weapon/lighter,
-/obj/item/device/flashlight/lamp,
-/obj/item/device/radio/intercom{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
 "UKd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -27710,15 +28008,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/cargo/mining)
-"UND" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Clown"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
 "UNF" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -27779,56 +28068,6 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
-/area/shuttle/ftl/security/brig)
-"UVC" = (
-/obj/machinery/button/massdriver{
-	id = "exec_driver";
-	pixel_x = 6;
-	pixel_y = -26;
-	req_one_access_txt = "1"
-	},
-/obj/machinery/button/door{
-	id = "exec_blast";
-	name = "Execution Blast Door";
-	pixel_x = -6;
-	pixel_y = -26;
-	req_access_txt = "1"
-	},
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/structure/table,
-/obj/item/clothing/under/color/orange{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/clothing/under/color/orange{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/weapon/restraints/handcuffs,
-/obj/item/weapon/restraints/handcuffs,
-/obj/item/weapon/restraints/handcuffs,
-/obj/item/weapon/restraints/handcuffs,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/item/device/taperecorder{
-	pixel_x = -3;
-	pixel_y = 0
-	},
-/obj/item/device/assembly/flash/handheld,
-/obj/item/weapon/reagent_containers/spray/pepper{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/black,
 /area/shuttle/ftl/security/brig)
 "UWI" = (
 /obj/machinery/computer/pmanagement,
@@ -27904,22 +28143,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"VfW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/main)
 "Vgz" = (
 /obj/structure/chair,
 /obj/item/device/radio/intercom{
@@ -28292,28 +28515,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/munitions)
-"VIK" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/structure/sink{
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/port)
-"VIZ" = (
-/obj/machinery/light/small{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2
-	},
-/obj/structure/fireaxecabinet{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/atmos/equipment)
 "VLP" = (
 /obj/structure/cryofeed,
 /turf/open/floor/plasteel/white,
@@ -28335,19 +28536,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/bridge)
-"VNy" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/shutters{
-	id = "warden_shutters_ext";
-	name = "shutters"
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/security/masteratarms)
 "VNP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -28381,6 +28569,23 @@
 	},
 /turf/open/floor/plasteel/darkbrown,
 /area/shuttle/ftl/cargo/office)
+"VPQ" = (
+/obj/machinery/camera{
+	c_tag = "Janitor's Closet";
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/janitor)
 "VQK" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Server Room";
@@ -28426,23 +28631,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"VTQ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "VTV" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -28512,13 +28700,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/engineering)
-"VZL" = (
-/obj/machinery/door/poddoor{
-	id = "exec_blast"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/shuttle/ftl/security/brig)
 "VZS" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/poddoor/shutters{
@@ -28608,20 +28789,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/engineering)
-"WgL" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "permabrig_shutters";
-	layer = 2
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/security/brig)
 "Wiq" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/research/xenobiology)
@@ -28725,30 +28892,35 @@
 /obj/item/weapon/reagent_containers/syringe,
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
-"WqS" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 22
+"Wpc" = (
+/obj/machinery/door/window/eastright{
+	dir = 2;
+	name = "Mass Driver Access";
+	req_access_txt = "1"
 	},
-/obj/machinery/firealarm{
-	pixel_y = -26
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/masteratarms)
 "Wrc" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/ftl/subshuttle/pod_3)
-"WsE" = (
-/obj/item/device/radio/intercom{
-	pixel_x = 0;
-	pixel_y = 28
+"WrH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
+	dir = 2
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/crew_quarters/sleep)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/main)
 "Wtg" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 2
@@ -28779,6 +28951,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/cargo/mining)
+"Wvb" = (
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 2
+	},
+/area/shuttle/ftl/crew_quarters/sleep)
 "WvM" = (
 /obj/machinery/computer/communications,
 /turf/open/floor/plasteel/shuttle/yellow,
@@ -28822,22 +29003,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/genetics)
-"WyA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
-	dir = 2
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	auto_name = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/masteratarms)
 "WyR" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/office)
@@ -28973,6 +29138,20 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/storage)
+"WIn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "WIy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -29022,6 +29201,38 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"WLP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 2
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/masteratarms)
+"WMA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/power/apc{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/rack,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/storage/toolbox/emergency{
+	pixel_x = -2;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "WNE" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -29030,19 +29241,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/medical/virology)
-"WOp" = (
-/obj/item/weapon/book/manual/detective,
-/obj/structure/rack,
-/obj/item/weapon/storage/secure/briefcase,
-/obj/item/weapon/storage/briefcase{
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/obj/item/weapon/paper/courtroom{
-	name = "paper- 'A Crash Course in Legal SOP"
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
 "WOP" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/mechanical,
@@ -29140,6 +29338,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
+"WZf" = (
+/obj/machinery/light_switch{
+	override = 0;
+	pixel_x = -10;
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/security/detectives_office)
 "WZO" = (
 /obj/machinery/light{
 	dir = 2
@@ -29199,6 +29406,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/tool_storage)
+"XdP" = (
+/obj/machinery/suit_storage_unit/security,
+/obj/item/device/radio/intercom{
+	pixel_x = -32
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/darkwarning{
+	dir = 8
+	},
+/area/shuttle/ftl/security/armory)
 "Xen" = (
 /obj/machinery/light/small{
 	dir = 2
@@ -29217,6 +29437,50 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
+"XeW" = (
+/obj/structure/closet/secure_closet/brig{
+	name = "Prisoner Equipment"
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 22
+	},
+/obj/item/weapon/restraints/handcuffs,
+/obj/item/weapon/restraints/handcuffs,
+/obj/item/weapon/restraints/handcuffs,
+/obj/item/weapon/restraints/handcuffs,
+/obj/item/device/taperecorder{
+	pixel_x = -3;
+	pixel_y = 0
+	},
+/obj/item/device/assembly/flash/handheld,
+/obj/item/weapon/reagent_containers/spray/pepper{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/under/color/orange{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/clothing/under/color/orange{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/clothing/under/color/orange{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/machinery/camera{
+	c_tag = "Master At Arms' Office";
+	dir = 8;
+	network = list("SS13","Brig")
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/masteratarms)
 "XhI" = (
 /obj/machinery/power/smes{
 	charge = 500000
@@ -29274,13 +29538,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engineering)
-"XnS" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
 "XoS" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -29349,6 +29606,12 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/surgery)
+"XsT" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "XtO" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/structure/cable{
@@ -29536,18 +29799,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/brig)
-"XGd" = (
-/obj/structure/rack,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/weapon/storage/toolbox/emergency{
-	pixel_x = -2;
-	pixel_y = -3
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 30
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/masteratarms)
 "XHE" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -29635,13 +29886,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
-"XXM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/security)
 "XYf" = (
 /obj/item/device/radio/intercom{
 	pixel_x = 0;
@@ -29800,6 +30044,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"Yod" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/masteratarms)
 "Yof" = (
 /obj/structure/shuttle/engine/heater{
 	icon_state = "heater";
@@ -29822,6 +30072,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/medbay)
+"YrG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/machinery/hologram/holopad,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "YsL" = (
 /obj/structure/shuttle/engine/propulsion/burst{
 	tag = "icon-propulsion (NORTH)";
@@ -29858,6 +30120,14 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/munitions)
+"YtN" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance";
+	req_access_txt = "0";
+	req_one_access_txt = "8;7"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/engineering)
 "YuR" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4;
@@ -29916,22 +30186,6 @@
 /obj/item/weapon/crowbar/red,
 /turf/open/floor/plating,
 /area/shuttle/ftl/engine/tool_storage)
-"Yyh" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/machinery/computer/secure_data,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
 "YyB" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/plasteel,
@@ -29940,23 +30194,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/shuttle/yellow,
 /area/shuttle/ftl/subshuttle/pod_3)
-"YAr" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/preopen{
-	id = "brig_enter_shutters"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "hos_shutters";
-	name = "shutters"
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/security/hos)
 "YAt" = (
 /obj/machinery/hologram/comms_pad,
 /turf/open/floor/plasteel/black,
@@ -30113,22 +30350,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/virology)
-"YIx" = (
-/obj/structure/chair/office/dark{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/masteratarms)
 "YKc" = (
 /obj/machinery/button/door{
 	id = "tele_shutters";
@@ -30191,11 +30412,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/engine/break_room)
-"YSO" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/med_data/laptop,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/security/detectives_office)
 "YTa" = (
 /obj/structure/sign/poster{
 	pixel_x = 32;
@@ -30348,34 +30564,10 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/assembly/robotics)
-"Zhl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/effect/landmark/start{
-	name = "Security Officer";
-	shuttle_abstract_movable = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/security/brig)
-"Zjh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 8
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
+"Zhn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/hos)
 "Zjm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 4
@@ -30517,6 +30709,10 @@
 /obj/machinery/computer/cargo,
 /turf/open/floor/plasteel/darkbrown,
 /area/shuttle/ftl/cargo/qm)
+"Zxx" = (
+/obj/machinery/computer/prisoner,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/masteratarms)
 "Zxy" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/bar,
@@ -30537,6 +30733,10 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/bar)
+"ZxB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/engine/engineering)
 "Zzs" = (
 /obj/structure/closet/wardrobe/miner,
 /obj/structure/window/reinforced{
@@ -30572,6 +30772,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"ZBv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 2
+	},
+/obj/structure/table,
+/obj/machinery/computer/security/wooden_tv{
+	density = 0;
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/security/brig)
 "ZDR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -30664,6 +30876,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
+"ZTp" = (
+/obj/machinery/ai_status_display{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "ZUa" = (
 /obj/machinery/computer/atmos_alert,
 /turf/open/floor/plasteel,
@@ -30717,16 +30940,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/turret_protected/ai)
-"ZUP" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/structure/sign/poster{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/brig)
 
 (1,1,1) = {"
 Kky
@@ -51138,10 +51351,10 @@ EPK
 EDx
 EDx
 Cde
-PYj
+eTr
 DUo
-pCY
-iRQ
+yia
+hZE
 Cde
 drw
 Kwf
@@ -51395,10 +51608,10 @@ EMr
 DWa
 KdR
 Cde
-TPs
+APg
 ShW
-UND
-pon
+yic
+NRC
 Cde
 hjd
 uQo
@@ -51434,9 +51647,9 @@ sAz
 sAz
 Bqp
 Ecu
-VIZ
-Vqh
-Mkl
+FwZ
+ZxB
+naz
 Mkl
 Mkl
 LTP
@@ -51653,11 +51866,11 @@ EDx
 dPj
 Cde
 EQz
-XnS
-yfw
+SMn
+tfT
 PhS
 Cde
-JkU
+GOQ
 FXc
 gSv
 ZTg
@@ -51691,9 +51904,9 @@ sAz
 JbE
 gXQ
 aDx
-gec
-CAn
-Dtf
+oqX
+pmZ
+esw
 Mkl
 Oph
 Vpe
@@ -51911,10 +52124,10 @@ ZUI
 Cde
 ZUL
 Cde
-bUB
+OFB
 Cde
 Cde
-SeP
+yDx
 PRp
 gSv
 Rgh
@@ -52168,7 +52381,7 @@ ZUJ
 ZUK
 QfX
 wTn
-XXM
+alz
 IAv
 ZUK
 GyI
@@ -52421,15 +52634,15 @@ fMD
 iOX
 Lon
 Lon
-CiY
 Lon
+Ahx
 EcC
 Lon
-kZM
-Lon
-SXX
-LTR
-uld
+nRp
+ezQ
+sjl
+nec
+BRI
 Pbr
 fDo
 BnG
@@ -52676,19 +52889,19 @@ VgA
 Ayi
 tEA
 jUT
-qkK
-qkK
-zPR
-qkK
-fgN
-fgN
-fgN
-fgN
-fgN
-hcM
-RAR
-rGM
-NxH
+HGs
+HGs
+HGs
+BSC
+HGs
+HGs
+HGs
+HGs
+HGs
+AOo
+ywN
+JKx
+hny
 BnG
 toK
 toK
@@ -52928,24 +53141,24 @@ toK
 toK
 toK
 toK
-toK
-qkK
-qkK
-qkK
-qkK
-qkK
-njh
-fRe
-Qxz
-fgN
-Hvp
-vkF
-TBL
-fgN
-ELw
-Gzd
-gVn
-hny
+vwv
+vwv
+vwv
+vwv
+vwv
+HGs
+kSn
+lOj
+ePB
+kSr
+NtJ
+Qvm
+bYD
+XGa
+vVC
+tOd
+rGM
+ZTp
 BnG
 CyX
 CyX
@@ -53185,25 +53398,25 @@ toK
 toK
 toK
 toK
-toK
-qkK
-vig
-wxU
-FaN
-SHo
-NrF
-mnd
-hXD
-qVy
-MFN
-ahM
-kaL
-fgN
+vwv
+PUS
+ewe
+TXF
+vwv
+CXI
+pcP
+WIn
+XsT
+CIu
+EFC
+rsp
+TPG
+URM
 vVC
 NXR
 oCP
-jKo
-FOC
+hFL
+YtN
 jqa
 OVU
 FOC
@@ -53442,25 +53655,25 @@ toK
 toK
 toK
 toK
-toK
-qkK
-qFE
-NrF
-Kek
-PkY
-KTk
-wLr
-Aaf
-fgN
-pUB
-eXv
-Rxb
-vWI
-XTc
-iGW
-cWs
-hny
-FOC
+fHg
+zJH
+zUz
+yoP
+rdS
+qDB
+tVS
+rHg
+wur
+KUu
+KUu
+KUu
+KUu
+HGs
+EJa
+NXR
+oCP
+fYU
+ZEY
 FOC
 FOC
 FOC
@@ -53699,26 +53912,26 @@ toK
 toK
 toK
 toK
-toK
-qkK
-OcO
-aUl
-MRk
-MRk
-MRk
-jnp
-hTG
-IDy
-vsg
-uel
-LLH
-fgN
+fHg
+dkO
+ChQ
+WZf
+vIt
+GgA
+MRp
+Uop
+DYs
+beJ
+CuW
+Qvm
+pRi
+XGa
 vVC
 NXR
-Kmh
-hny
+oCP
+BuX
+ZEY
 xuG
-FOC
 bia
 FOC
 ZEY
@@ -53956,26 +54169,26 @@ toK
 toK
 toK
 toK
-toK
-qkK
-mtT
-cQE
-RCD
-NrF
-STp
-VfW
-qrN
-fgN
-yiQ
-DQJ
-pzA
-fgN
-VIK
+vwv
+udU
+zJU
+ptw
+vwv
+xZP
+KXA
+YrG
+Giy
+CIu
+sWn
+rsp
+TPG
+URM
+mVf
 gKx
 oCP
-hny
+skq
+ZEY
 qQI
-FOC
 FOC
 FOC
 vPe
@@ -54213,26 +54426,26 @@ toK
 toK
 toK
 toK
-OyN
-OyN
-OyN
-OyN
-OyN
-nnz
-OyN
-kDN
-nfC
-fgN
-fgN
-fgN
-fgN
-fgN
+vwv
+vwv
+vwv
+vwv
+vwv
+nhM
+sbj
+GRW
+GPn
+KUu
+KUu
+KUu
+KUu
+HGs
 ETk
 NXR
 oCP
-hny
+xbC
+ZEY
 von
-FOC
 sJI
 FOC
 FOC
@@ -54470,20 +54683,20 @@ toK
 toK
 toK
 toK
-pFR
-fyL
-RYp
-pKy
-pHL
-BlS
-DHP
-rDz
-FDC
-zfg
-HGs
-rjP
-qjs
-HGs
+PNn
+Wkr
+Vqq
+HiU
+PNn
+PjD
+sbj
+GOC
+fAy
+jkq
+smk
+Qvm
+wtL
+XGa
 vVC
 NXR
 Yjb
@@ -54727,22 +54940,22 @@ toK
 toK
 toK
 toK
-TQm
-dRn
-DJV
-vot
-cCn
-YIx
-HWr
-tJX
-sth
-jRC
-uEV
-oZj
-CIr
-KuB
-CqH
-EZc
+cuz
+LsF
+FGS
+Fgx
+AcO
+FBk
+cXj
+cSq
+Giy
+uKz
+KDQ
+rsp
+TPG
+URM
+mVf
+DVX
 gRO
 gmo
 DQS
@@ -54984,23 +55197,23 @@ toK
 toK
 toK
 toK
-VNy
-XGd
-mjL
-pvL
-UkR
-WyA
-UCX
-cQe
-Hfv
-WwN
-gdt
-TUA
-sSv
-JLk
-JcD
-Njb
-QuL
+cuz
+IyO
+DPq
+pAr
+Zhn
+LjA
+MTT
+ltp
+rnK
+HGs
+HGs
+HGs
+HGs
+HGs
+vVC
+tbr
+rDS
 YEk
 doQ
 dTE
@@ -55241,19 +55454,19 @@ toK
 toK
 toK
 toK
-OyN
 PNn
+lJv
+ByU
+IWb
 PNn
-PNn
-PNn
-PNn
-OyN
-GwC
-tlt
-JsX
+ZBv
+QTB
+Pia
+FDC
+ASd
 HGs
-HpA
-zLN
+rjP
+qjs
 HGs
 vVC
 yXP
@@ -55498,22 +55711,22 @@ toK
 toK
 toK
 toK
-toK
 PNn
-Wkr
-Vqq
-HiU
 PNn
-fQZ
-jNR
-kbC
-HGs
-HGs
-HGs
-HGs
-HGs
-vVC
-vxK
+yYR
+BvJ
+PNn
+OyN
+WMA
+qEi
+hqQ
+jRC
+uEV
+oZj
+CIr
+KuB
+MpA
+zjD
 oCP
 GKy
 LAB
@@ -55755,23 +55968,23 @@ toK
 toK
 toK
 toK
-toK
-YAr
-LsF
-FGS
-CEd
-Kxh
-kZg
-Aem
-gSG
-kSr
-NtJ
-Qvm
-bYD
-XGa
-vVC
-vxK
-oCP
+OyN
+tZA
+nlR
+pwH
+DJN
+LgX
+xWi
+lQB
+niY
+WwN
+gdt
+TUA
+sSv
+JLk
+hro
+KEX
+cWs
 GKy
 YyB
 Mqb
@@ -56012,20 +56225,20 @@ toK
 toK
 toK
 toK
-toK
-YAr
-aZC
-ujl
-ock
-rNZ
-RNU
-GWQ
-IuD
-CIu
-EFC
-rsp
-TPG
-URM
+JqS
+Zxx
+WLP
+RTI
+zwk
+Moy
+LUj
+UpO
+FDC
+EZE
+HGs
+HpA
+zLN
+HGs
 vVC
 vxK
 WKH
@@ -56269,20 +56482,20 @@ toK
 toK
 toK
 toK
-toK
-YAr
-Dnv
-ByU
-IWb
-PNn
-UDM
-Lnk
-jzj
-KUu
-KUu
-KUu
-KUu
-HGs
+meV
+UEP
+xuW
+aiU
+ffD
+qkK
+qkK
+aSy
+nfC
+qkK
+qkK
+qkK
+qkK
+qkK
 qNb
 vxK
 oCP
@@ -56526,20 +56739,20 @@ toK
 toK
 toK
 toK
-HGs
-HGs
-uCB
-uCB
-uCB
-HGs
-lYp
-Zhl
-sQX
-beJ
-CuW
-Qvm
-pRi
-XGa
+BPk
+BWe
+Dtz
+zLp
+JII
+OYG
+NrF
+BZU
+tzi
+PkY
+dth
+xQG
+tiu
+qkK
 vVC
 vxK
 oCP
@@ -56783,20 +56996,20 @@ toK
 toK
 toK
 toK
-VZL
-hQD
-tBr
-ucO
-UVC
-HGs
-rzw
-VTQ
-IuD
-CIu
-sWn
-rsp
-TPG
-URM
+OyN
+LZj
+XeW
+vNW
+qll
+qkK
+Jod
+Nkq
+HrR
+ddm
+lVO
+Dyd
+mtT
+qkK
 vVC
 tjx
 UFa
@@ -57040,20 +57253,20 @@ toK
 VoJ
 toK
 toK
-HGs
-MkE
-pgZ
-jgR
-OnW
-vus
-THp
-OuN
-iaW
-KUu
-KUu
-KUu
-KUu
-HGs
+OyN
+OyN
+OyN
+Uhq
+rfT
+qkK
+Hfp
+fZH
+wiw
+mxX
+WrH
+Jbo
+EDp
+qkK
 fSC
 pVF
 jjj
@@ -57297,20 +57510,20 @@ toK
 toK
 toK
 toK
-HGs
-lhZ
-LbO
-vqu
-rqa
-CgR
-dDw
-lED
-cDw
-jkq
-smk
-Qvm
-wtL
-XGa
+rAK
+Exb
+IRE
+gvB
+TsL
+qkK
+gJW
+aXO
+NrF
+Exx
+uRG
+tzi
+vig
+qkK
 vVC
 vxK
 oCP
@@ -57338,8 +57551,8 @@ dNN
 Mkz
 Mkz
 YmQ
-myl
-ATH
+qox
+TPK
 zxX
 woN
 uLW
@@ -57554,20 +57767,20 @@ toK
 toK
 toK
 toK
-WgL
-lGF
-Zjh
-pzB
-tsB
-HGs
-KGh
-Yyh
-mux
-uKz
-KDQ
-rsp
-TPG
-URM
+qaJ
+Wpc
+xmb
+Yod
+DUY
+qkK
+knO
+wBk
+wVJ
+Exx
+fzZ
+HEv
+wgC
+qkK
 mVf
 wPc
 oOF
@@ -57811,20 +58024,20 @@ toK
 toK
 toK
 toK
-WgL
-MSU
-ZUP
-dfP
-DnX
-HGs
-HGs
-HGs
-HGs
-HGs
-HGs
-HGs
-HGs
-HGs
+qaJ
+Ucv
+Crt
+BUF
+Aqv
+qkK
+qkK
+fgN
+fgN
+Gco
+fgN
+aTX
+fgN
+fgN
 klw
 oPP
 YVW
@@ -58068,20 +58281,20 @@ toK
 toK
 toK
 toK
-HGs
-HGs
-HGs
-HGs
-HGs
-HGs
+OyN
+OyN
+OyN
+OyN
+OyN
+OyN
 Wzl
-vwv
-Dzl
-ptw
-fmJ
-WOp
-fMC
-vwv
+fgN
+iit
+hzo
+XdP
+NGm
+aMT
+fgN
 xYB
 vxK
 pzE
@@ -58332,15 +58545,15 @@ kok
 JlD
 VHF
 UNT
-vwv
-msG
-mYA
-fNc
-fNc
-lYb
-HwG
-cch
-Kbu
+fgN
+EHP
+Rlv
+JwG
+pJa
+rUJ
+fgN
+vVC
+vxK
 SRJ
 oNC
 bpf
@@ -58589,13 +58802,13 @@ Umo
 ErC
 wAj
 rjz
-vwv
-YSO
-MUe
-UJO
-fNc
-WqS
-vwv
+fgN
+rel
+iNF
+qhi
+JCm
+swI
+fgN
 THb
 vxK
 SRJ
@@ -58846,13 +59059,13 @@ qas
 wrr
 hlF
 qdc
-vwv
-vwv
-vwv
-vwv
-vwv
-vwv
-vwv
+fgN
+fgN
+fgN
+fgN
+fgN
+fgN
+fgN
 qpk
 pVF
 Ggy
@@ -59653,7 +59866,7 @@ jRc
 jrE
 exG
 HJY
-Hnk
+VPQ
 mNl
 kWH
 OOH
@@ -60185,7 +60398,7 @@ bvN
 bvN
 bvN
 Hnc
-amd
+bvN
 RMU
 toK
 toK
@@ -60680,7 +60893,7 @@ KJd
 BwY
 JeA
 RXd
-mXf
+odk
 IaW
 iSN
 TpE
@@ -61467,7 +61680,7 @@ hPB
 egx
 kPi
 PkC
-Idm
+DIl
 kPS
 bvN
 RMU
@@ -61708,7 +61921,7 @@ MnO
 KJd
 DPz
 RXd
-WsE
+Wvb
 XHS
 dTA
 TpE
@@ -61724,7 +61937,7 @@ kPS
 iXm
 Wol
 PkC
-krp
+Idm
 kPS
 bvN
 RMU
@@ -61981,7 +62194,7 @@ VSw
 iLS
 GKh
 zlm
-LfI
+krp
 kPS
 bvN
 diw
@@ -64494,7 +64707,7 @@ toK
 toK
 toK
 vXg
-Pjt
+Pxz
 HtO
 VWd
 FlV
@@ -64751,7 +64964,7 @@ toK
 toK
 toK
 WaW
-Pxz
+Pjt
 HtO
 fIK
 vXg


### PR DESCRIPTION
[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)

Puts the armory on the other side of the brig, courtesy of Honkmainster. The armory no longer borders maintenance. Security's new biggest fear should be cargo heists. 

NEW: 

![space station 13 2017-05-14 182115](https://cloud.githubusercontent.com/assets/22532898/26039007/311c3a20-38d2-11e7-93ff-69d129f6cb4a.png)



:cl: IndusRobot
Add: [Aetherwhisp] New brig layout. The armory does not border with maintenance. 
/:cl:
