### PR TITLE
Late join fixery

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -529,7 +529,7 @@ SUBSYSTEM_DEF(job)
 		SendToAtom(M, pick(latejoin_trackers), buckle)
 	else
 		//bad mojo
-		var/area/shuttle/arrival/A = locate() in GLOB.sortedAreas
+		var/area/shuttle/ftl/hallway/secondary/entry/A = locate() in GLOB.sortedAreas
 		if(A)
 			//first check if we can find a chair
 			var/obj/structure/chair/C = locate() in A
@@ -546,7 +546,7 @@ SUBSYSTEM_DEF(job)
 					return
 
 		//pick an open spot on arrivals and dump em
-		var/list/arrivals_turfs = shuffle(get_area_turfs(/area/shuttle/arrival))
+		var/list/arrivals_turfs = shuffle(get_area_turfs(/area/shuttle/ftl/hallway/secondary/entry))
 		if(arrivals_turfs.len)
 			for(var/turf/T in arrivals_turfs)
 				if(!is_blocked_turf(T, TRUE))

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -194,8 +194,10 @@
 	name = "JoinLate"
 
 /obj/effect/landmark/latejoin/Initialize(mapload)
-	..()
-	SSjob.latejoin_trackers += loc
+	.=..()	
+	for(var/obj/structure/chair/C in get_turf(loc))
+		SSjob.latejoin_trackers += C
+	qdel(src)
 
 // carp.
 /obj/effect/landmark/carpspawn


### PR DESCRIPTION
JoinLate would give a turf as it's location, which would be immediately useless as it points to space when the ship shifts z level to dock. JoinLate landmarks now designate chairs like how arrival shuttles do, allowing you to choose unique places for people to spawn with them. Changed job code slightly to default to the entry hall area instead of the arrivals shuttle in it's emergency checks.

:cl: AuroranAI
fix: Fixed late joins, so centcom doesn't bluespace you slackers into space.
/:cl:


