### PR TITLE
hacky fix for ftl and shield gen

### DIFF
--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -43,7 +43,7 @@
 	throw_atom(AM)
 
 /turf/open/space/transit/proc/throw_atom(atom/movable/AM)
-	if(noop || !AM || istype(AM, /obj/docking_port))
+	if(noop || !AM || istype(AM, /obj/docking_port) || istype(AM, /obj/machinery)) //hacky fix until the real cause is found
 		return
 	var/max = world.maxx-TRANSITIONEDGE
 	var/min = 1+TRANSITIONEDGE


### PR DESCRIPTION
:cl: ninjanomnom
fix: Machines don't get lost when in transit space for now while we figure out why it causes the ftl and shields to be lost on jump.
/:cl:
