### PR TITLE
Shuttle lighting fix

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -500,7 +500,7 @@ SUBSYSTEM_DEF(shuttle)
 
 	for(var/i in new_transit_dock.assigned_turfs)
 		var/turf/T = i
-		T.ChangeTurf(transit_path)
+		T.ChangeTurf(transit_path, FALSE, FALSE, TRUE)
 		T.flags &= ~(UNUSED_TRANSIT_TURF)
 
 	M.assigned_transit = new_transit_dock

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -212,7 +212,7 @@
 	return ChangeTurf(path, defer_change, ignore_air)
 
 //Creates a new turf
-/turf/proc/ChangeTurf(path, defer_change = FALSE, ignore_air = FALSE)
+/turf/proc/ChangeTurf(path, defer_change = FALSE, ignore_air = FALSE, replace = FALSE)
 	if(!path)
 		return
 	if(!GLOB.use_preloader && path == type) // Don't no-op if the map loader requires it to be reconstructed
@@ -224,7 +224,8 @@
 	qdel(src)	//Just get the side effects and call Destroy
 	var/turf/W = new path(src)
 
-	W.baseturf = old_baseturf
+	if(!replace)
+		W.baseturf = old_baseturf
 
 	if(!defer_change)
 		W.AfterChange(ignore_air)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -204,8 +204,8 @@
 /obj/docking_port/stationary/transit/proc/dezone()
 	for(var/i in assigned_turfs)
 		var/turf/T = i
-		if(T.type == turf_type)
-			T.ChangeTurf(/turf/open/space)
+		if(istype(T.type, turf_type))
+			T.ChangeTurf(/turf/open/space, FALSE, FALSE, TRUE)
 			T.flags |= UNUSED_TRANSIT_TURF
 
 /obj/docking_port/stationary/transit/Destroy(force=FALSE)
@@ -522,6 +522,8 @@
 			continue
 		if(!T1)
 			continue
+		for(var/atom/movable/AM in T0)
+			AM.beforeShuttleMove(T1, rotation)
 		var/transfer_area = 1
 		if(T1.loc.type == cutout_extarea)
 			new cutout_newturf(T0)
@@ -553,7 +555,6 @@
 		//move mobile to new location
 		for(var/atom/movable/AM in T0)
 			if(AM.loc == T0) // So that we don't shift large objects.
-				AM.beforeShuttleMove(T1, rotation)
 				if(AM.onShuttleMove(T1, rotation, knockdown))
 					moved_atoms += AM
 		if(rotation)
@@ -582,10 +583,6 @@
 	//remove area surrounding docking port
 	for(var/turf/T0 in L0)
 		A0.contents += T0
-/obj/docking_port/mobile/proc/findTransitDock()
-	var/obj/docking_port/stationary/transit/T = SSshuttle.getDock("[id]_transit")
-	if(T && !canDock(T))
-		return T
 
 /obj/docking_port/mobile/proc/findRoundstartDock()
 	return SSshuttle.getDock(roundstart_move)


### PR DESCRIPTION
Spent all day looking at shuttle code again and had to track this bug down from ground zero by comparing turf vars before during and after transit. If anyone breaks this again and I have to fix it a third time they can go fix it themselves.

I also deleted an unused proc in shuttle.dm

Fixes #1024 

:cl: ninjanomnom
fix: Lights are fixed in the second jump onward now
/:cl: