### PR TITLE
Makes the SM ejectable.

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -124,6 +124,9 @@
 /obj/machinery/power/supermatter_shard/make_frozen_visual()
 	return
 
+/obj/machinery/power/supermatter_shard/experience_pressure_difference() // We eat matter for breakfast, gas shouldn't push us around
+	return
+
 /obj/machinery/power/supermatter_shard/Initialize()
 	. = ..()
 	SSair.atmos_machinery += src
@@ -516,7 +519,6 @@
 	desc = "A strangely translucent and iridescent crystal."
 	base_icon_state = "darkmatter"
 	icon_state = "darkmatter"
-	anchored = TRUE
 	gasefficency = 0.15
 	explosion_power = 35
 


### PR DESCRIPTION
The SM now is no longer effected by space wind, so it is ejectable. Removes the anchored var from the core as well, so the mass driver can throw it without needing admins to edit it. Makes the Core recoverable by dragging as a side effect of unanchoring it.
:cl: AuroranAI
tweak: The SM core is now ejectable, and no longer can be pushed around by space wind. 
/:cl:


