### PR TITLE
Fix Janicart and other ride-able entities

### DIFF
--- a/code/datums/riding.dm
+++ b/code/datums/riding.dm
@@ -86,6 +86,7 @@
 		if(!Process_Spacemove(direction) || !isturf(ridden.loc))
 			return
 		step(ridden, direction)
+		user.dir = ridden.dir //Why this isnt checked somewhere else is byond me
 
 		handle_vehicle_layer()
 		handle_vehicle_offsets()


### PR DESCRIPTION
Fixes #1091 

:cl: NIN
fix: Janicart and other rideable things update directions properly
/:cl:

Basically just forces any player riding on something to point in the same direction as the thing they are riding. Easy.