### PR TITLE
Initializes planets on load and makes mineral turfs use planet gen

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -190,6 +190,35 @@ SUBSYSTEM_DEF(mapping)
 	repopulate_sorted_areas()
 	SSstarmap.is_loading = 0
 
+/datum/controller/subsystem/mapping/proc/initialize_z_level(z_level)
+	var/list/obj/machinery/atmospherics/atmos_machines = list()
+	var/list/obj/structure/cable/cables = list()
+	var/list/atom/atoms = list()
+	var/list/area/areas = list()
+
+	for(var/L in block(locate(1, 1, z_level), locate(world.maxx, world.maxy, z_level)))
+		var/turf/B = L
+		atoms += B
+		if(!(B.loc in areas))
+			areas += B.loc
+		for(var/A in B)
+			atoms += A
+			if(istype(A,/obj/structure/cable))
+				cables += A
+				continue
+			if(istype(A,/obj/machinery/atmospherics))
+				atmos_machines += A
+			CHECK_TICK
+		CHECK_TICK
+
+	if(SSlighting.initialized)
+		for(var/A in areas)
+			var/area/thing = A
+			thing.set_dynamic_lighting(thing.dynamic_lighting) //refreshes the dynamic lighting so SSlighting knows to set it up
+	SSatoms.InitializeAtoms(atoms)
+	SSmachines.setup_template_powernets(cables)
+	SSair.setup_template_machinery(atmos_machines)
+
 /datum/controller/subsystem/mapping/proc/add_z_to_planet(var/datum/planet/PL, var/load_name, var/params = null)
 	var/datum/planet_loader/map_name = load_name
 	message_admins("BOARD MAP LOAD TEST: [map_name]")

--- a/code/datums/planet_loader/planet_loader.dm
+++ b/code/datums/planet_loader/planet_loader.dm
@@ -23,7 +23,6 @@
 			GLOB.maploader.load_map(file, 1, 1, z_level)
 		else
 			return 0
-	SSmapping.mineral_spawn_override = null
 
 	for(var/obj/effect/landmark/L in GLOB.landmarks_list)
 		if(copytext(L.name, 1, 8) == "ftldock" && L.z == z_level)
@@ -42,8 +41,11 @@
 	if(ruins_args.len)
 		seedRuins(list(z_level), ruins_args[1], ruins_args[2], ruins_args[3])
 
-	smooth_zlevel(z_level)
 	if(SSlighting.initialized)
 		SSlighting.create_all_z_lighting_objects(z_level)
+	SSmapping.initialize_z_level(z_level)
+	smooth_zlevel(z_level)
+
+	SSmapping.mineral_spawn_override = null
 
 	return 1

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -156,7 +156,11 @@
 		icon_state = display_icon_state
 	..()
 	if (prob(mineralChance))
-		var/path = pickweight(mineralSpawnChanceList)
+		var/path
+		if(SSmapping && SSmapping.mineral_spawn_override)
+			path = pickweight(SSmapping.mineral_spawn_override)
+		else
+			path = pickweight(mineralSpawnChanceList)
 		var/turf/T = ChangeTurf(path,FALSE,TRUE)
 
 		if(T && ismineralturf(T))

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -20,27 +20,6 @@
 		height = bounds[MAP_MAXY]
 	return bounds
 
-/datum/map_template/proc/initTemplateBounds(var/list/bounds)
-	var/list/obj/machinery/atmospherics/atmos_machines = list()
-	var/list/obj/structure/cable/cables = list()
-	var/list/atom/atoms = list()
-
-	for(var/L in block(locate(bounds[MAP_MINX], bounds[MAP_MINY], bounds[MAP_MINZ]),
-	                   locate(bounds[MAP_MAXX], bounds[MAP_MAXY], bounds[MAP_MAXZ])))
-		var/turf/B = L
-		atoms += B
-		for(var/A in B)
-			atoms += A
-			if(istype(A,/obj/structure/cable))
-				cables += A
-				continue
-			if(istype(A,/obj/machinery/atmospherics))
-				atmos_machines += A
-
-	SSatoms.InitializeAtoms(atoms)
-	SSmachines.setup_template_powernets(cables)
-	SSair.setup_template_machinery(atmos_machines)
-
 /datum/map_template/proc/load_new_z()
 	var/x = round(world.maxx/2)
 	var/y = round(world.maxy/2)
@@ -52,8 +31,6 @@
 	smooth_zlevel(world.maxz)
 	repopulate_sorted_areas()
 
-	//initialize things that are normally initialized after map load
-	initTemplateBounds(bounds)
 	log_game("Z-level [name] loaded at at [x],[y],[world.maxz]")
 
 /datum/map_template/proc/load(turf/T, centered = FALSE)
@@ -73,8 +50,6 @@
 	if(!SSmapping.loading_ruins) //Will be done manually during mapping ss init
 		repopulate_sorted_areas()
 	
-	//initialize things that are normally initialized after map load
-	initTemplateBounds(bounds)
 
 	log_game("[name] loaded at at [T.x],[T.y],[T.z]")
 	return TRUE


### PR DESCRIPTION
:cl: ninjanomnom
fix: You can click on stations and planets once more
fix: Mineral turfs gen ore correctly
fix: Landmarks work correctly now
/:cl:

![dreamseeker_2017-06-20_09-14-17](https://user-images.githubusercontent.com/1234602/27335450-6d03ed64-559a-11e7-92b4-fbef9a3e5e42.png)

These bugs were a result of the New() to Initialize() transition

Fixes #1065 