### PR TITLE
Station Goal Typos Fix. Take 2.

### DIFF
--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -7,9 +7,9 @@
 
 /datum/station_goal/bluespace_cannon/get_report()
 	return {"Our military presence is inadequate in your sector.
-	 We need you to construct BSA-[rand(1,99)] Artillery position aboard your station.
+	 We need you to construct BSA-[rand(1,99)] Artillery position aboard your ship.
 
-	 Base parts are available for shipping via cargo.
+	 Base parts are available for shipping via cargo at certain stations.
 	 -Nanotrasen Naval Command"}
 
 /datum/station_goal/bluespace_cannon/on_report()

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -33,14 +33,14 @@
 
 /datum/station_goal/dna_vault/get_report()
 	return {"Our long term prediction systems indicate a 99% chance of system-wide cataclysm in the near future.
-	 We need you to construct a DNA Vault aboard your station.
+	 We need you to construct a DNA Vault aboard your ship.
 
 	 The DNA Vault needs to contain samples of:
 	 [animal_count] unique animal data
 	 [plant_count] unique non-standard plant data
 	 [human_count] unique sapient humanoid DNA data
 
-	 Base vault parts are available for shipping via cargo."}
+	 Base vault parts are available for shipping via cargo at certain stations."}
 
 
 /datum/station_goal/dna_vault/on_report()

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -6,10 +6,10 @@
 	var/coverage_goal = 500
 
 /datum/station_goal/station_shield/get_report()
-	return {"The station is located in a zone full of space debris.
+	return {"The ship is located in a zone full of space debris and asteroids.
 			 We have a prototype shielding system you must deploy to reduce collision-related accidents.
 
-			 You can order the satellites and control systems at cargo.
+			 You can order the satellites and control systems at cargo at specific stations.
 			 "}
 
 

--- a/code/modules/station_goals/station_goal.dm
+++ b/code/modules/station_goals/station_goal.dm
@@ -28,9 +28,9 @@
 
 /datum/station_goal/proc/print_result()
 	if(check_completion())
-		to_chat(world, "<b>Station Goal</b> : [name] :  <span class='greenannounce'>Completed!</span>")
+		to_chat(world, "<b>Ship Goal</b> : [name] :  <span class='greenannounce'>Completed!</span>")
 	else
-		to_chat(world, "<b>Station Goal</b> : [name] : <span class='boldannounce'>Failed!</span>")
+		to_chat(world, "<b>Ship Goal</b> : [name] : <span class='boldannounce'>Failed!</span>")
 
 /datum/station_goal/Destroy()
 	SSticker.mode.station_goals -= src


### PR DESCRIPTION
:cl:
fix: All station references in Station Goals have been changed to Ship.
add: Cargo now refers to Cargo on certain stations. Fits the theme.
/:cl:

This makes it part of FTL13 now instead of some leftover from TGstation.