### PR TITLE
Radio Channel Color Fixes

### DIFF
--- a/code/game/communications.dm
+++ b/code/game/communications.dm
@@ -160,8 +160,8 @@ GLOBAL_VAR_CONST(SYND_FREQ, 1213) //nuke op frequency, coloured dark brown in ch
 GLOBAL_VAR_CONST(SUPP_FREQ, 1347) //supply, coloured light brown in chat window
 GLOBAL_VAR_CONST(SERV_FREQ, 1349) //service, coloured green in chat window
 GLOBAL_VAR_CONST(SCI_FREQ, 1351) //science, coloured plum in chat window
-GLOBAL_VAR_CONST(COMM_FREQ, 1353) //command, colored gold in chat window
-GLOBAL_VAR_CONST(MED_FREQ, 1355) //medical, coloured blue in chat window
+GLOBAL_VAR_CONST(COMM_FREQ, 1353) //command, coloured dark blue in chat window
+GLOBAL_VAR_CONST(MED_FREQ, 1355) //medical, coloured light blue in chat window
 GLOBAL_VAR_CONST(ENG_FREQ, 1357) //engineering, coloured orange in chat window
 GLOBAL_VAR_CONST(SEC_FREQ, 1359) //security, coloured red in chat window
 GLOBAL_VAR_CONST(CENTCOM_FREQ, 1337) //centcom frequency, coloured grey in chat window

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -244,11 +244,11 @@ em						{font-style: normal;	font-weight: bold;}
 .deadsay				{color: #5c00e6;}
 .radio					{color: #008000;}
 .sciradio				{color: #993399;}
-.comradio				{color: #020994;}
-.secradio				{color: #a30000;}
-.medradio				{color: #337296;}
-.engradio				{color: #fb5613;}
-.suppradio				{color: #a8732b;}
+.comradio				{color: #193A7A;}
+.secradio				{color: #A30000;}
+.medradio				{color: #008160;}
+.engradio				{color: #A66300;}
+.suppradio				{color: #5F4519;}
 .servradio				{color: #6eaa2c;}
 .syndradio				{color: #6d3f40;}
 .centcomradio			{color: #686868;}

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -244,7 +244,7 @@ em						{font-style: normal;	font-weight: bold;}
 .deadsay				{color: #5c00e6;}
 .radio					{color: #008000;}
 .sciradio				{color: #993399;}
-.comradio				{color: #948f02;}
+.comradio				{color: #020994;}
 .secradio				{color: #a30000;}
 .medradio				{color: #337296;}
 .engradio				{color: #fb5613;}

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -246,7 +246,7 @@ em						{font-style: normal;	font-weight: bold;}
 .centradio				{color: #686868;}
 
 .aiprivradio			{color: #ff00ff;}
-.comradio				{color: #948f02;}
+.comradio				{color: #020994;}
 
 .secradio				{color: #a30000;}
 .engradio				{color: #fb5613;}

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -246,13 +246,13 @@ em						{font-style: normal;	font-weight: bold;}
 .centradio				{color: #686868;}
 
 .aiprivradio			{color: #ff00ff;}
-.comradio				{color: #020994;}
+.comradio				{color: #193A7A;}
 
-.secradio				{color: #a30000;}
-.engradio				{color: #fb5613;}
-.medradio				{color: #337296;}
+.secradio				{color: #A30000;}
+.engradio				{color: #A66300;}
+.medradio				{color: #008160;}
 .sciradio				{color: #993399;}
-.supradio				{color: #a8732b;}
+.supradio				{color: #5F4519;}
 .servadio				{color: #6eaa2c;}
 
 .attack					{color: #ff0000;}

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -38,11 +38,11 @@ em						{font-style: normal;	font-weight: bold;}
 .deadsay				{color: #5c00e6;}
 .radio					{color: #008000;}
 .sciradio				{color: #993399;}
-.comradio				{color: #020994;}
-.secradio				{color: #a30000;}
-.medradio				{color: #337296;}
-.engradio				{color: #fb5613;}
-.suppradio				{color: #a8732b;}
+.comradio				{color: #193A7A;}
+.secradio				{color: #A30000;}
+.medradio				{color: #008160;}
+.engradio				{color: #A66300;}
+.suppradio				{color: #5F4519;}
 .servradio				{color: #6eaa2c;}
 .syndradio				{color: #6d3f40;}
 .centcomradio			{color: #686868;}

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -38,7 +38,7 @@ em						{font-style: normal;	font-weight: bold;}
 .deadsay				{color: #5c00e6;}
 .radio					{color: #008000;}
 .sciradio				{color: #993399;}
-.comradio				{color: #948f02;}
+.comradio				{color: #020994;}
 .secradio				{color: #a30000;}
 .medradio				{color: #337296;}
 .engradio				{color: #fb5613;}


### PR DESCRIPTION
🆑 
typo: Distinguished between the Medradio lighter blue and Comradio darker blue in comment.
fix: Changes tg radio channel colors to pre-rebase FTL colors.
/ :cl:

Hopefully fixes #1069 