### PR TITLE
Random Station Name Fix

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -59,7 +59,7 @@ GLOBAL_VAR(command_name)
 		var/newname
 		if(config && config.station_name)
 			newname = config.station_name
-		else
+		else if(config)
 			newname = new_station_name()
 
 		set_station_name(newname)


### PR DESCRIPTION
:cl: 
fix: Checks to make sure config exists before deciding to generate a random name.
/:cl:

Hopefully fixes #1075 