### PR TITLE
Fixes #1539 crew monitoring computer can now be interacted with again

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -15,6 +15,7 @@
 	return ..()
 
 /obj/machinery/computer/crew/Initialize()
+	. = ..() // Remember to call base on descendants of /obj in Initialize
 	GLOB.crewmonitor.setupOffset()	//By now the port should be registered
 
 	light_color = LIGHT_COLOR_BLUE


### PR DESCRIPTION
This fixes the crew monitoring station computer not being able to be clicked on (open, dismantled etc). It failed to call the base in the Initialize() proc which was causing this issue.

Note this does not fix potential issues with the minimap not being shown or potential issues with mob offsets!