### PR TITLE
Radios now report the job title.

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -71,7 +71,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	return ""
 
 /atom/movable/proc/compose_job(atom/movable/speaker, message_langs, raw_message, radio_freq)
-	return ""
+	return "[" (" + speaker.GetJob() + ")"]"
 
 /atom/movable/proc/say_mod(input, message_mode)
 	var/ending = copytext(input, length(input))

--- a/code/modules/mob/say_readme.dm
+++ b/code/modules/mob/say_readme.dm
@@ -93,7 +93,7 @@ global procs
 		Composes the href tags used by the AI for tracking. Returns "" for all mobs except AIs.
 
 	compose_job(message, atom/movable/speaker, message_langs, raw_message, radio_freq)
-		Composes the job and the end tag for tracking hrefs. Returns "" for all mobs except AIs.
+		Composes the job and the end tag for tracking hrefs. Returns only job title string for all mobs except AIs.
 
 	hivecheck()
 		Returns 1 if the mob can hear and talk in the alien hivemind.


### PR DESCRIPTION
:cl: Kmsxkuse
add: Radios now report job title of the person speaking.
/:cl:

Surprisingly enough, the framework was already in the code for this. It was just hard trying to find it.
