### PR TITLE
Refactors inflatable cases, removes pen/paper from them

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -238,8 +238,7 @@
 	max_combined_w_class = 21
 	w_class = 3
 
-/obj/item/weapon/storage/briefcase/inflatable/New()
-	..()
+/obj/item/weapon/storage/briefcase/inflatable/PopulateContents()
 	new /obj/item/inflatable/door(src)
 	new /obj/item/inflatable/door(src)
 	new /obj/item/inflatable/door(src)


### PR DESCRIPTION
Moves the new() override to PopulateContents like the rest of the briefcase family. Removes a ..() call on it, so it doesn't spawn with a pen and paper. 

Legally, closes #1535

:cl: AuroranAI
del: Removed pen and folder from inflatable briefcases.
/:cl:
