### PR TITLE
muh lights

### DIFF
--- a/code/game/objects/effects/shipprojectiles.dm
+++ b/code/game/objects/effects/shipprojectiles.dm
@@ -42,6 +42,7 @@
 
 /obj/effect/temp_visual/ship_target/New(var/turf/T, var/datum/ship_attack/A)
 	playsound(T, 'sound/effects/hit_warning.ogg',100,0)
+	set_light(5, 15, "#ff0000")
 	spawn(30)
 		new /obj/effect/temp_visual/shipprojectile(T, A) //spawns the projectile after 3 seconds
 	spawn(50)


### PR DESCRIPTION
this expression indicates an ecolli's confusion and lack of understanding. When confronted with something he can not understand or respond to, ecolli mumbes "muh lights" or "muh lights muthafucka". This is usually followed by spouting out overscoped ideas and pictures of AAA games.

https://i.gyazo.com/9e408ed4535b4f0680fef08eeb66b1a9.mp4

:cl: floyd
add: Enemy targeting displays now blind your eyes with red light so if you still die to them I'm sorry but you're braindead
/:cl: