### PR TITLE
MIRROR PR: Made cell / holding cell windoors their own subtype 

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -310,6 +310,15 @@
 	reinf = 1
 	explosion_block = 1
 
+/obj/machinery/door/window/brigdoor/security/cell
+	name = "cell door"
+	desc = "For keeping in criminal scum."
+	req_access = list(ACCESS_BRIG)
+
+/obj/machinery/door/window/brigdoor/security/holding
+	name = "holding cell door"
+	req_access = list(ACCESS_SEC_DOORS, ACCESS_LAWYER) //love for the lawyer
+
 /obj/machinery/door/window/clockwork
 	name = "brass windoor"
 	desc = "A thin door with translucent brass paneling."
@@ -421,6 +430,70 @@
 	base_state = "rightsecure"
 
 /obj/machinery/door/window/brigdoor/southright
+	dir = SOUTH
+	icon_state = "rightsecure"
+	base_state = "rightsecure"
+
+/obj/machinery/door/window/brigdoor/security/cell/northleft
+	dir = NORTH
+
+/obj/machinery/door/window/brigdoor/security/cell/eastleft
+	dir = EAST
+
+/obj/machinery/door/window/brigdoor/security/cell/westleft
+	dir = WEST
+
+/obj/machinery/door/window/brigdoor/security/cell/southleft
+	dir = SOUTH
+
+/obj/machinery/door/window/brigdoor/security/cell/northright
+	dir = NORTH
+	icon_state = "rightsecure"
+	base_state = "rightsecure"
+
+/obj/machinery/door/window/brigdoor/security/cell/eastright
+	dir = EAST
+	icon_state = "rightsecure"
+	base_state = "rightsecure"
+
+/obj/machinery/door/window/brigdoor/security/cell/westright
+	dir = WEST
+	icon_state = "rightsecure"
+	base_state = "rightsecure"
+
+/obj/machinery/door/window/brigdoor/security/cell/southright
+	dir = SOUTH
+	icon_state = "rightsecure"
+	base_state = "rightsecure"
+
+/obj/machinery/door/window/brigdoor/security/holding/northleft
+	dir = NORTH
+
+/obj/machinery/door/window/brigdoor/security/holding/eastleft
+	dir = EAST
+
+/obj/machinery/door/window/brigdoor/security/holding/westleft
+	dir = WEST
+
+/obj/machinery/door/window/brigdoor/security/holding/southleft
+	dir = SOUTH
+
+/obj/machinery/door/window/brigdoor/security/holding/northright
+	dir = NORTH
+	icon_state = "rightsecure"
+	base_state = "rightsecure"
+
+/obj/machinery/door/window/brigdoor/security/holding/eastright
+	dir = EAST
+	icon_state = "rightsecure"
+	base_state = "rightsecure"
+
+/obj/machinery/door/window/brigdoor/security/holding/westright
+	dir = WEST
+	icon_state = "rightsecure"
+	base_state = "rightsecure"
+
+/obj/machinery/door/window/brigdoor/security/holding/southright
 	dir = SOUTH
 	icon_state = "rightsecure"
 	base_state = "rightsecure"

--- a/ftl13.dme
+++ b/ftl13.dme
@@ -22,6 +22,7 @@
 #include "code\__DATASTRUCTURES\linked_lists.dm"
 #include "code\__DATASTRUCTURES\priority_queue.dm"
 #include "code\__DATASTRUCTURES\stacks.dm"
+#include "code\__DEFINES\access.dm"
 #include "code\__DEFINES\admin.dm"
 #include "code\__DEFINES\antagonists.dm"
 #include "code\__DEFINES\atmospherics.dm"


### PR DESCRIPTION
Original pr:
"Updated all the cells doors & holding doors to their own subtype

Fixes #29272
Fixes #29287"

This has one extra addiction, which was to add the access define back to the .dme. For some reason it wasn't in my own DME and it fixed the error? Wait for travis to compile and see if it's fixed, i might need to include the access file which i just copy and pasted from thegithub. 
No map changes in this PR.

Closes #1617