### PR TITLE
Bridge Officer has his own headset now

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -103,17 +103,11 @@
 	icon_state = "xo_cypherkey"
 	channels = list("Supply" = 1, "Service" = 1, "Command" = 1)
 
-/obj/item/device/encryptionkey/heads/weapons
-	name ="\proper the weapons officer's encryption key"
-	desc = "An encryption key for a radio headset.  Channels are as follows: :u - supply, :c - command."
-	icon_state = "xo_cypherkey"
-	channels = list("Command" = 1, "Supply" = 1)
-
-/obj/item/device/encryptionkey/heads/helms
-	name = "\proper the helms officer's encryption key"
-	desc = "An encryption key for a radio headset.  Channels are as follows: :e - engineering, :c - command."
-	icon_state = "xo_cypherkey"
-	channels = list("Command" = 1, "Engineering" = 1)
+/obj/item/device/encryptionkey/heads/bo
+			name = "\proper bridge officer's encryption key"
+			desc = "An encryption key for a radio headset.  Channels are as follows: :c - command, :e - engineering, :u - supply."
+			icon_state = "xo_cypherkey"
+			channels = list("Command" = 1, "Engineering" = 1, "Supply" = 1)
 
 /obj/item/device/encryptionkey/headset_cargo
 	name = "supply radio encryption key"

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -104,10 +104,10 @@
 	channels = list("Supply" = 1, "Service" = 1, "Command" = 1)
 
 /obj/item/device/encryptionkey/heads/bo
-			name = "\proper bridge officer's encryption key"
-			desc = "An encryption key for a radio headset.  Channels are as follows: :c - command, :e - engineering, :u - supply."
-			icon_state = "xo_cypherkey"
-			channels = list("Command" = 1, "Engineering" = 1, "Supply" = 1)
+	name = "\proper bridge officer's encryption key"
+	desc = "An encryption key for a radio headset.  Channels are as follows: :c - command, :e - engineering, :u - supply."
+	icon_state = "xo_cypherkey"
+	channels = list("Command" = 1, "Engineering" = 1, "Supply" = 1)
 
 /obj/item/device/encryptionkey/headset_cargo
 	name = "supply radio encryption key"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -179,21 +179,13 @@
 	item_state = "com_headset_alt"
 	keyslot = new /obj/item/device/encryptionkey/heads/xo
 
-/obj/item/device/radio/headset/heads/weapons
-	name ="\proper the weapons officer's headset"
-	desc ="The headset of the guy who gets to press buttons and make pewpew noises. \nChannels are as follows: :u - supply, :c - command."
-	icon_state = "com_heaset"
-	icon_state = "com_headset_alt"
-	item_state = "com_headset_alt"
-	keyslot = new /obj/item/device/encryptionkey/heads/weapons
-
-/obj/item/device/radio/headset/heads/helms
-	name ="\proper the helms officer's headset"
-	desc ="The headset of the ships designated driver. \nChannels are as follows: :e - engineering, :c - command."
-	icon_state = "com_heaset"
-	icon_state = "com_headset_alt"
-	item_state = "com_headset_alt"
-	keyslot = new /obj/item/device/encryptionkey/heads/helms
+/obj/item/device/radio/headset/heads/bo
+			name ="\proper the bridge officer's headset"
+			desc ="\The headset of the guy who gets to press buttons and make the ship do stuff"
+			icon_state = "com_heaset"
+			icon_state = "com_headset_alt"
+			item_state = "com_headset_alt"
+			keyslot = new /obj/item/device/encryptionkey/heads/bo
 
 /obj/item/device/radio/headset/headset_cargo
 	name = "supply radio headset"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -180,12 +180,12 @@
 	keyslot = new /obj/item/device/encryptionkey/heads/xo
 
 /obj/item/device/radio/headset/heads/bo
-			name ="\proper the bridge officer's headset"
-			desc ="\The headset of the guy who gets to press buttons and make the ship do stuff"
-			icon_state = "com_heaset"
-			icon_state = "com_headset_alt"
-			item_state = "com_headset_alt"
-			keyslot = new /obj/item/device/encryptionkey/heads/bo
+	name ="\proper the bridge officer's headset"
+	desc ="\The headset of the guy who gets to press buttons and make the ship do stuff"
+	icon_state = "com_heaset"
+	icon_state = "com_headset_alt"
+	item_state = "com_headset_alt"
+	keyslot = new /obj/item/device/encryptionkey/heads/bo
 
 /obj/item/device/radio/headset/headset_cargo
 	name = "supply radio headset"

--- a/code/modules/jobs/job_types/bridge.dm
+++ b/code/modules/jobs/job_types/bridge.dm
@@ -21,12 +21,12 @@ Bridge Officer
 
 GLOBAL_LIST_INIT(posts, list("weapons", "helms"))
 
-/datum/outfit/job/bofficer //utilizes XO headset for now
+/datum/outfit/job/bofficer //Uses his own headset now
 	name = "Bridge Officer"
 
 	belt = /obj/item/device/pda/heads/bo //if you ever change this, remove the part that references it below
 	glasses = /obj/item/clothing/glasses/sunglasses
-	ears = /obj/item/device/radio/headset/heads/xo
+	ears = /obj/item/device/radio/headset/heads/bo
 	uniform =  /obj/item/clothing/under/rank/bofficer
 	shoes = /obj/item/clothing/shoes/laceup
 	head = /obj/item/clothing/head/bofficer
@@ -50,11 +50,9 @@ GLOBAL_LIST_INIT(posts, list("weapons", "helms"))
       if("weapons")
         post_access = list(ACCESS_WEAPONS_CONSOLE)
         spawn_point = locate(/obj/effect/landmark/start/bo/weapons) in GLOB.department_command_spawns
-        ears = /obj/item/device/radio/headset/heads/weapons
       if("helms")
         post_access = list(ACCESS_HELMS_CONSOLE)
         spawn_point = locate(/obj/effect/landmark/start/bo/helms) in GLOB.department_command_spawns
-        ears = /obj/item/device/radio/headset/heads/helms
 
 /datum/outfit/job/bofficer/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()


### PR DESCRIPTION
Changed Bridge Officer having XO's headset to having his own. Both officers now have access to Engineering, Command and Supply, they can now more effectively do the other BO's job if he's not present

/🆑 Changelog
add: Bridge Officer's Headset
add: Merged the two different before headsets into one with the same channels combined
fix: Replaces XO's headset with BO's headset for Bridge Officers
🆑/

[why]: I think it should be added, because of the sole fact Bridge Officer doesn't have his headset. Also about both of them having the same one is because they can now effectively do the other's officer job if he's absent and coordinate with the departments. Tested without errors