### PR TITLE
Fixes ships being unable to shoot at players, and players being unable to shoot back

### DIFF
--- a/code/controllers/subsystem/ships.dm
+++ b/code/controllers/subsystem/ships.dm
@@ -28,17 +28,17 @@ SUBSYSTEM_DEF(ship)
 
 
 /datum/controller/subsystem/ship/proc/init_datums()
-	var/list/factions = typesof(/datum/star_faction) - /datum/star_faction
+	var/list/factions = subtypesof(/datum/star_faction)
 
 	for(var/i in factions)
 		star_factions += new i
 
-	var/list/ship_components = typesof(/datum/ship_component) - /datum/ship_component
+	var/list/ship_components_paths = subtypesof(/datum/ship_component)
 
-	for(var/i in ship_components)
+	for(var/i in ship_components_paths)
 		ship_components += new i
 
-	var/list/ships = typesof(/datum/starship) - /datum/starship
+	var/list/ships = subtypesof(/datum/starship)
 
 	for(var/i in ships)
 		ship_types += new i

--- a/code/game/machinery/computer/ftl_weapons.dm
+++ b/code/game/machinery/computer/ftl_weapons.dm
@@ -127,7 +127,7 @@
 		if(target)
 			data["target"] = target.name
 			var/list/ship_components_list = list()
-			data["ship_components"] = ship_components_list
+			data["components"] = ship_components_list
 			for(var/cy in 1 to target.y_num)
 				var/list/row = list()
 				ship_components_list[++ship_components_list.len] = list("row" = row)


### PR DESCRIPTION
Ship components now generates it's datum list properly, and the tactical console now properly gets the component list.
Also did a wee bit of tidying up while i was here, and turned some typesof into subtypesof.
:cl: AuroranAI
fix: The Space Christmas Truce of 2914 is now over. Get back to work.
/:cl:

