### PR TITLE
Changes to ERT headsets

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -144,30 +144,35 @@
 	name = "Centcom commander radio encryption key"
 	desc = "An encryption key for a radio headset"
 	icon_state = "cent_cypherkey"
+	independent = TRUE
 	channels = list("Centcom" = 1, "Command" = 1, "Security" = 1, "Engineering" = 1, "Medical" = 1 )
 
 /obj/item/device/encryptionkey/headset_ert_med
 	name = "Centcom medic radio encryption key"
 	desc = "An encryption key for a radio headset"
 	icon_state = "cent_cypherkey"
+	independent = TRUE
 	channels = list("Centcom"= 1, "Medical" = 1)
 
 /obj/item/device/encryptionkey/headset_ert_sec
 	name = "Centcom security officer radio encryption key"
 	desc = "An encryption key for a radio headset"
 	icon_state = "cent_cypherkey"
+	independent = TRUE
 	channels = list("Centcom" = 1, "Security" = 1)
 
 /obj/item/device/encryptionkey/headset_ert_eng
 	name = "Centcom engineer radio encryption key"
 	desc = "An encryption key for a radio headset"
 	icon_state = "cent_cypherkey"
+	independent = TRUE
 	channels = list("Centcom" = 1, "Engineering" = 1)
 
 /obj/item/device/encryptionkey/headset_ert_common
 	name = "Centcom officer radio encryption key"
 	desc = "An encryption key for a radio headset"
 	icon_state = "cent_cypherkey"
+	independent = TRUE
 	channels = list("Centcom" = 1)
 
 /obj/item/device/encryptionkey/ai //ported from NT, this goes 'inside' the AI.

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -140,6 +140,36 @@
 	independent = TRUE
 	channels = list("Centcom" = 1)
 
+/obj/item/device/encryptionkey/headset_ert_commander
+	name = "Centcom commander radio encryption key"
+	desc = "An encryption key for a radio headset"
+	icon_state = "cent_cypherkey"
+	channels = list("Centcom" = 1, "Command" = 1, "Security" = 1, "Engineering" = 1, "Medical" = 1 )
+
+/obj/item/device/encryptionkey/headset_ert_med
+	name = "Centcom medic radio encryption key"
+	desc = "An encryption key for a radio headset"
+	icon_state = "cent_cypherkey"
+	channels = list("Centcom"= 1, "Medical" = 1)
+
+/obj/item/device/encryptionkey/headset_ert_sec
+	name = "Centcom security officer radio encryption key"
+	desc = "An encryption key for a radio headset"
+	icon_state = "cent_cypherkey"
+	channels = list("Centcom" = 1, "Security" = 1)
+
+/obj/item/device/encryptionkey/headset_ert_eng
+	name = "Centcom engineer radio encryption key"
+	desc = "An encryption key for a radio headset"
+	icon_state = "cent_cypherkey"
+	channels = list("Centcom" = 1, "Engineering" = 1)
+
+/obj/item/device/encryptionkey/headset_ert_common
+	name = "Centcom officer radio encryption key"
+	desc = "An encryption key for a radio headset"
+	icon_state = "cent_cypherkey"
+	channels = list("Centcom" = 1)
+
 /obj/item/device/encryptionkey/ai //ported from NT, this goes 'inside' the AI.
 	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "Science" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1, "AI Private" = 1)
 

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -141,35 +141,35 @@
 	channels = list("Centcom" = 1)
 
 /obj/item/device/encryptionkey/headset_ert_commander
-	name = "Centcom commander radio encryption key"
+	name = "\improper centcom commander radio encryption key"
 	desc = "An encryption key for a radio headset"
 	icon_state = "cent_cypherkey"
 	independent = TRUE
 	channels = list("Centcom" = 1, "Command" = 1, "Security" = 1, "Engineering" = 1, "Medical" = 1 )
 
 /obj/item/device/encryptionkey/headset_ert_med
-	name = "Centcom medic radio encryption key"
+	name = "\improper centcom medic radio encryption key"
 	desc = "An encryption key for a radio headset"
 	icon_state = "cent_cypherkey"
 	independent = TRUE
 	channels = list("Centcom"= 1, "Medical" = 1)
 
 /obj/item/device/encryptionkey/headset_ert_sec
-	name = "Centcom security officer radio encryption key"
+	name = "\improper centcom security officer radio encryption key"
 	desc = "An encryption key for a radio headset"
 	icon_state = "cent_cypherkey"
 	independent = TRUE
 	channels = list("Centcom" = 1, "Security" = 1)
 
 /obj/item/device/encryptionkey/headset_ert_eng
-	name = "Centcom engineer radio encryption key"
+	name = "\improper centcom engineer radio encryption key"
 	desc = "An encryption key for a radio headset"
 	icon_state = "cent_cypherkey"
 	independent = TRUE
 	channels = list("Centcom" = 1, "Engineering" = 1)
 
 /obj/item/device/encryptionkey/headset_ert_common
-	name = "Centcom officer radio encryption key"
+	name = "\improper centcom officer radio encryption key"
 	desc = "An encryption key for a radio headset"
 	icon_state = "cent_cypherkey"
 	independent = TRUE

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -134,42 +134,42 @@
 	channels = list("Service" = 1)
 
 /obj/item/device/encryptionkey/headset_cent
-	name = "centcom radio encryption key"
-	desc = "An encryption key for a radio headset.  To access the centcom channel, use :y."
+	name = "Centcom radio encryption key"
+	desc = "An encryption key for a radio headset.  To access the Centcom channel, use :y."
 	icon_state = "cent_cypherkey"
 	independent = TRUE
 	channels = list("Centcom" = 1)
 
 /obj/item/device/encryptionkey/headset_ert_commander
-	name = "\improper centcom commander radio encryption key"
+	name = "\improper Centcom commander radio encryption key"
 	desc = "An encryption key for a radio headset"
 	icon_state = "cent_cypherkey"
 	independent = TRUE
 	channels = list("Centcom" = 1, "Command" = 1, "Security" = 1, "Engineering" = 1, "Medical" = 1 )
 
 /obj/item/device/encryptionkey/headset_ert_med
-	name = "\improper centcom medic radio encryption key"
+	name = "\improper Centcom medic radio encryption key"
 	desc = "An encryption key for a radio headset"
 	icon_state = "cent_cypherkey"
 	independent = TRUE
 	channels = list("Centcom"= 1, "Medical" = 1)
 
 /obj/item/device/encryptionkey/headset_ert_sec
-	name = "\improper centcom security officer radio encryption key"
+	name = "\improper Centcom security officer radio encryption key"
 	desc = "An encryption key for a radio headset"
 	icon_state = "cent_cypherkey"
 	independent = TRUE
 	channels = list("Centcom" = 1, "Security" = 1)
 
 /obj/item/device/encryptionkey/headset_ert_eng
-	name = "\improper centcom engineer radio encryption key"
+	name = "\improper Centcom engineer radio encryption key"
 	desc = "An encryption key for a radio headset"
 	icon_state = "cent_cypherkey"
 	independent = TRUE
 	channels = list("Centcom" = 1, "Engineering" = 1)
 
 /obj/item/device/encryptionkey/headset_ert_common
-	name = "\improper centcom officer radio encryption key"
+	name = "\improper Centcom officer radio encryption key"
 	desc = "An encryption key for a radio headset"
 	icon_state = "cent_cypherkey"
 	independent = TRUE

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -223,12 +223,36 @@
 /obj/item/device/radio/headset/headset_cent/commander
 	keyslot = new /obj/item/device/encryptionkey/heads/captain
 
-/obj/item/device/radio/headset/headset_cent/alt
+/obj/item/device/radio/headset/headset_cent/ert
 	name = "\improper Centcom bowman headset"
 	desc = "A headset especially for emergency response personnel. Protects ears from flashbangs. \nTo access the centcom channel, use :y."
 	icon_state = "cent_headset_alt"
 	item_state = "cent_headset_alt"
 	keyslot = null
+
+/obj/item/device/radio/headset/headset_ert_commander
+	name = "\improper Centcom headset"
+	desc ="A headset especially for the emergency respone team commander. \nTo access the centcom channel, use :y. For command, use :c. For security, use :s. For medical, use :m. For engineering, :e."
+	icon_state = "cent_headset"
+	keyslot = new /obj/item/device/encryptionkey/headset_ert_commander
+
+/obj/item/device/radio/headset/headset_ert_med
+	name = "\improper Centcom bowman headset"
+	desc = "A headset especially for the emergency respone team medical crew. \nTo access the centcom channel, use :y. For medical, use :m"
+	icon_state = "cent_headset_alt"
+	keyslot = new /obj/item/device/encryptionkey/headset_ert_med
+
+/obj/item/device/radio/headset/headset_ert_eng
+	name = "\improper Centcom bowman headset"
+	desc = "A headset especially for the response team engineering crew. \nTo access the centcom channel, use :y. For engineering, use :e."
+	icon_state = "cent_headset_alt"
+	keyslot = new /obj/item/device/encryptionkey/headset_ert_eng
+
+/obj/item/device/radio/headset/headset_ert_sec
+	name = "\improper Centcom bowman headset"
+	desc = "A headset especially for the emergency response team security officers. \nTo access the centcom channel, use :y. For security, use :s."
+	icon_state = "cent_headset_alt"
+	keyslot = new /obj/item/device/encryptionkey/headset_ert_sec
 
 /obj/item/device/radio/headset/headset_cent/alt/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -224,32 +224,32 @@
 	keyslot = new /obj/item/device/encryptionkey/heads/captain
 
 /obj/item/device/radio/headset/headset_cent/ert
-	name = "\improper Centcom bowman headset"
+	name = "\improper centcom bowman headset"
 	desc = "A headset especially for emergency response personnel. Protects ears from flashbangs. \nTo access the centcom channel, use :y."
 	icon_state = "cent_headset_alt"
 	item_state = "cent_headset_alt"
 	keyslot = null
 
 /obj/item/device/radio/headset/headset_ert_commander
-	name = "\improper Centcom headset"
+	name = "\improper centcom headset"
 	desc ="A headset especially for the emergency respone team commander. \nTo access the centcom channel, use :y. For command, use :c. For security, use :s. For medical, use :m. For engineering, :e."
 	icon_state = "cent_headset"
 	keyslot = new /obj/item/device/encryptionkey/headset_ert_commander
 
 /obj/item/device/radio/headset/headset_ert_med
-	name = "\improper Centcom bowman headset"
+	name = "\improper centcom bowman headset"
 	desc = "A headset especially for the emergency respone team medical crew. \nTo access the centcom channel, use :y. For medical, use :m"
 	icon_state = "cent_headset_alt"
 	keyslot = new /obj/item/device/encryptionkey/headset_ert_med
 
 /obj/item/device/radio/headset/headset_ert_eng
-	name = "\improper Centcom bowman headset"
+	name = "\improper centcom bowman headset"
 	desc = "A headset especially for the response team engineering crew. \nTo access the centcom channel, use :y. For engineering, use :e."
 	icon_state = "cent_headset_alt"
 	keyslot = new /obj/item/device/encryptionkey/headset_ert_eng
 
 /obj/item/device/radio/headset/headset_ert_sec
-	name = "\improper Centcom bowman headset"
+	name = "\improper centcom bowman headset"
 	desc = "A headset especially for the emergency response team security officers. \nTo access the centcom channel, use :y. For security, use :s."
 	icon_state = "cent_headset_alt"
 	keyslot = new /obj/item/device/encryptionkey/headset_ert_sec

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -215,7 +215,7 @@
 
 /obj/item/device/radio/headset/headset_cent
 	name = "\improper Centcom headset"
-	desc = "A headset used by the upper echelons of Nanotrasen. \nTo access the centcom channel, use :y."
+	desc = "A headset used by the upper echelons of Nanotrasen. \nTo access the Centcom channel, use :y."
 	icon_state = "cent_headset"
 	keyslot = new /obj/item/device/encryptionkey/headset_com
 	keyslot2 = new /obj/item/device/encryptionkey/headset_cent
@@ -224,33 +224,33 @@
 	keyslot = new /obj/item/device/encryptionkey/heads/captain
 
 /obj/item/device/radio/headset/headset_cent/ert
-	name = "\improper centcom bowman headset"
-	desc = "A headset especially for emergency response personnel. Protects ears from flashbangs. \nTo access the centcom channel, use :y."
+	name = "\improper Centcom bowman headset"
+	desc = "A headset especially for emergency response personnel. Protects ears from flashbangs. \nTo access the Centcom channel, use :y."
 	icon_state = "cent_headset_alt"
 	item_state = "cent_headset_alt"
 	keyslot = null
 
 /obj/item/device/radio/headset/headset_ert_commander
-	name = "\improper centcom headset"
-	desc ="A headset especially for the emergency respone team commander. \nTo access the centcom channel, use :y. For command, use :c. For security, use :s. For medical, use :m. For engineering, :e."
+	name = "\improper Centcom headset"
+	desc ="A headset especially for the emergency respone team commander. \nTo access the Centcom channel, use :y. For command, use :c. For security, use :s. For medical, use :m. For engineering, :e."
 	icon_state = "cent_headset"
 	keyslot = new /obj/item/device/encryptionkey/headset_ert_commander
 
 /obj/item/device/radio/headset/headset_ert_med
-	name = "\improper centcom bowman headset"
-	desc = "A headset especially for the emergency respone team medical crew. \nTo access the centcom channel, use :y. For medical, use :m"
+	name = "\improper Centcom bowman headset"
+	desc = "A headset especially for the emergency respone team medical crew. \nTo access the Centcom channel, use :y. For medical, use :m"
 	icon_state = "cent_headset_alt"
 	keyslot = new /obj/item/device/encryptionkey/headset_ert_med
 
 /obj/item/device/radio/headset/headset_ert_eng
-	name = "\improper centcom bowman headset"
-	desc = "A headset especially for the response team engineering crew. \nTo access the centcom channel, use :y. For engineering, use :e."
+	name = "\improper Centcom bowman headset"
+	desc = "A headset especially for the response team engineering crew. \nTo access the Centcom channel, use :y. For engineering, use :e."
 	icon_state = "cent_headset_alt"
 	keyslot = new /obj/item/device/encryptionkey/headset_ert_eng
 
 /obj/item/device/radio/headset/headset_ert_sec
-	name = "\improper centcom bowman headset"
-	desc = "A headset especially for the emergency response team security officers. \nTo access the centcom channel, use :y. For security, use :s."
+	name = "\improper Centcom bowman headset"
+	desc = "A headset especially for the emergency response team security officers. \nTo access the Centcom channel, use :y. For security, use :s."
 	icon_state = "cent_headset_alt"
 	keyslot = new /obj/item/device/encryptionkey/headset_ert_sec
 

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -4,7 +4,7 @@
 	uniform = /obj/item/clothing/under/rank/centcom_officer
 	shoes = /obj/item/clothing/shoes/combat/swat
 	gloves = /obj/item/clothing/gloves/combat
-	ears = /obj/item/device/radio/headset/headset_cent/alt
+	ears = /obj/item/device/radio/headset/headset_cent/ert
 
 
 
@@ -14,7 +14,7 @@
 	uniform = /obj/item/clothing/under/rank/chef
 	shoes = /obj/item/clothing/shoes/combat/swat
 	gloves = /obj/item/clothing/gloves/combat
-	ears = /obj/item/device/radio/headset/headset_cent/alt
+	ears = /obj/item/device/radio/headset/headset_ert_commander
 	suit = /obj/item/clothing/suit/space/hardsuit/carp
 	back = /obj/item/weapon/storage/backpack/satchel/hyd
 	id = /obj/item/weapon/card/id/ert
@@ -26,10 +26,6 @@
 	var/obj/item/weapon/implant/mindshield/L = new/obj/item/weapon/implant/mindshield(H)
 	L.implant(H, null, 1)
 
-	var/obj/item/device/radio/R = H.ears
-	R.set_frequency(GLOB.CENTCOM_FREQ)
-	R.freqlock = 1
-
 	var/obj/item/weapon/card/id/W = H.wear_id
 	W.registered_name = H.real_name
 	W.update_label(W.registered_name, W.assignment)
@@ -40,6 +36,7 @@
 	id = /obj/item/weapon/card/id/ert
 	suit = /obj/item/clothing/suit/space/hardsuit/ert
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
+	ears = /obj/item/device/radio/headset/headset_ert_commander
 	back = /obj/item/weapon/storage/backpack/captain
 	belt = /obj/item/weapon/storage/belt/security/full
 	backpack_contents = list(/obj/item/weapon/storage/box/engineer=1,\
@@ -53,9 +50,6 @@
 
 	if(visualsOnly)
 		return
-	var/obj/item/device/radio/R = H.ears
-	R.keyslot = new /obj/item/device/encryptionkey/heads/captain
-	R.recalculateChannels()
 
 /datum/outfit/ert/commander/alert
 	name = "ERT Commander - High Alert"
@@ -74,6 +68,7 @@
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/sec
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	back = /obj/item/weapon/storage/backpack/security
+	ears = /obj/item/device/radio/headset/headset_ert_sec
 	belt = /obj/item/weapon/storage/belt/security/full
 	backpack_contents = list(/obj/item/weapon/storage/box/engineer=1,\
 		/obj/item/weapon/storage/box/handcuffs=1,\
@@ -86,10 +81,6 @@
 
 	if(visualsOnly)
 		return
-
-	var/obj/item/device/radio/R = H.ears
-	R.keyslot = new /obj/item/device/encryptionkey/heads/hos
-	R.recalculateChannels()
 
 /datum/outfit/ert/security/alert
 	name = "ERT Security - High Alert"
@@ -108,6 +99,7 @@
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/med
 	glasses = /obj/item/clothing/glasses/hud/health
 	back = /obj/item/weapon/storage/backpack/satchel/med
+	ears = /obj/item/device/radio/headset/headset_ert_med
 	belt = /obj/item/weapon/storage/belt/medical
 	r_hand = /obj/item/weapon/storage/firstaid/regular
 	backpack_contents = list(/obj/item/weapon/storage/box/engineer=1,\
@@ -122,10 +114,6 @@
 
 	if(visualsOnly)
 		return
-
-	var/obj/item/device/radio/R = H.ears
-	R.keyslot = new /obj/item/device/encryptionkey/heads/cmo
-	R.recalculateChannels()
 
 /datum/outfit/ert/medic/alert
 	name = "ERT Medic - High Alert"
@@ -144,6 +132,7 @@
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/engi
 	glasses =  /obj/item/clothing/glasses/meson/engine
 	back = /obj/item/weapon/storage/backpack/industrial
+	ears = /obj/item/device/radio/headset/headset_ert_eng
 	belt = /obj/item/weapon/storage/belt/utility/full
 	l_pocket = /obj/item/weapon/rcd_ammo/large
 	r_hand = /obj/item/weapon/storage/firstaid/regular
@@ -158,10 +147,6 @@
 
 	if(visualsOnly)
 		return
-
-	var/obj/item/device/radio/R = H.ears
-	R.keyslot = new /obj/item/device/encryptionkey/heads/ce
-	R.recalculateChannels()
 
 /datum/outfit/ert/engineer/alert
 	name = "ERT Engineer - High Alert"


### PR DESCRIPTION
:cl: Changes to ERT personnel headsets
Added new headsets for each of ERT. So ERT medic gets access to Centcom and Medical (He can both listen and talk)
WIP: Choose intent either to help or disturb the station will change the vox channels accessible 
/:cl:

[why]:  This enables ERT to communicate with their team (through centcom channel) and other departments to help the station, for example engineer can coordinate with the ERT team through the centcom channel and with the engineering crew on the station through the engineering channel. So if ERT engi found an injured, he can notify ERT team and then they can either do thing on their own, or now the medic can communicate through medical channel to coordinate rescue!