### PR TITLE
Admin smite messages

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1188,16 +1188,24 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 			T.Beam(target, icon_state="lightning[rand(1,12)]", time = 5)
 			target.adjustFireLoss(75)
 			target.electrocution_animation(40)
-			to_chat(target, "<span class='userdanger'>The gods have punished you for your sins!</span>")
+			if(!message)
+				message = "The gods have punished you for your sins!"
+			to_chat(target, "<span class='userdanger'>[message]</span>")
 		if(ADMIN_PUNISHMENT_BRAINDAMAGE)
-					if(!message)
+			if(!message)
 							message = "You feel dumber"
-					target.adjustBrainLoss(75)
-					to_chat(target, "<span class='userdanger'>[message]</span>")
+			target.adjustBrainLoss(75)
+			to_chat(target, "<span class='userdanger'>[message]</span>")
 		if(ADMIN_PUNISHMENT_GIB)
+			if(!message)
+				message = The gods have punished you for your sins!
 			target.gib(FALSE)
+			to_chat(target, "<span class='userdanger'>[message]</span>")
 		if(ADMIN_PUNISHMENT_BSA)
+			if(!message)
+				message = "It seems you have angered Centcom a bit too much"
 			bluespace_artillery(target)
+			to_chat(target,"<span class='userdange'>[message]</span>")
 
 	var/msg = "[key_name_admin(usr)] punished [key_name_admin(target)] with [punishment]."
 	message_admins(msg)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1193,12 +1193,12 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 			to_chat(target, "<span class='userdanger'>[message]</span>")
 		if(ADMIN_PUNISHMENT_BRAINDAMAGE)
 			if(!message)
-							message = "You feel dumber"
+				message = "You feel dumber"
 			target.adjustBrainLoss(75)
 			to_chat(target, "<span class='userdanger'>[message]</span>")
 		if(ADMIN_PUNISHMENT_GIB)
 			if(!message)
-				message = The gods have punished you for your sins!
+				message = "The gods have punished you for your sins!"
 			target.gib(FALSE)
 			to_chat(target, "<span class='userdanger'>[message]</span>")
 		if(ADMIN_PUNISHMENT_BSA)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1176,7 +1176,7 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 		return
 
 	var/list/punishment_list = list(ADMIN_PUNISHMENT_LIGHTNING, ADMIN_PUNISHMENT_BRAINDAMAGE, ADMIN_PUNISHMENT_GIB, ADMIN_PUNISHMENT_BSA)
-
+	var/message = input("Choose the message they will receive") as text
 	var/punishment = input("Choose a punishment", "DIVINE SMITING") as null|anything in punishment_list
 
 	if(QDELETED(target) || !punishment)
@@ -1190,7 +1190,10 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 			target.electrocution_animation(40)
 			to_chat(target, "<span class='userdanger'>The gods have punished you for your sins!</span>")
 		if(ADMIN_PUNISHMENT_BRAINDAMAGE)
-			target.adjustBrainLoss(75)
+					if(!message)
+							message = "You feel dumber"
+					target.adjustBrainLoss(75)
+					to_chat(target, "<span class='userdanger'>[message]</span>")
 		if(ADMIN_PUNISHMENT_GIB)
 			target.gib(FALSE)
 		if(ADMIN_PUNISHMENT_BSA)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1176,11 +1176,11 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 		return
 
 	var/list/punishment_list = list(ADMIN_PUNISHMENT_LIGHTNING, ADMIN_PUNISHMENT_BRAINDAMAGE, ADMIN_PUNISHMENT_GIB, ADMIN_PUNISHMENT_BSA)
-	var/message = input("Choose the message they will receive") as text
 	var/punishment = input("Choose a punishment", "DIVINE SMITING") as null|anything in punishment_list
 
 	if(QDELETED(target) || !punishment)
 		return
+	var/message = input("Choose the message they will receive") as text
 
 	switch(punishment)
 		if(ADMIN_PUNISHMENT_LIGHTNING)
@@ -1205,7 +1205,7 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 			if(!message)
 				message = "It seems you have angered Centcom a bit too much"
 			bluespace_artillery(target)
-			to_chat(target,"<span class='userdange'>[message]</span>")
+			to_chat(target,"<span class='userdanger'>[message]</span>")
 
 	var/msg = "[key_name_admin(usr)] punished [key_name_admin(target)] with [punishment]."
 	message_admins(msg)


### PR DESCRIPTION
:cl: Smitting
Added an abbility for admins to choose what message they will display on the smitten player
Added the default message for every smite type when you don't input a message
/:cl:

[why]:  A minor thingy to make the game more clear. Now instead of just taking those 75 brain damage for example, you will also get a message, either chosen by the admin who smitted you, or the default one!