### PR TITLE
Round start modular computers work again

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -55,7 +55,6 @@
 	if(!physical)
 		physical = src
 	comp_light_color = "#FFFFFF"
-	all_components = list()
 	idle_threads = list()
 	update_icon()
 


### PR DESCRIPTION
Fixes #1944 
and also amends #1395

:cl: Funce
fix: Round start modular computers work once more
/:cl:

Cheers to Ike for figuring this one out.
