### PR TITLE
Update toolsmerge-upstream-pull-request.sh

### DIFF
--- a/tools/toolsmerge-upstream-pull-request.sh
+++ b/tools/toolsmerge-upstream-pull-request.sh
@@ -4,10 +4,8 @@ set -u # don't expand unbound variable
 set -f # disable pathname expansion
 set -C # noclobber
 
-BASE_PATCH_URL="https://patch-diff.githubusercontent.com/raw/tgstation/tgstation/pull/"
-BASE_BRANCH_NAME="upstream-merge-"
-
-tmpfile=$(mktemp /tmp/git-patch-script.XXXXXX)
+readonly BASE_BRANCH_NAME="upstream-merge-"
+readonly BASE_PULL_URL="https://api.github.com/repos/tgstation/tgstation/pulls"
 
 # Ensure the current directory is a git directory
 if [ ! -d .git ]; then
@@ -21,21 +19,20 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
-# Make sure our temp file exists
-if [ ! -f "$tmpfile" ]; then
-    echo "Error: mktemp failed to create a temporarily file"
-    exit 1
+# Ensure curl exists and is available in the current context
+type curl >/dev/null 2>&1 || { echo >&2 "Error: This script requires curl, please ensure curl is installed and exists in the current PATH"; exit 1; }
+
+# Ensure jq exists and is available in the current context
+type jq >/dev/null 2>&1 || { echo >&2 "Error: This script requires jq, please ensure jq is installed and exists in the current PATH"; exit 1; }
+
+# Make sure we have our upstream remote
+if ! git remote | grep tgstation > /dev/null; then
+   git remote add tgstation https://github.com/tgstation/tgstation.git
 fi
-
-# Ensure wget exists and is available in the current context
-type wget >/dev/null 2>&1 || { echo >&2 "Error: This script requires wget, please ensure wget is installed and exists in the current PATH"; exit 1; }
-
-# Download the patchfile
-wget "$BASE_PATCH_URL$1.patch" -q -O "$tmpfile"
 
 # We need to make sure we are always on a clean master when creating the new branch.
 # So we forcefully reset, clean and then checkout the master branch
-git fetch
+git fetch --all
 git checkout master
 git reset --hard origin/master
 git clean -f
@@ -46,17 +43,34 @@ git branch | grep -v "master" | xargs git branch -D
 # Create a new branch
 git checkout -b "$BASE_BRANCH_NAME$1"
 
-# Apply the patch on top of this new branch
-git apply --reject --ignore-space-change --ignore-whitespace "$tmpfile"
+# Grab the SHA of the merge commit
+readonly MERGE_SHA=$(curl --silent "$BASE_PULL_URL/$1" | jq '.merge_commit_sha' -r)
 
-# Add all files onto this branch
-git add -A .
+# Get the commits
+readonly COMMITS=$(curl "$BASE_PULL_URL/$1/commits" | jq '.[].sha' -r)
+
+# Cherry pick onto the new branch
+CHERRY_PICK_OUTPUT=$(git cherry-pick -m 1 "$MERGE_SHA" 2>&1)
+echo "$CHERRY_PICK_OUTPUT"
+
+# If it's a squash commit, you can't use -m 1, you need to remove it
+# You also can't use -m 1 if it's a rebase and merge...
+if echo "$CHERRY_PICK_OUTPUT" | grep 'error: mainline was specified but commit'; then
+  echo "Commit was a squash, retrying"
+  for commit in $COMMITS; do
+  	echo "Cherry-picking: $commit"
+	git cherry-pick "$commit"
+	# Add all files onto this branch
+	git add -A .
+	git cherry-pick --continue
+  done
+else
+  # Add all files onto this branch
+  git add -A .
+fi
 
 # Commit these changes
-git commit -m "$2"
+git commit --allow-empty -m "$2"
 
 # Push them onto the branch
 git push -u origin "$BASE_BRANCH_NAME$1"
-
-# Remove the temp file
-rm "$tmpfile"


### PR DESCRIPTION
This is an updated version of the merge script used by the PRMirrorer, it handles an edge case that the original script doesn't and should do a much better job of merging things.

Before merging this make sure the server you're using has curl and jq installed, you can do this with `apt-get install curl jq`

It's important to keep this script up-to-date btw, we've been working on it for awhile, but you've got the original version of it.