### PR TITLE
Fixes ruins spawning inside the ship area

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -208,9 +208,12 @@
 
 	var/planet_dock = FALSE //var to help with escape pod landings
 
+/obj/docking_port/stationary/New()
+	. = ..()
+	SSshuttle.stationary += src //This has to be here to pre-empt ruin spawning
+
 /obj/docking_port/stationary/Initialize()
 	. = ..()
-	SSshuttle.stationary += src
 	if(!id)
 		id = "[SSshuttle.stationary.len]"
 	if(name == "dock")


### PR DESCRIPTION
:cl: ninjanomnom
fix: Ruins should no longer spawn in the ship area
/:cl:

Because of how map gen works we have to use new here unfortunately unless we want to do quite a bit larger of a rewrite.