### PR TITLE
Mirror Fix: Action buttons for spells now include their description 

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -490,6 +490,7 @@
 	var/obj/effect/proc_holder/spell/S = target
 	S.action = src
 	name = S.name
+	desc = S.desc
 	icon_icon = S.action_icon
 	button_icon_state = S.action_icon_state
 	background_icon_state = S.action_background_icon_state


### PR DESCRIPTION
Closes #1808

"🆑 Xhuis
tweak: Spell action buttons now have their description in a tooltip.
/🆑

I always thought that it was odd and inconsistent that spell action buttons didn't have any tooltips or general information about the spell save for their names."