### PR TITLE
Make the FOB locked message more clear

### DIFF
--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -44,6 +44,8 @@
 			dat += "<A href='?src=\ref[src];move=[S.id]'>Send to [S.name]</A><br>"
 		if(!destination_found)
 			dat += "<B>Shuttle Locked</B><br>"
+			if(!admin_controlled)
+				dat += "No destination found<br>"
 			if(admin_controlled)
 				dat += "Authorized personnel only<br>"
 				dat += "<A href='?src=\ref[src];request=1]'>Request Authorization</A><br>"


### PR DESCRIPTION
:cl:tweak: tweaked a few things - Made it easier to tell why the shuttle is locked/:cl:

[why]: Because it makes it less rage inducing when you don't know that you're over a gas giant.
