### PR TITLE
NERFS FTL LAG (Makes planet gen occur when FTL starts, instead of at the end)

### DIFF
--- a/code/__DEFINES/ship.dm
+++ b/code/__DEFINES/ship.dm
@@ -13,3 +13,7 @@
 #define PRICE_CAP 500 //maximum price of resources
 #define SHIP_BUILD_PRICE 1000 //price to build a ship on top of resources
 #define FACTION_BUILD_DELAY 900 //delay in between building ships
+
+#define FTL_NOT_LOADING 0
+#define FTL_LOADING 1
+#define FTL_DONE_LOADING 2

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -189,9 +189,9 @@ SUBSYSTEM_DEF(mapping)
 	GLOB.space_manager.do_transition_setup()
 	repopulate_sorted_areas()
 	if((!SSstarmap.in_transit && !SSstarmap.in_transit_planet)) //Cheap(?) fix so it doesn't get stuck when the round first loads
-		SSstarmap.is_loading = 0
+		SSstarmap.is_loading = FTL_NOT_LOADING
 	else
-		SSstarmap.is_loading = 2
+		SSstarmap.is_loading = FTL_DONE_LOADING
 
 /datum/controller/subsystem/mapping/proc/initialize_z_level(z_level)
 	var/list/obj/machinery/atmospherics/atmos_machines = list()

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -188,7 +188,10 @@ SUBSYSTEM_DEF(mapping)
 	// on star system load
 	GLOB.space_manager.do_transition_setup()
 	repopulate_sorted_areas()
-	SSstarmap.is_loading = 0
+	if((!SSstarmap.in_transit && !SSstarmap.in_transit_planet)) //Cheap(?) fix so it doesn't get stuck when the round first loads
+		SSstarmap.is_loading = 0
+	else
+		SSstarmap.is_loading = 2
 
 /datum/controller/subsystem/mapping/proc/initialize_z_level(z_level)
 	var/list/obj/machinery/atmospherics/atmos_machines = list()

--- a/code/controllers/subsystem/starmap.dm
+++ b/code/controllers/subsystem/starmap.dm
@@ -20,7 +20,7 @@ SUBSYSTEM_DEF(starmap)
 	var/datum/planet/to_planet
 	var/in_transit_planet // In transit between planets?
 
-	var/is_loading = 0 // 0 = not loading. 1 = loading/unloading new z levels. 2 = recently ran, waiting for she ship to leave FTL
+	var/is_loading = FTL_NOT_LOADING // Status of z level loading during FTL
 
 	var/obj/machinery/ftl_drive/ftl_drive
 	var/obj/machinery/ftl_shieldgen/ftl_shieldgen
@@ -121,12 +121,12 @@ SUBSYSTEM_DEF(starmap)
 	..()
 
 /datum/controller/subsystem/starmap/fire()
-	if(is_loading == 1 && world.time >= to_time)
+	if(is_loading == FTL_LOADING && world.time >= to_time)
 		to_time += 100
 
 	if(in_transit || in_transit_planet)
 		var/obj/docking_port/mobile/ftl/ftl = SSshuttle.getShuttle("ftl")
-		if(ftl.mode == SHUTTLE_TRANSIT && is_loading == 0 && world.time >= from_time + 50)
+		if(ftl.mode == SHUTTLE_TRANSIT && is_loading == FTL_NOT_LOADING && world.time >= from_time + 50)
 			if(in_transit)
 				SSmapping.load_planet(to_system.planets[1])
 			else if(in_transit_planet)
@@ -139,7 +139,7 @@ SUBSYSTEM_DEF(starmap)
 		else if(in_transit_planet)
 			current_planet = to_planet
 
-		if(is_loading == 2 && world.time >= to_time && (in_transit || in_transit_planet))
+		if(is_loading == FTL_DONE_LOADING && world.time >= to_time && (in_transit || in_transit_planet))
 			var/obj/docking_port/stationary/dest = current_planet.main_dock
 			ftl.mode = SHUTTLE_CALL
 			ftl.destination = dest
@@ -159,7 +159,7 @@ SUBSYSTEM_DEF(starmap)
 			to_system = null
 			in_transit = FALSE
 			in_transit_planet = FALSE
-			is_loading = 0
+			is_loading = FTL_NOT_LOADING
 
 	// Check and update ship objectives
 	var/objectives_complete = 1

--- a/code/controllers/subsystem/starmap.dm
+++ b/code/controllers/subsystem/starmap.dm
@@ -132,14 +132,13 @@ SUBSYSTEM_DEF(starmap)
 			else if(in_transit_planet)
 				SSmapping.load_planet(to_planet)
 
-		if(in_transit)
-			current_system = to_system
-			current_system.visited = TRUE
-			current_planet = current_system.planets[1]
-		else if(in_transit_planet)
-			current_planet = to_planet
-
-		if(is_loading == FTL_DONE_LOADING && world.time >= to_time && (in_transit || in_transit_planet))
+		if(is_loading == FTL_DONE_LOADING && world.time >= to_time)
+			if(in_transit) //Update the ships new location
+				current_system = to_system
+				current_system.visited = TRUE
+				current_planet = current_system.planets[1]
+			else if(in_transit_planet)
+				current_planet = to_planet
 			var/obj/docking_port/stationary/dest = current_planet.main_dock
 			ftl.mode = SHUTTLE_CALL
 			ftl.destination = dest

--- a/code/controllers/subsystem/starmap.dm
+++ b/code/controllers/subsystem/starmap.dm
@@ -126,7 +126,7 @@ SUBSYSTEM_DEF(starmap)
 
 	if(in_transit || in_transit_planet)
 		var/obj/docking_port/mobile/ftl/ftl = SSshuttle.getShuttle("ftl")
-		if(ftl.mode == SHUTTLE_TRANSIT && is_loading == 0 && world.time <= from_time + 70)
+		if(ftl.mode == SHUTTLE_TRANSIT && is_loading == 0 && world.time >= from_time + 50)
 			if(in_transit)
 				SSmapping.load_planet(to_system.planets[1])
 			else if(in_transit_planet)


### PR DESCRIPTION
an actual big fix holy heck

:cl: TMTIME
fix: Makes planetgen occur during FTL, instead of when the timer hits 0
tweak: Increased planet to planet jump time as 60 seconds isn't enough for the potato
/:cl:

[why]: # b u g 

tldr for a long time it was assumed that planet gen was loading every planet in the system, causing FTL to always overrun the 3 minute timer.
looking into what was actually going on the planets would only be unloaded/loaded when the FTL was supposed to end according to the timer.

Give or take the performance on the server, and how habitable planets take forever this will cut the time down for each jump significantly

~~speedmerge when~~

late edit: One drawback to this PR is now anyone off the ship when it jumps gets deleted right away. No three minute window to ahelp for help
