### PR TITLE
Disables weather subsystem

### DIFF
--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -3,6 +3,7 @@ SUBSYSTEM_DEF(weather)
 	name = "Weather"
 	flags = SS_BACKGROUND
 	wait = 10
+	can_fire = 0
 	runlevels = RUNLEVEL_GAME
 	var/list/processing = list()
 	var/list/existing_weather = list()

--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -3,7 +3,7 @@ SUBSYSTEM_DEF(weather)
 	name = "Weather"
 	flags = SS_BACKGROUND
 	wait = 10
-	can_fire = 0
+	can_fire = 0 //bandaid to stop the random ash storms on planets, at least until it's revamped to planetary weather
 	runlevels = RUNLEVEL_GAME
 	var/list/processing = list()
 	var/list/existing_weather = list()
@@ -30,7 +30,6 @@ SUBSYSTEM_DEF(weather)
 
 /datum/controller/subsystem/weather/Initialize(start_timeofday)
 	..()
-	can_fire = 0 //bandaid to stop the random ash storms on planets, at least until it's revamped to planetary weather
 	for(var/V in subtypesof(/datum/weather))
 		var/datum/weather/W = V
 		new W	//weather->New will handle adding itself to the list

--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -29,6 +29,7 @@ SUBSYSTEM_DEF(weather)
 
 /datum/controller/subsystem/weather/Initialize(start_timeofday)
 	..()
+	can_fire = 0 //bandaid to stop the random ash storms on planets, at least until it's revamped to planetary weather
 	for(var/V in subtypesof(/datum/weather))
 		var/datum/weather/W = V
 		new W	//weather->New will handle adding itself to the list


### PR DESCRIPTION
Just makes it so weather subsystem starts disabled, at least until someone actually changes the weather effects to something more thematic, like snow or something.

:cl: Vivalas

del: Removes ash storms

/:cl:

[why]: Because they are out of place and annoying.
