### PR TITLE
Lower role priority for the Head of Security at round start

### DIFF
--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -1,10 +1,10 @@
 GLOBAL_LIST_INIT(command_positions, list(
 	"Captain",
 	"Executive Officer",
-	"Head of Security",
 	"Chief Engineer",
 	"Research Director",
 	"Chief Medical Officer",
+	"Head of Security",
 	"Bridge Officer",))
 
 


### PR DESCRIPTION
Move the Head of Security to one of the last command level positions to be filled where applicable. This will force people to fill more ship critical spots (starting with the CE) before taking on the HoS role.

🆑 Crossedfall
Modification: Moved Head of Security down a few lines in the command positions
/🆑