### PR TITLE
Scarab Map Changes take two

### DIFF
--- a/_maps/map_files/Scarab/scarab.dmm
+++ b/_maps/map_files/Scarab/scarab.dmm
@@ -51,11 +51,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/space)
-"aam" = (
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/engine/engineering{
-	name = "Port Auxilary SMES"
-	})
 "aan" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/hallway/primary/port)
@@ -75,17 +70,6 @@
 	pixel_x = 0
 	},
 /turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
-"aaq" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/glass_external{
-	name = "External Access";
-	req_access_txt = "10";
-	req_one_access_txt = "10;48"
-	},
-/turf/open/floor/plasteel/delivery{
-	name = "floor"
-	},
 /area/shuttle/ftl/hallway/primary/port)
 "aay" = (
 /turf/closed/wall/r_wall,
@@ -193,62 +177,6 @@
 "aaS" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/cargo/qm)
-"aaT" = (
-/obj/item/device/radio/intercom{
-	pixel_x = 0;
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
-	},
-/obj/machinery/computer/monitor{
-	name = "primary power monitoring console"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engineering{
-	name = "Port Auxilary SMES"
-	})
-"aaU" = (
-/obj/machinery/power/smes{
-	capacity = 1e+006;
-	charge = 1e+006
-	},
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engineering{
-	name = "Port Auxilary SMES"
-	})
-"aaV" = (
-/obj/machinery/power/terminal{
-	tag = "icon-term (WEST)";
-	icon_state = "term";
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engineering{
-	name = "Port Auxilary SMES"
-	})
 "aaW" = (
 /obj/structure/sign/securearea{
 	pixel_x = -32
@@ -381,9 +309,6 @@
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
 /obj/item/weapon/crowbar/red,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
-"abi" = (
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
 "abj" = (
@@ -562,103 +487,6 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/space)
-"abK" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/power/apc/ship{
-	auto_name = 1;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engineering{
-	name = "Port Auxilary SMES"
-	})
-"abL" = (
-/obj/machinery/light/small,
-/obj/structure/sign/poster/random{
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 8;
-	name = "Forward atmos emergency shutoff valve";
-	req_access_txt = "10"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engineering{
-	name = "Port Auxilary SMES"
-	})
-"abM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "Port Auxilary SMES";
-	dir = 1;
-	network = list("SS13")
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engineering{
-	name = "Port Auxilary SMES"
-	})
-"abN" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Auxilary SMES Airlock";
-	req_access_txt = "10"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engineering{
-	name = "Port Auxilary SMES"
-	})
 "abO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -806,10 +634,6 @@
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
 /obj/item/weapon/crowbar/red,
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
-"abZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
 "acg" = (
@@ -1163,38 +987,6 @@
 /area/shuttle/ftl/security/checkpoint{
 	name = "Departures Checkpoint"
 	})
-"acN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/engine/engineering{
-	name = "Port Auxilary SMES"
-	})
-"acO" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/engine/engineering{
-	name = "Port Auxilary SMES"
-	})
-"acP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/engine/engineering{
-	name = "Port Auxilary SMES"
-	})
 "acQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -1336,45 +1128,6 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/shuttle/ftl/hallway/primary/port)
-"adc" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
-"add" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/glass_external{
-	name = "External Access";
-	req_access_txt = "10";
-	req_one_access_txt = "10;48"
-	},
-/turf/open/floor/plasteel/delivery{
-	name = "floor"
-	},
-/area/shuttle/ftl/hallway/primary/port)
-"ade" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
 "adf" = (
 /obj/structure/disposalpipe/segment{
@@ -2027,14 +1780,6 @@
 /obj/structure/sign/poster/random{
 	pixel_x = 0;
 	pixel_y = 32
-	},
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 4
-	},
-/area/shuttle/ftl/hallway/primary/port)
-"aen" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
@@ -4108,13 +3853,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
 /turf/open/floor/plasteel/vault{
 	dir = 10
-	},
-/area/shuttle/ftl/hallway/primary/port)
-"ahM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/obj/effect/landmark/start/new_player,
-/turf/open/floor/plasteel/vault{
-	dir = 6
 	},
 /area/shuttle/ftl/hallway/primary/port)
 "ahN" = (
@@ -8671,22 +8409,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"aqD" = (
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/glass_external{
-	name = "External Access";
-	req_access_txt = "10";
-	req_one_access_txt = "10;48"
-	},
-/turf/open/floor/plasteel/delivery{
-	name = "floor"
-	},
-/area/shuttle/ftl/hallway/primary/port)
 "aqE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 8
@@ -11025,88 +10747,8 @@
 /area/shuttle/ftl/crew_quarters/theatre{
 	name = "Lounge"
 	})
-"auG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
 "auH" = (
 /obj/structure/bookcase/random,
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
-"auI" = (
-/obj/item/weapon/twohanded/required/kirbyplants/random,
-/obj/machinery/power/apc/ship{
-	auto_name = 1;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
-"auJ" = (
-/obj/structure/table/wood,
-/obj/item/device/flashlight/lamp/green{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/obj/item/weapon/paper_bin{
-	pixel_x = 7;
-	pixel_y = 4
-	},
-/obj/item/weapon/pen/blue{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/mob/living/simple_animal/mouse{
-	layer = 2.7
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
-"auK" = (
-/obj/structure/table/wood,
-/obj/machinery/newscaster{
-	pixel_y = 30
-	},
-/obj/item/weapon/book/codex_gigas,
-/obj/item/clothing/mask/cigarette/pipe,
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
-"auL" = (
-/obj/item/device/radio/intercom{
-	dir = 0;
-	name = "Station Intercom (General)";
-	pixel_y = 28
-	},
-/obj/effect/landmark/start{
-	name = "Assistant"
-	},
-/obj/structure/chair/comfy/black,
 /turf/open/floor/wood,
 /area/shuttle/ftl/crew_quarters/theatre{
 	name = "Lounge"
@@ -11944,66 +11586,8 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/hallway/primary/port)
-"awg" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
 "awh" = (
 /turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
-"awi" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
-"awj" = (
-/obj/effect/landmark/start{
-	name = "Librarian"
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
-"awk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
-"awl" = (
-/obj/machinery/holopad,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
-"awm" = (
-/turf/open/floor/carpet,
 /area/shuttle/ftl/crew_quarters/theatre{
 	name = "Lounge"
 	})
@@ -12508,45 +12092,6 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/hallway/primary/port)
-"axg" = (
-/obj/effect/landmark/start{
-	name = "Assistant"
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken7"
-	},
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
-"axh" = (
-/obj/effect/landmark/start/chaplain,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
-"axi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
-"axj" = (
-/obj/effect/landmark/start{
-	name = "Assistant"
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
-"axk" = (
-/obj/structure/table/wood,
-/obj/item/device/modular_computer/laptop/preset/civillian,
-/obj/item/device/camera_film,
-/obj/item/device/camera,
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
 "axl" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13181,26 +12726,6 @@
 /area/shuttle/ftl/maintenance/bar{
 	name = "Primary Maintenance"
 	})
-"ayh" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12";
-	req_one_access_txt = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/port)
 "ayi" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -13298,90 +12823,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/hallway/primary/port)
-"ayr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/closed/wall,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
-"ays" = (
-/obj/structure/displaycase/trophy,
-/obj/machinery/camera{
-	c_tag = "Study";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
-"ayt" = (
-/obj/machinery/bookbinder,
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
-"ayu" = (
-/obj/machinery/libraryscanner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
-"ayv" = (
-/obj/machinery/photocopier,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
-"ayw" = (
-/obj/structure/displaycase/trophy,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken"
-	},
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
-"ayx" = (
-/obj/item/weapon/twohanded/required/kirbyplants/random,
-/obj/machinery/light/small,
-/obj/structure/sign/poster/random{
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
-"ayy" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/effect/landmark/latejoin,
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
 "ayz" = (
 /obj/structure/fluff/broken_flooring{
 	tag = "icon-plating (NORTH)";
@@ -13795,26 +13236,6 @@
 "azk" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/heads)
-"azl" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating/airless/warnplate,
-/area/shuttle/ftl/storage/tech{
-	name = "Port Frontal Armor"
-	})
-"azm" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating/airless/warnplate,
-/area/shuttle/ftl/storage/tech{
-	name = "Port Frontal Armor"
-	})
 "azn" = (
 /turf/open/floor/plating/airless/warnplate,
 /area/shuttle/ftl/storage/tech{
@@ -14179,20 +13600,6 @@
 	},
 /turf/open/floor/plasteel/green/corner,
 /area/shuttle/ftl/hallway/primary/aft)
-"azS" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12";
-	req_one_access_txt = ""
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/aft)
 "azT" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -14462,17 +13869,6 @@
 /area/shuttle/ftl/munitions{
 	name = "Port Weapons Mount"
 	})
-"aAo" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/open/space/basic,
-/area/shuttle/ftl/munitions{
-	name = "Port Weapons Mount"
-	})
 "aAp" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -14513,17 +13909,6 @@
 /turf/open/space/basic,
 /area/shuttle/ftl/munitions{
 	name = "Port Weapons Mount"
-	})
-"aAt" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/space/basic,
-/area/shuttle/ftl/storage/tech{
-	name = "Port Frontal Armor"
 	})
 "aAu" = (
 /turf/open/space,
@@ -15686,21 +15071,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/engine/engineering)
-"aCr" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "Engine Room";
-	name = "engineering security door"
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Room";
-	req_access_txt = "10"
-	},
-/obj/machinery/atmospherics/pipe/simple/supplymain/hidden,
-/turf/open/floor/plasteel/delivery{
-	name = "floor"
-	},
-/area/shuttle/ftl/engine/engineering)
 "aCs" = (
 /obj/structure/sign/securearea,
 /turf/closed/wall/r_wall,
@@ -16203,17 +15573,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/heads)
-"aDi" = (
-/obj/structure/lattice/catwalk,
-/obj/item/stack/cable_coil{
-	amount = 1;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/space,
-/area/shuttle/ftl/munitions{
-	name = "Port Weapons Mount"
-	})
 "aDj" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -16784,20 +16143,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/heads)
-"aEe" = (
-/obj/structure/lattice/catwalk,
-/obj/item/stack/cable_coil{
-	amount = 1;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/stack/cable_coil{
-	amount = 1
-	},
-/turf/open/space,
-/area/shuttle/ftl/munitions{
-	name = "Port Weapons Mount"
-	})
 "aEf" = (
 /obj/structure/frame/machine{
 	desc = "Partially constructed phase cannon. Still need a few more parts before its operational.";
@@ -16913,24 +16258,6 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engineering)
-"aEr" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "Engine Room";
-	name = "engineering security door"
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Room";
-	req_access_txt = "10"
-	},
-/obj/machinery/atmospherics/pipe/simple/supplymain/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/delivery{
-	name = "floor"
-	},
 /area/shuttle/ftl/engine/engineering)
 "aEs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -17243,17 +16570,6 @@
 "aEW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
 /turf/open/floor/plasteel/black,
-/area/shuttle/ftl/turret_protected/ai)
-"aEX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/mob/living/simple_animal/bot/floorbot,
-/turf/open/floor/circuit,
 /area/shuttle/ftl/turret_protected/ai)
 "aEY" = (
 /obj/structure/cable{
@@ -17654,24 +16970,6 @@
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/area/shuttle/ftl/turret_protected/ai)
-"aFO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/open/floor/circuit,
 /area/shuttle/ftl/turret_protected/ai)
 "aFP" = (
 /obj/structure/rack,
@@ -18097,18 +17395,6 @@
 	dir = 6
 	},
 /area/shuttle/ftl/medical/medbay)
-"aGD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "genetics_shutters"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/shuttle/ftl/medical/genetics)
 "aGE" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_medical{
@@ -18127,39 +17413,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/ftl/medical/genetics)
-"aGF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "genetics_shutters"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/medical/genetics)
 "aGG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/shuttle/ftl/turret_protected/ai)
-"aGH" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "AI Core Access";
-	req_access_txt = "71"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "AI Chamber entrance shutters";
-	name = "AI Chamber entrance shutters"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/delivery,
 /area/shuttle/ftl/turret_protected/ai)
 "aGI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -18647,16 +17903,6 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/black,
-/area/shuttle/ftl/turret_protected/ai)
-"aHB" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
 /area/shuttle/ftl/turret_protected/ai)
 "aHC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -21862,23 +21108,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/darkblue,
-/area/shuttle/ftl/bridge)
-"aMH" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/food/drinks/britcup{
-	pixel_x = -4
-	},
-/obj/item/weapon/reagent_containers/food/drinks/coffee{
-	pixel_x = 6;
-	pixel_y = 4
 	},
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/bridge)
@@ -25876,29 +25105,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/engine/engineering)
-"aTi" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "Engine Room";
-	name = "engineering security door"
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Room";
-	req_access_txt = "10"
-	},
-/obj/machinery/atmospherics/pipe/simple/supplymain/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/delivery{
-	name = "floor"
-	},
-/area/shuttle/ftl/engine/engineering)
 "aTj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -26042,21 +25248,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/assembly/robotics)
-"aTv" = (
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/structure/rack,
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/borg/upgrade/rename,
-/obj/item/borg/upgrade/rename,
-/turf/open/floor/plasteel,
 /area/shuttle/ftl/assembly/robotics)
 "aTw" = (
 /obj/structure/table/glass,
@@ -29819,21 +29010,6 @@
 	icon_state = "white"
 	},
 /area/shuttle/ftl/medical/virology)
-"aZC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/ai_status_display{
-	pixel_y = 32
-	},
-/obj/machinery/smartfridge/chemistry/virology/preloaded,
-/turf/open/floor/plasteel/whitegreen/side{
-	dir = 1
-	},
-/area/shuttle/ftl/medical/virology)
 "aZD" = (
 /obj/structure/reagent_dispensers/virusfood{
 	density = 0;
@@ -30352,47 +29528,6 @@
 /obj/structure/sign/science,
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/hor)
-"bay" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rdprivacy"
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "R&D_blastdoor"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/crew_quarters/hor)
-"baz" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/weapon/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/eastright{
-	dir = 2;
-	name = "Research and Development Desk";
-	req_access_txt = "30"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rdprivacy";
-	name = "research shutters"
-	},
-/obj/item/weapon/pen,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "R&D_blastdoor"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/crew_quarters/hor)
 "baA" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/crew_quarters/hor)
@@ -30545,26 +29680,6 @@
 /area/shuttle/ftl/maintenance/bar{
 	name = "Primary Maintenance"
 	})
-"baL" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12";
-	req_one_access_txt = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/hallway/primary/starboard)
 "baM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -31098,27 +30213,6 @@
 	dir = 1
 	},
 /area/shuttle/ftl/research/lab)
-"bbA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 4
-	},
-/area/shuttle/ftl/research/lab)
 "bbB" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -31130,59 +30224,6 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
-/area/shuttle/ftl/crew_quarters/hor)
-"bbC" = (
-/obj/machinery/computer/card/minor/rd{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/shuttle/ftl/crew_quarters/hor)
-"bbD" = (
-/obj/effect/landmark/start{
-	name = "Research Director";
-	shuttle_abstract_movable = 1
-	},
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/shuttle/ftl/crew_quarters/hor)
-"bbE" = (
-/obj/machinery/button/door{
-	id = "R&D_blastdoor";
-	name = "Secure Lab Shutter Control";
-	pixel_x = -5;
-	pixel_y = -5;
-	req_access_txt = "47"
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "rdprivacy";
-	name = "Privacy Shutters Control";
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/machinery/button/door{
-	id = "Biohazard";
-	name = "Entrance Shutter Control";
-	pixel_x = -5;
-	pixel_y = 5;
-	req_access_txt = "30"
-	},
-/obj/machinery/button/door{
-	id = "xeno_shutters";
-	name = "Xenobiology Shutters Control";
-	pixel_x = 5;
-	pixel_y = -5;
-	req_access_txt = "30"
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
 /area/shuttle/ftl/crew_quarters/hor)
 "bbF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31616,80 +30657,6 @@
 /area/shuttle/ftl/engine/tool_storage{
 	name = "Secure Storage"
 	})
-"bcr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/circuit,
-/area/shuttle/ftl/research/xenobiology)
-"bcs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/circuit,
-/area/shuttle/ftl/research/xenobiology)
-"bct" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
-/turf/open/floor/circuit,
-/area/shuttle/ftl/research/xenobiology)
-"bcu" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio2";
-	name = "containment blast door"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/cyan{
-	tag = "icon-intact (SOUTHEAST)";
-	icon_state = "intact";
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/research/xenobiology)
-"bcv" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8;
-	target_temperature = 80
-	},
-/obj/machinery/camera{
-	c_tag = "Xenobiology Office";
-	dir = 2;
-	network = list("SS13","RD")
-	},
-/obj/machinery/ai_status_display{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/xenobiology)
-"bcw" = (
-/obj/machinery/shieldwallgen/xenobiologyaccess,
-/obj/structure/closet/crate/science,
-/obj/machinery/requests_console{
-	department = "Science";
-	departmentType = 2;
-	name = "Science Requests Console";
-	pixel_y = 30;
-	receive_ore_updates = 1
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/shuttle/ftl/research/xenobiology)
 "bcx" = (
 /obj/structure/sink{
 	pixel_x = 6;
@@ -31839,22 +30806,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/research/lab)
-"bcI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 4
-	},
-/area/shuttle/ftl/research/lab)
 "bcJ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -31884,18 +30835,6 @@
 "bcL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/station{
 	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/shuttle/ftl/crew_quarters/hor)
-"bcM" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of his office.";
-	name = "Research Monitor";
-	network = list("RD");
-	pixel_y = 2
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -32486,58 +31425,6 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/atmos/equipment)
-"bdI" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio2";
-	name = "containment blast door"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/cyan{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/research/xenobiology)
-"bdJ" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio2";
-	name = "containment blast door"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/cyan{
-	tag = "icon-intact (EAST)";
-	icon_state = "intact";
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/research/xenobiology)
-"bdK" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio2";
-	name = "containment blast door"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/manifold/cyan,
-/turf/open/floor/engine,
-/area/shuttle/ftl/research/xenobiology)
-"bdL" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio2";
-	name = "containment blast door"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/cyan{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/shuttle/ftl/research/xenobiology)
 "bdM" = (
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 4
@@ -32678,19 +31565,6 @@
 	dir = 8
 	},
 /area/shuttle/ftl/research/lab)
-"bdW" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 4
-	},
-/area/shuttle/ftl/research/lab)
 "bdX" = (
 /obj/machinery/modular_computer/console/preset/research{
 	dir = 4
@@ -32700,12 +31574,6 @@
 	},
 /area/shuttle/ftl/crew_quarters/hor)
 "bdY" = (
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/shuttle/ftl/crew_quarters/hor)
-"bdZ" = (
-/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -33116,42 +31984,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/science)
-"beP" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/weapon/extinguisher{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/weapon/extinguisher,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel/warnwhite/side{
-	tag = "icon-white_warn_side (EAST)";
-	icon_state = "white_warn_side";
-	dir = 4
-	},
-/area/shuttle/ftl/research/xenobiology)
-"beQ" = (
-/obj/machinery/processor{
-	desc = "A machine used to process slimes and retrieve their extract.";
-	name = "Slime Processor"
-	},
-/turf/open/floor/plasteel/warnwhite/side{
-	tag = "icon-white_warn_side (EAST)";
-	icon_state = "white_warn_side";
-	dir = 4
-	},
-/area/shuttle/ftl/research/xenobiology)
-"beR" = (
-/obj/machinery/monkey_recycler,
-/turf/open/floor/plasteel/warnwhite/side{
-	tag = "icon-white_warn_side (EAST)";
-	icon_state = "white_warn_side";
-	dir = 4
-	},
-/area/shuttle/ftl/research/xenobiology)
 "beS" = (
 /obj/structure/sign/biohazard,
 /turf/closed/wall/r_wall,
@@ -33579,34 +32411,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/prison)
-"bfB" = (
-/obj/machinery/camera{
-	c_tag = "Brig Cell 1";
-	dir = 4;
-	network = list("SS13","Brig")
-	},
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/wheat,
-/obj/item/weapon/cultivator{
-	force = 0;
-	name = "Plastic cultivator"
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/prison)
-"bfC" = (
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/prison)
-"bfD" = (
-/obj/item/toy/cards/deck{
-	pixel_y = 4
-	},
-/obj/structure/table,
-/mob/living/simple_animal/mouse{
-	layer = 2.7;
-	name = "Perma the pet mouse"
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/shuttle/ftl/security/prison)
 "bfE" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -33727,21 +32531,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/shuttle/ftl/maintenance/science)
-"bfR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/machinery/button/door{
-	id = "xenos_seperation_shutters1";
-	name = "Seperation Shutters Control";
-	pixel_x = -28;
-	pixel_y = -6;
-	req_access_txt = "0"
-	},
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 9
-	},
-/area/shuttle/ftl/research/xenobiology)
 "bfS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -34826,38 +33615,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/ftl/security/prison)
-"bhw" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/door/poddoor/preopen{
-	id = "brig_enter_shutters"
-	},
-/obj/structure/cable{
-	crit_fail = 0;
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/security/prison)
-"bhx" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/security/prison)
 "bhy" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -35273,26 +34030,6 @@
 	dir = 5
 	},
 /area/shuttle/ftl/crew_quarters/hor)
-"bik" = (
-/obj/structure/table/glass,
-/obj/item/weapon/book/manual/wiki/department_standard_operating_procedure_science{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/device/paicard{
-	pixel_x = 4
-	},
-/obj/machinery/power/apc/ship{
-	auto_name = 1;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/shuttle/ftl/crew_quarters/hor)
 "bil" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 1
@@ -35476,27 +34213,6 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/shuttle/ftl/security/prison)
-"biB" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 3";
-	name = "Cell 3 Locker"
-	},
-/obj/machinery/camera{
-	c_tag = "Brig Cell 3";
-	dir = 4;
-	network = list("SS13","Brig")
-	},
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/under/rank/prisoner,
-/obj/structure/sign/poster/random{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/floorgrime,
 /area/shuttle/ftl/security/prison)
 "biC" = (
 /obj/structure/bed,
@@ -38356,40 +37072,6 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/cargo/mining)
-"bnn" = (
-/obj/structure/closet/crate{
-	name = "solar pack crate"
-	},
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/weapon/circuitboard/computer/solar_control,
-/obj/item/weapon/electronics/tracker,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/shuttle/ftl/cargo/mining)
 "bno" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -39983,23 +38665,6 @@
 	dir = 1
 	},
 /area/shuttle/ftl/security/brig)
-"bpS" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
-	},
-/area/shuttle/ftl/security/brig)
 "bpT" = (
 /obj/effect/landmark/start/lawyer,
 /turf/open/floor/plasteel/darkred/side{
@@ -40285,20 +38950,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/darkred/corner,
 /area/shuttle/ftl/cargo/mining)
-"bqt" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "FoB bridge blast";
-	layer = 2.9;
-	name = "bridge blast door"
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/cargo/mining)
 "bqu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -40541,25 +39192,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
-/area/shuttle/ftl/research/server)
-"bqP" = (
-/obj/machinery/door/airlock/glass_command{
-	name = "Server Room";
-	req_access_txt = "30"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/fans/tiny,
-/obj/machinery/atmospherics/pipe/simple/cyan{
-	tag = "icon-intact (NORTH)";
-	icon_state = "intact";
-	dir = 1
-	},
-/turf/open/floor/plasteel/delivery,
 /area/shuttle/ftl/research/server)
 "bqQ" = (
 /obj/machinery/r_n_d/protolathe,
@@ -41123,24 +39755,6 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/shuttle/ftl/atmos)
-"brK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "engineering security door"
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "0";
-	req_one_access_txt = "10;24"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
 "brL" = (
 /obj/machinery/door/poddoor/preopen{
@@ -42192,29 +40806,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/starboard)
-"btx" = (
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/engine/engineering{
-	name = "Starboard Auxilary SMES"
-	})
-"bty" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 1
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/engine/engineering{
-	name = "Starboard Auxilary SMES"
-	})
-"btz" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/ftl/engine/engineering{
-	name = "Starboard Auxilary SMES"
-	})
 "btA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -42677,110 +41268,6 @@
 /obj/structure/disposaloutlet,
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/lab)
-"buv" = (
-/obj/structure/chair/office/dark,
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/power/apc/ship{
-	auto_name = 1;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engineering{
-	name = "Starboard Auxilary SMES"
-	})
-"buw" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/sign/poster/random{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 8;
-	name = "Forward atmos emergency shutoff valve";
-	req_access_txt = "10"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engineering{
-	name = "Starboard Auxilary SMES"
-	})
-"bux" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/obj/machinery/camera{
-	c_tag = "Starboard Auxilary SMES";
-	dir = 2;
-	network = list("SS13")
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engineering{
-	name = "Starboard Auxilary SMES"
-	})
-"buy" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Auxilary SMES Airlock";
-	req_access_txt = "10"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engineering{
-	name = "Starboard Auxilary SMES"
-	})
 "buz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -42986,51 +41473,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/ftl/subshuttle/pod_4)
-"buX" = (
-/obj/item/device/radio/intercom{
-	pixel_x = 0;
-	pixel_y = -28
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
-	dir = 1
-	},
-/obj/machinery/computer/monitor{
-	dir = 1;
-	name = "primary power monitoring console"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engineering{
-	name = "Starboard Auxilary SMES"
-	})
-"buY" = (
-/obj/machinery/power/smes{
-	capacity = 1e+006;
-	charge = 1e+006
-	},
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engineering{
-	name = "Starboard Auxilary SMES"
-	})
-"buZ" = (
-/obj/machinery/power/terminal{
-	tag = "icon-term (WEST)";
-	icon_state = "term";
-	dir = 8
-	},
-/obj/structure/cable/yellow,
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/engine/engineering{
-	name = "Starboard Auxilary SMES"
-	})
 "bva" = (
 /obj/structure/sign/securearea{
 	pixel_x = -32
@@ -43197,6 +41639,40 @@
 	},
 /turf/open/floor/plasteel/darkwarning/side,
 /area/shuttle/ftl/subshuttle/pod_main)
+"bUC" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "genetics_shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/medical/genetics)
+"bVt" = (
+/obj/structure/displaycase/trophy,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
+"ceQ" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8;
+	target_temperature = 80
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
+"crU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
 "cBT" = (
 /obj/machinery/door/airlock/glass_security{
 	id_tag = "";
@@ -43206,6 +41682,34 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/subshuttle/pod_main)
+"cQC" = (
+/obj/machinery/atmospherics/pipe/simple/cyan{
+	tag = "icon-intact (EAST)";
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/machinery/processor{
+	desc = "A machine used to process slimes and retrieve their extract.";
+	name = "Slime Processor"
+	},
+/turf/open/floor/plasteel/warnwhite/side{
+	tag = "icon-white_warn_side (EAST)";
+	icon_state = "white_warn_side";
+	dir = 4
+	},
+/area/shuttle/ftl/research/xenobiology)
+"dgN" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/starboard)
 "enN" = (
 /obj/machinery/door/airlock/shuttle{
 	name = "Emergency Shuttle Airlock";
@@ -43222,6 +41726,33 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/subshuttle/pod_main)
+"eqI" = (
+/obj/item/clothing/gloves/color/fyellow,
+/obj/item/weapon/dice/d6,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/structure/table,
+/obj/item/weapon/stock_parts/cell/high,
+/obj/item/device/t_scanner,
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 4
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"eRt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"eSd" = (
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 1
+	},
+/area/shuttle/ftl/research/xenobiology)
 "fzR" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -43233,6 +41764,23 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/subshuttle/pod_main)
+"fGc" = (
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = -28
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 1
+	},
+/obj/machinery/computer/monitor{
+	dir = 1;
+	name = "primary power monitoring console"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/maintenance/cargo{
+	name = "Starboard Auxiliary SMES"
+	})
 "fPM" = (
 /obj/item/device/radio/intercom{
 	pixel_x = 0;
@@ -43241,10 +41789,118 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/subshuttle/pod_main)
+"fYz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/whitepurple/corner{
+	dir = 4
+	},
+/area/shuttle/ftl/research/xenobiology)
+"glo" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/chair/comfy/black{
+	dir = 2
+	},
+/obj/effect/landmark/start/chaplain,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
+"gnj" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "brig_enter_shutters"
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/prison)
+"gAP" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/prison)
 "gKb" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/subshuttle/pod_main)
+"gVz" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rdprivacy"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "R&D_blastdoor"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/hor)
+"hqD" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "0";
+	req_one_access_txt = "10;24"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/atmos)
+"hvj" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Auxilary SMES Airlock";
+	req_access_txt = "10"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/maintenance/medbay{
+	name = "Port Auxiliary SMES"
+	})
 "hxP" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/glass/bottle/epinephrine{
@@ -43272,6 +41928,32 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/subshuttle/pod_main)
+"hAr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 4
+	},
+/area/shuttle/ftl/research/lab)
 "ikZ" = (
 /obj/structure/chair{
 	dir = 1
@@ -43288,6 +41970,42 @@
 	},
 /turf/open/floor/plasteel/darkwarning/side,
 /area/shuttle/ftl/subshuttle/pod_main)
+"iZJ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "genetics_shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/shuttle/ftl/medical/genetics)
+"jiP" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "brig_enter_shutters"
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/security/prison)
+"jmB" = (
+/obj/machinery/vending/assist,
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 4
+	},
+/area/shuttle/ftl/hallway/primary/port)
 "jsx" = (
 /obj/machinery/door/airlock/external{
 	id_tag = null;
@@ -43318,6 +42036,99 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/subshuttle/pod_main)
+"kfT" = (
+/obj/machinery/photocopier,
+/obj/item/device/radio/intercom{
+	dir = 0;
+	name = "Station Intercom (General)";
+	pixel_y = 28
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
+"kre" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "FoB bridge blast";
+	layer = 2.9;
+	name = "bridge blast door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/cargo/mining)
+"kBs" = (
+/obj/machinery/atmospherics/pipe/simple/cyan{
+	tag = "icon-intact (NORTHEAST)";
+	icon_state = "intact";
+	dir = 5
+	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/weapon/extinguisher{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/weapon/extinguisher,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/warnwhite/side{
+	tag = "icon-white_warn_side (EAST)";
+	icon_state = "white_warn_side";
+	dir = 4
+	},
+/area/shuttle/ftl/research/xenobiology)
+"kPh" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/weapon/storage/belt/utility,
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 4
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"lgc" = (
+/obj/item/device/radio/intercom{
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/machinery/computer/monitor{
+	name = "primary power monitoring console"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/maintenance/medbay{
+	name = "Port Auxiliary SMES"
+	})
+"lkO" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/prison)
 "mdM" = (
 /obj/structure/chair{
 	dir = 1
@@ -43328,6 +42139,101 @@
 	dir = 1
 	},
 /area/shuttle/ftl/subshuttle/pod_main)
+"mmJ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engine Room";
+	name = "engineering security door"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room";
+	req_access_txt = "10"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/delivery{
+	name = "floor"
+	},
+/area/shuttle/ftl/engine/engineering)
+"msD" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rdprivacy"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/hor)
+"mzI" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "0";
+	req_one_access_txt = "12;25;28;35;5"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/aft)
+"nad" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/glass,
+/obj/item/weapon/reagent_containers/food/drinks/britcup{
+	pixel_x = -4
+	},
+/obj/item/weapon/reagent_containers/food/drinks/coffee{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/shuttle/ftl/bridge)
+"ome" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/maintenance/cargo{
+	name = "Starboard Auxiliary SMES"
+	})
+"ouN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/camera{
+	c_tag = "Port Auxilary SMES";
+	dir = 1;
+	network = list("SS13")
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/maintenance/medbay{
+	name = "Port Auxiliary SMES"
+	})
+"oMY" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/maintenance/cargo{
+	name = "Starboard Auxiliary SMES"
+	})
 "oSj" = (
 /obj/machinery/door/airlock/command{
 	name = "Shuttle Bridge";
@@ -43336,6 +42242,12 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/subshuttle/pod_main)
+"pkI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/turf/open/floor/plasteel/vault{
+	dir = 6
+	},
+/area/shuttle/ftl/hallway/primary/port)
 "ptu" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -43345,6 +42257,52 @@
 	dir = 5
 	},
 /area/shuttle/ftl/subshuttle/pod_main)
+"pzt" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the RD's goons from the safety of his office.";
+	name = "Research Monitor";
+	network = list("RD");
+	pixel_y = 2
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/shuttle/ftl/crew_quarters/hor)
+"pIA" = (
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/borg/upgrade/rename,
+/obj/item/borg/upgrade/rename,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/assembly/robotics)
+"qIc" = (
+/obj/machinery/door/airlock/glass_command{
+	name = "Server Room";
+	req_access_txt = "30"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/simple/cyan{
+	tag = "icon-intact (NORTH)";
+	icon_state = "intact";
+	dir = 1
+	},
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/research/server)
 "raK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -43361,6 +42319,54 @@
 	dir = 10
 	},
 /area/shuttle/ftl/bridge)
+"rcY" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Core Access";
+	req_access_txt = "71"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "AI Chamber entrance shutters";
+	name = "AI Chamber entrance shutters"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/delivery,
+/area/shuttle/ftl/turret_protected/ai)
+"rqQ" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/power/apc/ship{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/maintenance/medbay{
+	name = "Port Auxiliary SMES"
+	})
 "rsI" = (
 /obj/item/device/radio/intercom{
 	pixel_x = 0;
@@ -43375,6 +42381,52 @@
 	dir = 6
 	},
 /area/shuttle/ftl/subshuttle/pod_main)
+"sYm" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9;
+	max_integrity = 300;
+	obj_integrity = 300
+	},
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 4
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"thI" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor{
+	id = "Supermatter doors"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/supermatter_core)
+"tjZ" = (
+/obj/machinery/libraryscanner,
+/obj/machinery/camera{
+	c_tag = "Study";
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
+"tAM" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless/warnplate,
+/area/shuttle/ftl/storage/tech{
+	name = "Port Frontal Armor"
+	})
+"tJF" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/mob/living/simple_animal/bot/floorbot,
+/turf/open/floor/circuit,
+/area/shuttle/ftl/turret_protected/ai)
 "tVV" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -43387,12 +42439,50 @@
 	},
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/subshuttle/pod_main)
+"uoY" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/space/basic,
+/area/shuttle/ftl/munitions{
+	name = "Port Weapons Mount"
+	})
+"uvi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
 "uDi" = (
 /obj/machinery/computer/emergency_shuttle,
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 5
 	},
 /area/shuttle/ftl/subshuttle/pod_main)
+"vNv" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/shuttle/ftl/crew_quarters/hor)
+"wbc" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan,
+/obj/machinery/monkey_recycler,
+/turf/open/floor/plasteel/warnwhite/side{
+	tag = "icon-white_warn_side (EAST)";
+	icon_state = "white_warn_side";
+	dir = 4
+	},
+/area/shuttle/ftl/research/xenobiology)
 "wbW" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -43400,12 +42490,33 @@
 /obj/structure/shuttle/engine/propulsion/burst,
 /turf/open/space,
 /area/shuttle/ftl/subshuttle/pod_main)
+"wDw" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/station,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
 "wND" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/ftl/subshuttle/pod_main)
 "wOi" = (
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/subshuttle/pod_main)
+"xaa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/machinery/button/door{
+	id = "xenos_seperation_shutters1";
+	name = "Seperation Shutters Control";
+	pixel_x = -28;
+	pixel_y = -6;
+	req_access_txt = "0"
+	},
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 8
+	},
+/area/shuttle/ftl/research/xenobiology)
 "xHG" = (
 /obj/machinery/recharge_station,
 /obj/machinery/newscaster{
@@ -43413,6 +42524,25 @@
 	},
 /turf/open/floor/circuit,
 /area/shuttle/ftl/subshuttle/pod_main)
+"xNt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
+"xOB" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
+"xWp" = (
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 5
+	},
+/area/shuttle/ftl/research/xenobiology)
 "yqE" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 0;
@@ -43424,6 +42554,96 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/subshuttle/pod_main)
+"yvx" = (
+/obj/structure/closet/crate{
+	name = "solar pack crate"
+	},
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/weapon/circuitboard/computer/solar_control,
+/obj/item/weapon/electronics/tracker,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/cargo/mining)
+"yEx" = (
+/obj/structure/closet/crate/science,
+/obj/machinery/shieldwallgen/xenobiologyaccess,
+/obj/machinery/shieldwallgen/xenobiologyaccess,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
+"yIW" = (
+/obj/structure/chair/office/dark,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/power/apc/ship{
+	auto_name = 1;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/maintenance/cargo{
+	name = "Starboard Auxiliary SMES"
+	})
+"yKo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/window/reinforced,
+/turf/open/floor/circuit,
+/area/shuttle/ftl/research/xenobiology)
 "yPg" = (
 /obj/structure/table,
 /obj/item/weapon/restraints/handcuffs,
@@ -43438,11 +42658,120 @@
 "yQQ" = (
 /turf/open/floor/plasteel/darkwarning,
 /area/shuttle/ftl/subshuttle/pod_main)
+"zbb" = (
+/obj/machinery/door/window/southright,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 2
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"zbx" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engine Room";
+	name = "engineering security door"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room";
+	req_access_txt = "10"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/delivery{
+	name = "floor"
+	},
+/area/shuttle/ftl/engine/engineering)
+"zdf" = (
+/obj/machinery/power/smes{
+	capacity = 1e+006;
+	charge = 1e+006
+	},
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE";
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/maintenance/medbay{
+	name = "Port Auxiliary SMES"
+	})
 "zhi" = (
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 4
 	},
 /area/shuttle/ftl/subshuttle/pod_main)
+"ziX" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/open/floor/circuit,
+/area/shuttle/ftl/turret_protected/ai)
+"ztJ" = (
+/obj/structure/lattice/catwalk,
+/obj/item/stack/cable_coil{
+	amount = 1;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable,
+/turf/open/space,
+/area/shuttle/ftl/munitions{
+	name = "Port Weapons Mount"
+	})
+"zwZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
+/obj/machinery/camera{
+	c_tag = "Starboard Auxilary SMES";
+	dir = 2;
+	network = list("SS13")
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/maintenance/cargo{
+	name = "Starboard Auxiliary SMES"
+	})
 "zEX" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light{
@@ -43454,6 +42783,17 @@
 	dir = 10
 	},
 /area/shuttle/ftl/subshuttle/pod_main)
+"zKu" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/libraryconsole/bookmanagement,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
 "zPa" = (
 /obj/structure/chair{
 	dir = 8
@@ -43473,6 +42813,48 @@
 	dir = 6
 	},
 /area/shuttle/ftl/subshuttle/pod_main)
+"zTw" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/maintenance/medbay{
+	name = "Port Auxiliary SMES"
+	})
+"zXZ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 2
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/prison)
+"AwW" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "0";
+	req_one_access_txt = "55,12"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/aft)
+"AyG" = (
+/obj/structure/table/wood,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/machinery/power/apc/ship{
+	auto_name = 1;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
 "ACr" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -43489,12 +42871,115 @@
 	dir = 10
 	},
 /area/shuttle/ftl/subshuttle/pod_main)
+"AMr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
+"APT" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/maintenance/medbay{
+	name = "Port Auxiliary SMES"
+	})
+"Bcy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
+"BEF" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/glass_external{
+	name = "External Access";
+	req_access_txt = "10";
+	req_one_access_txt = "10;48"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/delivery{
+	name = "floor"
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"CiX" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/turf/open/space,
+/area/shuttle/ftl/munitions{
+	name = "Port Weapons Mount"
+	})
+"CFe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
 "DfS" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/subshuttle/pod_main)
+"Dhu" = (
+/obj/structure/table/wood,
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
+/obj/item/device/flashlight/lamp/green{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/weapon/pen/blue{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/mob/living/simple_animal/mouse{
+	layer = 2.7
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
+"EbI" = (
+/obj/structure/bookcase/random,
+/obj/machinery/light/small,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
 "EJQ" = (
 /obj/structure/chair{
 	dir = 8
@@ -43507,6 +42992,26 @@
 	dir = 4
 	},
 /area/shuttle/ftl/subshuttle/pod_main)
+"EQe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "0";
+	req_one_access_txt = "12;25;28;35;5"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/starboard)
 "ETb" = (
 /obj/machinery/door/window/southright{
 	dir = 8;
@@ -43517,15 +43022,210 @@
 	dir = 8
 	},
 /area/shuttle/ftl/subshuttle/pod_main)
+"Fai" = (
+/obj/machinery/button/door{
+	id = "R&D_blastdoor";
+	name = "Secure Lab Shutter Control";
+	pixel_x = -5;
+	pixel_y = -5;
+	req_access_txt = "47"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "rdprivacy";
+	name = "Privacy Shutters Control";
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/machinery/button/door{
+	id = "Biohazard";
+	name = "Entrance Shutter Control";
+	pixel_x = -5;
+	pixel_y = 5;
+	req_access_txt = "30"
+	},
+/obj/machinery/button/door{
+	id = "xeno_shutters";
+	name = "Xenobiology Shutters Control";
+	pixel_x = 5;
+	pixel_y = -5;
+	req_access_txt = "30"
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/shuttle/ftl/crew_quarters/hor)
+"Fuw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Assistant"
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
+"FDx" = (
+/obj/structure/lattice/catwalk,
+/obj/item/stack/cable_coil{
+	amount = 1;
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/turf/open/space,
+/area/shuttle/ftl/munitions{
+	name = "Port Weapons Mount"
+	})
+"FQX" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/weapon/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/eastright{
+	dir = 2;
+	name = "Research and Development Desk";
+	req_access_txt = "30"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rdprivacy";
+	name = "research shutters"
+	},
+/obj/item/weapon/pen,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "R&D_blastdoor"
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/hor)
 "FSi" = (
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/subshuttle/pod_main)
+"FTi" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/space/basic,
+/area/shuttle/ftl/munitions{
+	name = "Port Weapons Mount"
+	})
+"Gmv" = (
+/obj/effect/landmark/start{
+	name = "Research Director";
+	shuttle_abstract_movable = 1
+	},
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/shuttle/ftl/crew_quarters/hor)
 "Gpc" = (
 /obj/machinery/computer/communications,
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 9
 	},
 /area/shuttle/ftl/subshuttle/pod_main)
+"GUP" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rdprivacy"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/hor)
+"GVl" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engine Room";
+	name = "engineering security door"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room";
+	req_access_txt = "10"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/delivery{
+	name = "floor"
+	},
+/area/shuttle/ftl/engine/engineering)
+"HsF" = (
+/obj/machinery/camera{
+	c_tag = "Brig Cell 1";
+	dir = 4;
+	network = list("SS13","Brig")
+	},
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/wheat,
+/obj/item/weapon/cultivator{
+	force = 0;
+	name = "Plastic cultivator"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/prison)
 "HCk" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/ftl/subshuttle/pod_main)
@@ -43537,11 +43237,85 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/subshuttle/pod_main)
+"HHp" = (
+/obj/machinery/light/small,
+/obj/structure/sign/poster/random{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/maintenance/medbay{
+	name = "Port Auxiliary SMES"
+	})
+"HZv" = (
+/obj/machinery/power/smes{
+	capacity = 1e+006;
+	charge = 1e+006
+	},
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/maintenance/cargo{
+	name = "Starboard Auxiliary SMES"
+	})
+"IGM" = (
+/obj/machinery/door/window/southright{
+	dir = 8
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 1
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"JhU" = (
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/maintenance/cargo{
+	name = "Starboard Auxiliary SMES"
+	})
+"JiJ" = (
+/obj/item/weapon/twohanded/required/kirbyplants/random,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
 "Jtq" = (
 /obj/structure/window/shuttle,
 /obj/structure/grille,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/subshuttle/pod_main)
+"JJx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Librarian"
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
 "KyJ" = (
 /turf/open/floor/plasteel/darkwarning/corner{
 	tag = "icon-black_warn_corner (NORTH)";
@@ -43549,11 +43323,60 @@
 	dir = 1
 	},
 /area/shuttle/ftl/subshuttle/pod_main)
+"LFC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = "90Curve"
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
+"LGj" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/blue/corner{
+	dir = 4
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
 "LMm" = (
 /obj/structure/window/shuttle,
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/shuttle/ftl/subshuttle/pod_main)
+"MdA" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/shuttle/ftl/hallway/primary/starboard)
+"MAn" = (
+/obj/machinery/computer/card/minor/rd{
+	dir = 4
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/shuttle/ftl/crew_quarters/hor)
 "MEi" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/structure/sink{
@@ -43564,6 +43387,26 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/subshuttle/pod_main)
+"MSs" = (
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 9
+	},
+/area/shuttle/ftl/research/xenobiology)
+"NbW" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
+/obj/machinery/smartfridge/chemistry/virology/preloaded,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whitegreen/side{
+	dir = 1
+	},
+/area/shuttle/ftl/medical/virology)
 "NjW" = (
 /obj/structure/closet/emcloset,
 /obj/item/weapon/tank/internals/emergency_oxygen,
@@ -43573,6 +43416,25 @@
 	dir = 8
 	},
 /area/shuttle/ftl/subshuttle/pod_main)
+"Nkv" = (
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/device/flashlight/glowstick/random,
+/obj/item/device/flashlight/glowstick/random,
+/obj/item/device/radio{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/item/device/radio,
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/weapon/crowbar/large,
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 4
+	},
+/area/shuttle/ftl/hallway/primary/port)
 "NuG" = (
 /obj/machinery/sleeper{
 	dir = 8;
@@ -43587,6 +43449,74 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/subshuttle/pod_main)
+"Nvq" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/turret_protected/ai)
+"NAS" = (
+/obj/machinery/bookbinder,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
+"NZW" = (
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	name = "Science Requests Console";
+	pixel_y = 30;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
+"OjO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Assistant"
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
+"OEZ" = (
+/obj/structure/table/wood,
+/obj/item/weapon/paper_bin{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/weapon/folder/red,
+/obj/item/weapon/pen/blue{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
+"OGG" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engine Room";
+	name = "engineering security door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/engine/engineering)
 "ORt" = (
 /obj/structure/cable{
 	crit_fail = 0;
@@ -43598,6 +43528,33 @@
 	name = "floor"
 	},
 /area/shuttle/ftl/hallway/primary/starboard)
+"Pcr" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/sign/poster/random{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/maintenance/cargo{
+	name = "Starboard Auxiliary SMES"
+	})
 "Pqi" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/emergency,
@@ -43607,6 +43564,54 @@
 	},
 /turf/open/floor/plasteel/darkblue,
 /area/shuttle/ftl/subshuttle/pod_main)
+"PKN" = (
+/obj/item/toy/cards/deck{
+	pixel_y = 4
+	},
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/mob/living/simple_animal/mouse{
+	layer = 2.7;
+	name = "Perma the pet mouse"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/prison)
+"PMo" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "0";
+	req_one_access_txt = "12;25;28;35;5"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/hallway/primary/port)
+"PMt" = (
+/obj/structure/table/wood,
+/obj/item/device/modular_computer/laptop/preset/civillian,
+/obj/item/device/camera_film,
+/obj/item/device/camera,
+/obj/machinery/light/small,
+/obj/structure/sign/poster/random{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
 "PVx" = (
 /obj/machinery/computer/shuttle/advanced{
 	dir = 8;
@@ -43614,6 +43619,25 @@
 	},
 /turf/open/floor/plasteel/darkred,
 /area/shuttle/ftl/cargo/mining)
+"Qnt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/maintenance/medbay{
+	name = "Port Auxiliary SMES"
+	})
+"QYc" = (
+/obj/structure/table/wood,
+/obj/machinery/newscaster{
+	pixel_y = 30
+	},
+/obj/item/weapon/book/codex_gigas,
+/obj/item/clothing/mask/cigarette/pipe,
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
 "RnR" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -43637,6 +43661,118 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/subshuttle/pod_main)
+"RCQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
+"RGO" = (
+/obj/structure/table/glass,
+/obj/item/weapon/book/manual/wiki/department_standard_operating_procedure_science{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/device/paicard{
+	pixel_x = 4
+	},
+/obj/machinery/power/apc/ship{
+	auto_name = 1;
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/shuttle/ftl/crew_quarters/hor)
+"RGY" = (
+/obj/structure/window/reinforced{
+	dir = 2;
+	layer = 2.9;
+	max_integrity = 300;
+	obj_integrity = 300
+	},
+/obj/item/device/analyzer,
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/wrench,
+/obj/item/device/flashlight/glowstick/random,
+/obj/item/device/flashlight/glowstick/random,
+/obj/item/weapon/screwdriver,
+/obj/item/device/toner,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 2
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"RPw" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Auxilary SMES Airlock";
+	req_access_txt = "10"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/maintenance/cargo{
+	name = "Starboard Auxiliary SMES"
+	})
+"RTs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/shuttle/ftl/research/xenobiology)
+"RVE" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/space,
+/area/shuttle/ftl/munitions{
+	name = "Port Weapons Mount"
+	})
+"Shu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/maintenance/medbay{
+	name = "Port Auxiliary SMES"
+	})
 "SyK" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -43659,6 +43795,21 @@
 /obj/item/weapon/storage/firstaid/regular,
 /turf/open/floor/plasteel/black,
 /area/shuttle/ftl/subshuttle/pod_main)
+"SJw" = (
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/cargo/mining)
+"SPz" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/holopad,
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
 "TjY" = (
 /obj/structure/chair{
 	dir = 8
@@ -43678,6 +43829,44 @@
 	dir = 8
 	},
 /area/shuttle/ftl/subshuttle/pod_main)
+"UzW" = (
+/obj/machinery/power/terminal{
+	tag = "icon-term (WEST)";
+	icon_state = "term";
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/maintenance/medbay{
+	name = "Port Auxiliary SMES"
+	})
+"UDZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/shuttle/ftl/security/brig)
+"UJK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/station,
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/port)
 "UVt" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -43689,6 +43878,67 @@
 	},
 /turf/open/space,
 /area/shuttle/ftl/subshuttle/pod_main)
+"VLd" = (
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 2;
+	layer = 2.9;
+	max_integrity = 300;
+	obj_integrity = 300
+	},
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/device/multitool{
+	pixel_x = 4
+	},
+/obj/item/weapon/wirecutters,
+/obj/item/weapon/weldingtool,
+/obj/item/weapon/screwdriver,
+/obj/item/device/t_scanner,
+/obj/item/device/assembly/signaler,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 2
+	},
+/area/shuttle/ftl/hallway/primary/port)
+"Wlg" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rdprivacy"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "R&D_blastdoor"
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/crew_quarters/hor)
+"WzE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 4
+	},
+/area/shuttle/ftl/research/lab)
 "WDp" = (
 /obj/structure/chair{
 	dir = 1
@@ -43698,6 +43948,73 @@
 	},
 /turf/open/floor/plasteel/darkwarning/side,
 /area/shuttle/ftl/subshuttle/pod_main)
+"WIZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/window/reinforced,
+/turf/open/floor/circuit,
+/area/shuttle/ftl/research/xenobiology)
+"XaL" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 4
+	},
+/area/shuttle/ftl/research/lab)
+"Xuf" = (
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 3";
+	name = "Cell 3 Locker"
+	},
+/obj/machinery/camera{
+	c_tag = "Brig Cell 3";
+	dir = 4;
+	network = list("SS13","Brig")
+	},
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/under/rank/prisoner,
+/obj/structure/sign/poster/random{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 2
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/shuttle/ftl/security/prison)
+"XDk" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/ftl/security/prison)
+"XVM" = (
+/obj/structure/closet/crate{
+	name = "spare equipment crate"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/shuttle/ftl/cargo/mining)
 "YaW" = (
 /obj/machinery/door/airlock/shuttle{
 	name = "Emergency Shuttle Airlock";
@@ -43711,6 +44028,41 @@
 	dir = 8
 	},
 /area/shuttle/ftl/subshuttle/pod_main)
+"Yfh" = (
+/obj/machinery/camera{
+	c_tag = "Xenobiology Office";
+	dir = 2;
+	network = list("SS13","RD")
+	},
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/shuttle/ftl/research/xenobiology)
+"ZLu" = (
+/obj/machinery/power/terminal{
+	tag = "icon-term (WEST)";
+	icon_state = "term";
+	dir = 8
+	},
+/obj/structure/cable/yellow,
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/maintenance/cargo{
+	name = "Starboard Auxiliary SMES"
+	})
+"ZYL" = (
+/obj/structure/cable{
+	crit_fail = 0;
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
 
 (1,1,1) = {"
 aaa
@@ -60931,7 +61283,7 @@ bmk
 bnw
 boR
 bgy
-brK
+hqD
 bsW
 btc
 btc
@@ -63912,7 +64264,7 @@ aFj
 aFj
 aHb
 aIb
-aJh
+thI
 aKf
 aLv
 aMO
@@ -65915,7 +66267,7 @@ aAG
 aBs
 aCp
 aCq
-aEr
+mmJ
 aCs
 aGi
 aCn
@@ -65925,11 +66277,11 @@ aCn
 aCn
 aCn
 aCn
-aOZ
-aOZ
+OGG
+OGG
 aOZ
 aCs
-aTi
+zbx
 aCq
 aCp
 aWg
@@ -66440,10 +66792,10 @@ aYf
 aaH
 aPd
 aZo
-bcr
-bdI
-beP
-bfR
+yKo
+kBs
+MSs
+xaa
 bgQ
 bgQ
 bgQ
@@ -66666,7 +67018,7 @@ ayL
 azv
 aAH
 ahl
-aCr
+GVl
 aDr
 aEu
 aCp
@@ -66691,10 +67043,10 @@ aYi
 aaH
 aPd
 aZo
-bcs
-bdJ
-beQ
-bfS
+WIZ
+cQC
+eSd
+uvi
 bgR
 bhZ
 biT
@@ -66929,8 +67281,8 @@ aCn
 aCn
 aCn
 aCn
-aOZ
-aOZ
+OGG
+OGG
 aCn
 aCp
 aCp
@@ -66942,10 +67294,10 @@ aYj
 aaH
 aPd
 aZo
-bct
-bdK
-beR
-bfS
+RTs
+wbc
+xWp
+fYz
 bgS
 aZo
 bgZ
@@ -67193,8 +67545,8 @@ aYf
 aaH
 bam
 aZo
-bcu
-bdL
+yEx
+ceQ
 beS
 bfS
 bgT
@@ -67444,7 +67796,7 @@ aYk
 aZn
 ban
 aZo
-bcv
+Yfh
 bdM
 beT
 bfT
@@ -67695,7 +68047,7 @@ aYl
 aaH
 aPd
 aZo
-bcw
+NZW
 bdN
 beU
 bfS
@@ -69213,7 +69565,7 @@ bid
 aZo
 bnV
 bpo
-bqP
+qIc
 brV
 btj
 bul
@@ -70191,12 +70543,12 @@ aJm
 aKx
 aLM
 aNd
-aJm
+AwW
 aPe
 aQl
 aRE
 aSx
-aTv
+pIA
 aSx
 aVt
 aWs
@@ -70957,9 +71309,9 @@ aAR
 aYw
 aZu
 baw
-bbA
-bcI
-bdW
+hAr
+WzE
+XaL
 bff
 bfZ
 bhc
@@ -71208,7 +71560,7 @@ aXq
 aYx
 aZv
 bax
-bbB
+GUP
 bcJ
 bbB
 bfg
@@ -71458,15 +71810,15 @@ aOd
 aXr
 aYy
 aZw
-bay
-bbC
+Wlg
+MAn
 bcK
 bdX
 bfh
 bga
 bhe
 bii
-bbB
+msD
 bjZ
 blt
 bmD
@@ -71709,15 +72061,15 @@ aOd
 aXs
 aYy
 aZw
-baz
-bbD
+FQX
+Gmv
 bcL
 bdY
 bfi
 bdY
 bhf
 bij
-bbB
+msD
 bka
 blu
 bmE
@@ -71960,15 +72312,15 @@ aOe
 aXt
 aYz
 aZw
-bay
-bbE
-bcM
-bdZ
+Wlg
+Fai
+pzt
+vNv
 bfj
 bgb
 bhg
-bik
-bbB
+RGO
+msD
 bkb
 blv
 bmF
@@ -72212,9 +72564,9 @@ aXu
 aYy
 aZx
 baA
-bay
-bay
-bay
+gVz
+gVz
+gVz
 baA
 baA
 baA
@@ -72924,7 +73276,7 @@ acI
 adP
 aff
 agx
-ahM
+pkI
 aiW
 aku
 alK
@@ -73189,7 +73541,7 @@ avu
 awO
 arf
 awU
-azS
+mzI
 aAZ
 aAZ
 aCI
@@ -73698,7 +74050,7 @@ aCK
 aDK
 aEM
 aFE
-aGD
+iZJ
 aHn
 aIu
 aJv
@@ -74200,7 +74552,7 @@ aCM
 aCM
 aEO
 aFG
-aGF
+bUC
 aHr
 aIw
 aJx
@@ -74469,7 +74821,7 @@ aVH
 aWA
 aXz
 aVH
-aZC
+NbW
 baE
 bbJ
 bcR
@@ -74925,9 +75277,9 @@ aab
 aad
 aad
 aad
-aam
-aam
-aam
+zTw
+zTw
+zTw
 acM
 adX
 adX
@@ -74953,7 +75305,7 @@ aCO
 aCM
 aER
 aFJ
-aGF
+bUC
 aHt
 aIz
 aJz
@@ -74988,10 +75340,10 @@ bgc
 bpI
 brf
 bsl
-btx
-btx
-btx
-btx
+JhU
+JhU
+JhU
+JhU
 aad
 aad
 aad
@@ -75176,10 +75528,10 @@ aab
 aad
 aad
 aad
-aam
-aaT
-abK
-acN
+zTw
+lgc
+rqQ
+Shu
 adY
 afm
 afm
@@ -75204,7 +75556,7 @@ aCN
 aCM
 aES
 aFK
-aGF
+bUC
 aHu
 aIA
 aJA
@@ -75239,10 +75591,10 @@ bgc
 bpJ
 brg
 bsm
-bty
-buv
-buX
-btx
+ome
+yIW
+fGc
+JhU
 aad
 aad
 aad
@@ -75427,10 +75779,10 @@ aab
 aad
 aad
 aad
-aam
-aaU
-abL
-acN
+zTw
+zdf
+HHp
+Qnt
 adZ
 afn
 agD
@@ -75490,10 +75842,10 @@ bgc
 bpK
 brd
 bsk
-btx
-buw
-buY
-btx
+JhU
+Pcr
+HZv
+JhU
 aad
 aad
 aad
@@ -75678,10 +76030,10 @@ aab
 aad
 aad
 aad
-aam
-aaV
-abM
-acO
+zTw
+UzW
+ouN
+APT
 aea
 abR
 agE
@@ -75741,10 +76093,10 @@ bgc
 bpL
 brd
 bsn
-btz
-bux
-buZ
-btx
+oMY
+zwZ
+ZLu
+JhU
 aad
 aad
 aad
@@ -75929,10 +76281,10 @@ aab
 aad
 aad
 aad
-aam
-aam
-abN
-acP
+zTw
+zTw
+hvj
+Qnt
 aeb
 abR
 agF
@@ -75992,10 +76344,10 @@ bgc
 bpM
 brd
 bso
-btx
-buy
-btx
-btx
+JhU
+RPw
+JhU
+JhU
 aad
 aad
 aad
@@ -77461,9 +77813,9 @@ aBa
 aBS
 aCT
 aDS
-aEX
-aFO
-aGH
+tJF
+ziX
+rcY
 aHy
 aIE
 aJE
@@ -77746,7 +78098,7 @@ bkv
 blO
 bmW
 bom
-bpS
+UDZ
 brm
 bss
 bpE
@@ -78468,7 +78820,7 @@ aad
 aad
 aad
 aad
-aHB
+Nvq
 aII
 aJI
 aad
@@ -79745,10 +80097,10 @@ aye
 bbN
 bdh
 beq
-bfB
-bgo
-bhv
-biB
+HsF
+zXZ
+gAP
+Xuf
 bgo
 bhv
 blU
@@ -79996,9 +80348,9 @@ ayd
 bbN
 bdi
 ber
-bfC
+bgo
 bgp
-bhw
+jiP
 ber
 bgp
 bkD
@@ -80247,9 +80599,9 @@ ayd
 bbN
 bdj
 bes
-bfD
+PKN
 bgq
-bhv
+XDk
 biC
 bjw
 bhv
@@ -80448,8 +80800,8 @@ aad
 aad
 aaf
 aan
-aan
-aan
+sYm
+IGM
 adb
 aem
 afC
@@ -80466,7 +80818,7 @@ ata
 auv
 aqc
 awZ
-ayh
+PMo
 aan
 aAe
 abR
@@ -80494,13 +80846,13 @@ aWL
 aXG
 aYQ
 aZL
-baL
+EQe
 bbN
 bbN
 bet
-bfE
+gnj
 bfA
-bhx
+lkO
 bfE
 bfE
 bkE
@@ -80698,11 +81050,11 @@ aab
 aad
 aad
 aag
-aap
-abh
-abY
-adc
-aen
+aao
+jmB
+UJK
+zbb
+atq
 afD
 agT
 aid
@@ -80749,9 +81101,9 @@ baM
 aZM
 bdk
 aZM
-aZM
+MdA
 bgr
-aZM
+eRt
 aZM
 aZM
 bkF
@@ -80949,11 +81301,11 @@ aab
 aad
 aad
 aah
-aaq
-abi
-abZ
-add
-aeo
+aao
+eqI
+aec
+RGY
+aep
 afE
 agU
 agU
@@ -81002,7 +81354,7 @@ aZN
 aZN
 aZN
 bgs
-aZN
+dgN
 aZN
 aZN
 bkG
@@ -81201,9 +81553,9 @@ aad
 aad
 aag
 aao
-abj
-abj
-ade
+Nkv
+kPh
+VLd
 aep
 afF
 ael
@@ -81253,7 +81605,7 @@ bdl
 beu
 bfF
 bgt
-aZO
+LGj
 aZO
 aZO
 bkH
@@ -81755,9 +82107,9 @@ bdn
 bev
 aZQ
 aad
-bgw
-bgw
-bjx
+aad
+aad
+aad
 aad
 aZL
 bnf
@@ -81765,10 +82117,10 @@ ORt
 bqg
 aZL
 aad
-bgw
-bgw
-bjx
-aac
+aad
+aad
+aad
+aad
 aac
 aad
 aad
@@ -82005,21 +82357,21 @@ bbP
 bdo
 bew
 aZQ
-bgu
-bgw
-bgw
-bgw
-bgu
+aad
+aad
+aad
+aad
+aad
 aZL
 bng
 boy
 bng
 aZL
-bsE
-btL
-btL
-btL
-bgu
+aad
+aad
+aad
+aad
+aad
 aac
 aad
 aad
@@ -82256,21 +82608,21 @@ bbQ
 bdp
 bev
 aZQ
-bgv
-bhz
-bhz
-bhz
-bgv
+aad
+bgw
+bgw
+bjx
+aad
 bgv
 bnh
 boz
 bqh
 bgv
-bsF
-bhz
-bhz
-bhz
-bgv
+aad
+bgw
+bgw
+bjx
+aac
 aac
 aad
 aad
@@ -82507,21 +82859,21 @@ bbR
 bdq
 bev
 aZQ
+bgu
+bgw
+bgw
+bgw
+bgu
 bgv
-bhA
-bgx
-bgx
-bkI
+SJw
+boF
+SJw
 bgv
-bni
-boA
-bni
-bgv
-bsG
-bgx
-buJ
-bvj
-bgv
+bsE
+btL
+btL
+btL
+bgu
 aac
 aae
 aad
@@ -82759,19 +83111,19 @@ bdr
 bex
 aZQ
 bgv
-bhB
-biD
-bjy
-bkJ
-blV
-bnj
-boB
-bqi
-blV
-bsH
-bgx
-buK
-bvk
+bhz
+bhz
+bhz
+bgv
+bgv
+bni
+boF
+XVM
+bgv
+bsF
+bhz
+bhz
+bhz
 bgv
 aac
 aad
@@ -83010,19 +83362,19 @@ bds
 bey
 aZU
 bgv
-bhC
+bhA
 bgx
 bgx
 bkI
 bgv
-bnk
-boC
-bqj
+bni
+boA
+bni
 bgv
-bsI
-btM
-buK
-bvl
+bsG
+bgx
+buJ
+bvj
 bgv
 aac
 aad
@@ -83261,19 +83613,19 @@ bdt
 bey
 aZU
 bgv
-bhD
-bgx
-bgx
-bkK
-bgv
-bnl
-boD
-bni
-bgv
-bsJ
+bhB
+biD
+bjy
+bkJ
+blV
+bnj
+boB
+bqi
+blV
+bsH
 bgx
 buK
-bvm
+bvk
 bgv
 aac
 aad
@@ -83511,21 +83863,21 @@ bbV
 bdu
 bez
 aZU
-bgu
-bgu
-biE
-bjz
-bjz
-blW
-bnm
-boE
-bqk
-bry
-bsK
-btN
-buL
-bgu
-bgu
+bgv
+bhC
+bgx
+bgx
+bkI
+bgv
+bnk
+boC
+bqj
+bgv
+bsI
+btM
+buK
+bvl
+bgv
 aac
 aad
 aad
@@ -83762,21 +84114,21 @@ bbW
 bdv
 beA
 aZU
-aad
-bgu
-bgu
-bjA
-bkL
 bgv
-bnn
-boF
-bql
-bgv
-bsL
+bhD
 bgx
-bgu
-bgu
-aad
+bgx
+bkK
+bgv
+bnl
+boD
+bni
+bgv
+bsJ
+bgx
+buK
+bvm
+bgv
 aac
 aac
 aad
@@ -84013,21 +84365,21 @@ bbX
 baW
 aZU
 aZU
-aad
-aad
-bgv
-bgv
-bgv
-blX
-bno
-boG
-bqm
-bgv
-bsM
-btO
-bgv
-aad
-aad
+bgu
+bgu
+biE
+bjz
+bjz
+blW
+bnm
+boE
+bqk
+bry
+bsK
+btN
+buL
+bgu
+bgu
 aac
 aac
 aad
@@ -84265,19 +84617,19 @@ bdw
 aZU
 aad
 aad
-aad
+bgu
+bgu
+bjA
+bkL
 bgv
-bjB
-bkM
-blY
+yvx
+boF
+bql
 bgv
-boH
-bqn
-bgv
-bgv
-bgv
-bgv
-aad
+bsL
+bgx
+bgu
+bgu
 aad
 aac
 aac
@@ -84517,17 +84869,17 @@ aZU
 aad
 aad
 aad
-biF
-bjC
-bkN
-blZ
-biF
-boI
-bqo
-brz
-bsN
-btP
-brz
+bgv
+bgv
+bgv
+blX
+bno
+boG
+bqm
+bgv
+bsM
+btO
+bgv
 aad
 aad
 aad
@@ -84768,17 +85120,17 @@ aZU
 aad
 aad
 aad
-biF
-bjD
-bkO
-bma
-bnp
-boJ
-bqp
-brA
-bsO
-bsO
-jsx
+bgv
+bjB
+bkM
+blY
+bgv
+boH
+bqn
+bgv
+bgv
+bgv
+bgv
 aad
 aad
 aad
@@ -84989,8 +85341,8 @@ aan
 aAn
 aBk
 aCe
-aDi
-aEe
+ztJ
+FDx
 aCe
 aCe
 aGX
@@ -85020,15 +85372,15 @@ aad
 aad
 aad
 biF
-bjE
-bkP
-bmb
+bjC
+bkN
+blZ
 biF
 boI
 bqo
 brz
-bsP
-btQ
+bsN
+btP
 brz
 aad
 aad
@@ -85249,7 +85601,7 @@ aHU
 aIU
 aJW
 aLl
-aMH
+nad
 aNR
 aOK
 aIU
@@ -85270,17 +85622,17 @@ aZU
 aad
 aad
 aad
-bgv
-bjF
-bkQ
-bmc
-bgv
-boK
-bqo
-brB
-bsQ
-btR
-bgv
+biF
+bjD
+bkO
+bma
+bnp
+boJ
+bqp
+brA
+bsO
+bsO
+jsx
 aad
 aad
 aad
@@ -85519,21 +85871,21 @@ aZU
 baZ
 aZU
 aXT
-bgw
-bhE
-bgv
-bgv
-bgv
-bmd
-bgv
-boL
+aad
+aad
+biF
+bjE
+bkP
+bmb
+biF
+boI
 bqo
-brC
-brC
-brC
 brz
-bgw
-bvo
+bsP
+btQ
+brz
+aad
+aad
 aad
 aad
 aad
@@ -85735,11 +86087,11 @@ aqz
 arQ
 atr
 atr
-awg
 ats
-ayr
+ats
+RCQ
 atu
-aad
+atu
 aAs
 aad
 aad
@@ -85770,21 +86122,21 @@ aZU
 baZ
 aZU
 aXT
-bgx
-bgx
+aad
+aad
 bgv
-bjG
-bkR
-bme
-bnq
-boI
-bqq
-brD
-bsR
-btS
+bjF
+bkQ
+bmc
 bgv
-bgx
-btL
+boK
+bqo
+brB
+bsQ
+btR
+bgv
+aad
+aad
 aad
 aad
 aad
@@ -85986,12 +86338,12 @@ aqA
 arR
 ats
 auF
-awh
-axg
-ays
+auH
+bVt
+Fuw
+auH
 atu
-aAo
-aBl
+aAs
 aAn
 aAm
 aAm
@@ -86021,21 +86373,21 @@ aZU
 baZ
 aZU
 aZb
+bgw
+bhE
 bgv
 bgv
 bgv
-bjH
-bkS
-bmf
-bnr
-boJ
-bqr
-brE
-bsS
+bmd
+bgv
+boL
+bqo
 brC
-buN
-bgv
-bgv
+brC
+brC
+brz
+bgw
+bvo
 aad
 aad
 aad
@@ -86236,13 +86588,13 @@ aoZ
 aqB
 arS
 att
-auG
-awi
-awm
-ayt
+CFe
+LFC
+xNt
+crU
+EbI
 atu
-aAp
-aac
+RVE
 aac
 aac
 aac
@@ -86272,21 +86624,21 @@ aZU
 baZ
 aZU
 aXT
-bgu
+bgx
+bgx
 bgv
+bjG
+bkR
+bme
+brz
+boI
+bqq
+brD
+bsR
+btS
 bgv
-bjI
-bkT
-bmg
-bnq
-boM
-bqs
-brF
-bsT
-btT
-bgv
-bgv
-bgu
+bgx
+btL
 aad
 aad
 aad
@@ -86487,13 +86839,13 @@ apa
 aqC
 arT
 ats
-auH
-awj
-awm
-ayu
+JiJ
+ZYL
+AMr
+crU
+awh
 ats
-aAq
-aad
+aAr
 aad
 aad
 aad
@@ -86523,21 +86875,21 @@ aZQ
 bdx
 aZQ
 aXT
-aad
-aad
-bgu
-bgv
-bgv
-bmd
-bgv
-boN
-bqt
 bgv
 bgv
 bgv
-bgu
-aad
-aad
+bjH
+bkS
+bmf
+bnr
+boJ
+bqr
+brE
+bsS
+brC
+buN
+bgv
+bgv
 aad
 aad
 aad
@@ -86735,16 +87087,16 @@ afO
 aml
 aan
 aao
-aqD
+BEF
 aap
 atu
-auI
-awk
-axh
-ayv
+kfT
+glo
+xOB
+crU
+tjZ
 ats
-aAr
-aad
+uoY
 aad
 aad
 aad
@@ -86774,21 +87126,21 @@ aZQ
 bbb
 aZQ
 aXT
-aXT
-aad
 bgu
 bgv
-bkU
-bmh
-bns
-boO
-bqu
-brG
-bsU
+bgv
+bjI
+bkT
+bmg
+bnq
+boM
+bqs
+brF
+bsT
+btT
+bgv
 bgv
 bgu
-aad
-aad
 aad
 aad
 aad
@@ -86989,13 +87341,13 @@ abj
 aqE
 abh
 atu
-auJ
-awl
-axi
-ayw
+Dhu
+SPz
+OEZ
+JJx
+NAS
 ats
 aAs
-aAn
 aad
 aad
 aad
@@ -87025,19 +87377,19 @@ aZV
 bbc
 aZV
 aXV
-aXT
-aXU
-aXU
+aXS
+aXS
 bgu
-bkV
-bmi
-bnt
-boP
-bqv
-brH
+bgv
+bgv
+bmd
+bgv
+boN
+kre
+bgv
+bgv
 bgv
 bgu
-aad
 aad
 aad
 aad
@@ -87240,13 +87592,13 @@ abj
 aqF
 abY
 atu
-auK
-awm
-axj
-ayx
+AyG
+OjO
+awn
+crU
+PMt
 atu
 aAs
-aad
 aad
 aad
 aad
@@ -87276,21 +87628,21 @@ aZW
 bbd
 aZW
 bfG
-aXW
-aXT
 aXU
-aad
+aXU
+bgu
 bgv
-bmj
-bnu
-PVx
-bqw
-brI
+bkU
+bmh
+bns
+boO
+bqu
+brG
+bsU
 bgv
+bgu
 aad
 aad
-aac
-aac
 aac
 aac
 aad
@@ -87491,13 +87843,13 @@ aao
 aqG
 aap
 atu
-auL
-awm
-awm
-ayy
+QYc
+awh
+wDw
+Bcy
+zKu
 atu
-aAs
-aad
+FTi
 aad
 aad
 aad
@@ -87530,18 +87882,18 @@ aXT
 aXT
 aXT
 aXT
-aXU
 bgu
-bgv
-bnv
-bnv
-bnv
+bkV
+bmi
+bnt
+boP
+bqv
+brH
 bgv
 bgu
 aad
 aad
-aac
-aac
+aad
 aac
 aac
 aad
@@ -87743,12 +88095,12 @@ aqH
 amo
 ats
 ats
-awn
-axk
+bVt
+JiJ
+bVt
 ats
 ats
-aAs
-aad
+aAq
 aad
 aad
 aad
@@ -87781,16 +88133,16 @@ aXT
 aXV
 aXT
 aXT
-aXT
-aXT
-aXT
-aXT
-aXT
-aXY
+aXS
+bgv
+bmj
+bnu
+PVx
+bqw
+brI
+bgv
 aad
 aad
-aad
-aac
 aac
 aac
 aac
@@ -87997,9 +88349,9 @@ ats
 ats
 ats
 ats
-azl
-aAt
-aad
+ats
+aaN
+uoY
 aad
 aad
 aad
@@ -88032,16 +88384,16 @@ aXW
 aXU
 aXT
 aXT
-bfI
 aXU
-aXT
-aXS
-aXU
-aaN
+bgu
+bgv
+bnv
+bnv
+bnv
+bgv
+bgu
 aad
 aad
-aad
-aac
 aac
 aac
 aac
@@ -88248,9 +88600,9 @@ atw
 atw
 axl
 atw
-azm
-aio
-aac
+tAM
+CiX
+aBl
 aac
 aac
 aac
@@ -88284,10 +88636,10 @@ aXS
 aXT
 aXT
 aXT
-aWW
-bhF
+aXT
+aXT
 aXY
-aad
+aaN
 aad
 aac
 aac


### PR DESCRIPTION
[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)
[]: # (See here for how to easily make a changelog: https://github.com/tgstation/tgstation/wiki/Changelogs. An example changelog has been provided below. Please edit or remove)


:cl: Ecolli The FTL Guy
fix: Pushed the mining shuttle forward so the airlock is no longer eaten when the shuttle returns.
add: Added more space to the library to fit a library computer. Uploading copies of WGW has never been easier!
add: Added a tool storage by the escape shuttle.
fix: Fixed some maintenance access to allow people without maintenance access to get out of their department.
fix: Lobby is no longer focused on customs checkpoints, hopefully?
fix: Corrected some invisible pipes.
fix: Corrected some invisible wiring.
fix: Resolved duplicate Auxiliary SMES areas by utilising unused areas.
/:cl:

Time to switch back to the Scarab.
