### PR TITLE
Removed duplicate water vapor entries

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -84,7 +84,7 @@ GLOBAL_LIST_INIT(hardcoded_gases, list("o2","n2","co2","plasma")) //the main fou
 	specific_heat = 20
 	name = "BZ"
 	dangerous = TRUE
-	
+
 /datum/gas/hydrogen
 	id = "hydrogen"
 	specific_heat = 300
@@ -92,19 +92,12 @@ GLOBAL_LIST_INIT(hardcoded_gases, list("o2","n2","co2","plasma")) //the main fou
 	gas_overlay = "hydrogen"
 	moles_visible = 1
 	dangerous = TRUE
-	
+
 /datum/gas/fusion_plasma
 	id = "fusion_plasma"
 	specific_heat = 600
 	name = "Fusion Plasma"
 	dangerous = TRUE
-	
-/datum/gas/water_vapor
-	id = "water_vapor"
-	specific_heat = 40
-	name = "Water Vapor"
-	gas_overlay = "water_vapor"
-	moles_visible = MOLES_PLASMA_VISIBLE
 
 /obj/effect/overlay/gas
 	icon = 'icons/effects/tile_effects.dmi'


### PR DESCRIPTION
Remove them vapes (Credit to Altangy for the spot)

:cl: Crossedfall
del: Removed duplicate water vapor entry from the gas mixtures list
/:cl:

[why]: # It rustled my jimmies.... Also, clean code is happy code. No reason to have duplicate gas entries with the same ID.
