### PR TITLE
Meteors no longer just delete shield effects

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -147,8 +147,7 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 					A.visible_message("<span class='warning'>[src] slams into [A].</span>", "<span class='userdanger'>[src] slams into you!.</span>")
 				A.ex_act(hitpwr)
 			else //We hit the ships shields
-				for(var/area/shuttle/ftl/area in world)
-					area << SSship.shield_hit_sound
+				SSstarmap.ftl_sound(SSship.shield_hit_sound)
 				SSstarmap.ftl_shieldgen.take_hit()
 				SSship.broadcast_message("<span class=warning>Impact detected from a meteor! Hit absorbed by shields.",SSship.error_sound)
 				qdel(src) //Now delete the meteor

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -147,10 +147,10 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 					A.visible_message("<span class='warning'>[src] slams into [A].</span>", "<span class='userdanger'>[src] slams into you!.</span>")
 				A.ex_act(hitpwr)
 			else //We hit the ships shields
-				for(var/area/shuttle/ftl/A in world)
-					A << shield_hit_sound
+				for(var/area/shuttle/ftl/area in world)
+					area << SSship.shield_hit_sound
 				SSstarmap.ftl_shieldgen.take_hit()
-				broadcast_message("<span class=warning>Impact detected from a meteor! Hit absorbed by shields.",error_sound,S)
+				SSship.broadcast_message("<span class=warning>Impact detected from a meteor! Hit absorbed by shields.",SSship.error_sound)
 				qdel(src) //Now delete the meteor
 
 

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -139,12 +139,20 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 		get_hit()
 
 /obj/effect/meteor/proc/ram_turf(turf/T)
-	//first bust whatever is in the turf
+	//first bust whatever is in the turf or check if we hit a shield
 	for(var/atom/A in T)
 		if(A != src)
-			if(isliving(A))
-				A.visible_message("<span class='warning'>[src] slams into [A].</span>", "<span class='userdanger'>[src] slams into you!.</span>")
-			A.ex_act(hitpwr)
+			if(!istype(A,/obj/effect/ftl_shield))
+				if(isliving(A))
+					A.visible_message("<span class='warning'>[src] slams into [A].</span>", "<span class='userdanger'>[src] slams into you!.</span>")
+				A.ex_act(hitpwr)
+			else //We hit the ships shields
+				for(var/area/shuttle/ftl/A in world)
+					A << shield_hit_sound
+				SSstarmap.ftl_shieldgen.take_hit()
+				broadcast_message("<span class=warning>Impact detected from a meteor! Hit absorbed by shields.",error_sound,S)
+				qdel(src) //Now delete the meteor
+
 
 	//then, ram the turf if it still exists
 	if(T)

--- a/code/game/machinery/ftl_shieldgen.dm
+++ b/code/game/machinery/ftl_shieldgen.dm
@@ -200,6 +200,10 @@
 	anchored = 1
 	pass_flags = LETPASSTHROW
 
+
+/obj/effect/ftl_shield/forceMove(turf/target) //Don't move this effect during FTL
+	return
+
 /obj/effect/ftl_shield/CanPass(atom/movable/mover, turf/target, height=0) // Shields are one-way: Shit can leave, but shit can't enter
 	if(istype(loc, /turf/open/space/transit))
 		return 0


### PR DESCRIPTION
because the crew needs *more* help blowing the ship up clearly

REQUIRES #3520 FOR SHIELDS TO NOT FUCK OFF DURING FTL

:cl: TMTIME
fix: Meteors now cause shields to drop
/:cl:

[why]: 

This is a bug that resulted in admins always cancelling meteor events
