### PR TITLE
Make shells explosive again

### DIFF
--- a/code/game/objects/structures/cannon_shell.dm
+++ b/code/game/objects/structures/cannon_shell.dm
@@ -29,11 +29,11 @@
 	if(armed) icon_state = "[icon_state]_armed"
 	else icon_state = initial(icon_state)
 
-/obj/structure/shell/Bump(obstacle)
-	if(throwing && armed)
-		explosion(get_turf(src), 1, 2, 6)
-		throwing = 0
-	..()
+/obj/structure/shell/Collide(atom/A)
+	if((A))
+		if(throwing && armed)
+			explosion(get_turf(src), 1, 2, 6)
+			throwing = 0
 
 /obj/item/weapon/twohanded/required/shell_casing
 	name = "cannon shell casing"

--- a/code/game/objects/structures/cannon_shell.dm
+++ b/code/game/objects/structures/cannon_shell.dm
@@ -32,7 +32,7 @@
 /obj/structure/shell/Collide(atom/A)
 	if((A))
 		if(throwing && armed)
-			explosion(get_turf(src), 1, 2, 6)
+			explosion(get_turf(src), 2, 5, 10)
 			throwing = 0
 
 /obj/item/weapon/twohanded/required/shell_casing


### PR DESCRIPTION
This change makes mac shells explode if armed and ejected from the cannon again. I have also increased the explosion radius to make it a little more punishing. The new explosion radius is enough to do some serious damage to munitions and the surrounding rooms, but not enough to be a round ended. The operator has a chance to survive a shell explosion.

:cl: Crossedfall
tweak: Shell explosion size, made it the equivalent of an explosion with a power of 25. _(2, 5, 10)_
fix: Replaced the old "Bump" movement proc with the better "Collision" proc (see [atoms_movable.dm](https://github.com/FTL13/FTL13/blob/master/code/game/atoms_movable.dm) as a reference)
/:cl:

## Old explosion
![old explosion](https://user-images.githubusercontent.com/26130695/39162618-04148c02-473c-11e8-8d23-f90c999cf239.png)
## New explosion
![New explosion](https://user-images.githubusercontent.com/26130695/39162609-f1803532-473b-11e8-9931-802479aa02e6.png)

[why]: Shells are meant to be explosive when armed. This will resolve #3524
