### PR TITLE
Stops shuttles doing that weird move thing 

### DIFF
--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -43,6 +43,7 @@
 	throw_atom(AM)
 
 /turf/open/space/transit/proc/throw_atom(atom/movable/AM)
+	set waitfor = FALSE
 	if(noop || !AM || istype(AM, /obj/docking_port))
 		return
 	if(AM.loc != src) //Multi-tile objects are "in" multiple locs but its loc is it's true placement.


### PR DESCRIPTION
merge fast please


:cl: TMTIME
fix: Stops the shuttle from moving line by line when moving
/:cl:

[why]: aaaaaaaaaaaa its now moving and not stopping everything from processing at the same time
