### PR TITLE
Sets dirs for planet landings

### DIFF
--- a/code/modules/shuttle/dock_landmarks.dm
+++ b/code/modules/shuttle/dock_landmarks.dm
@@ -72,3 +72,4 @@
 	allowed_shuttles = ALL_SHUTTLES
 	keep_hidden = FALSE
 	distance = -25
+	dir = 8


### PR DESCRIPTION
gitkracken why did you make to make this change so hard

:cl: TMTIME
fix: FOB shuttle no longer lands sideways
/:cl:

