### PR TITLE
Gives admins the power to create weapon hit markers

### DIFF
--- a/code/controllers/subsystem/ships.dm
+++ b/code/controllers/subsystem/ships.dm
@@ -195,7 +195,7 @@ SUBSYSTEM_DEF(ship)
 		if(!istype(T,/turf/open/space))
 			target = T //Turf picked to fire at.
 
-	W.attack_effect(target) //Spawns the hit marker
+	W.attack_data.attack_effect(target) //Spawns the hit marker
 
 	spawn(50) //TODO:heretic filth replace with timer someday
 

--- a/code/datums/ship.dm
+++ b/code/datums/ship.dm
@@ -423,7 +423,7 @@ GLOBAL_VAR(next_ship_id)
 	attack_data = /datum/ship_attack/stun_bomb
 
 /datum/ship_component/weapon/fast_stunbomb
-	name = "fast chaingun"
+	name = "fast stunbomber"
 	cname = "fast_stunbomber"
 	fire_rate = 150
 

--- a/code/datums/ship.dm
+++ b/code/datums/ship.dm
@@ -287,9 +287,6 @@ GLOBAL_VAR(next_ship_id)
 
 	alt_image = "weapon"
 
-/datum/ship_component/weapon/proc/attack_effect(var/turf/T)
-	new /obj/effect/temp_visual/ship_target(T, attack_data)
-
 /datum/ship_component/weapon/random
 	name = "standard mount"
 	cname = "r_weapon"
@@ -473,14 +470,6 @@ GLOBAL_VAR(next_ship_id)
 	health = 30 //please dont 1shot my fancy new weapon please
 
 	fire_rate = 500
-
-/datum/ship_component/weapon/unknown_ship_weapon/attack_effect(var/turf/T) //10 shots, 7 spread
-	var/turf/target_sub
-	new /obj/effect/temp_visual/ship_target(T, attack_data) //Initial hit
-	for(var/I = 1 to 10) //Loop for each fragment
-		spawn(attack_data.warning_time+I)//Saves spamming many audio queues at once
-			target_sub = locate(T.x + rand(-7,7),T.y + rand(-7,7), T.z)
-			new /obj/effect/temp_visual/ship_target(target_sub, attack_data)
 
 // AI MODULES
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -783,22 +783,15 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, list(
 	set name = "Create ship weapon impact"
 	set category = "FTL"
 	set desc = "Spawn a weapon hit marker at your current location"
-	var/list/weapons = list()
-	for(var/datum/ship_component/weapon/W in SSship.ship_components) //TODO: improve when floyd finishes the weapon revamp by moving the attack_effect proc into ship_attack
-		weapons += W
-	for(var/datum/ship_component/weapon/random/memegun/W in SSship.ship_components) //fuck random weapons
-		for(var/datum/ship_attack/A in W.possible_weapons)
-			var/datum/ship_component/weapon/temp = new /datum/ship_component/weapon
-			temp.attack_data = new A
-			temp.name = temp.attack_data.cname
-			weapons += temp
+	var/list/weapons = subtypesof(/datum/ship_attack)
 
-	var/datum/ship_component/weapon/tofire = input("Which weapon do you want to fire at the ship?") in (list("CANCEL") + weapons)
-	if(tofire != "CANCEL")
-		tofire.attack_effect(mob.loc)
-		SSship.broadcast_message("<span class=warning>A stray round from a [tofire.name] has pierced the shield and hit! Hit location: [mob.loc.loc].</span>",SSship.error_sound)
-		log_admin("[key_name(usr)] spawned a [tofire.name] impact at [mob.loc.loc]")
-		message_admins("[key_name(usr)] spawned a [tofire.name] impact at [mob.loc.loc]")
+	var/input = input("Which weapon do you want to fire at the ship?") in (list("CANCEL") + weapons)
+	if(input == "CANCEL") return
+	var/datum/ship_attack/a = new input
+	a.attack_effect(mob.loc)
+	SSship.broadcast_message("<span class=warning>A stray round from a [a.cname] has pierced the shield and hit! Hit location: [mob.loc.loc].</span>",SSship.error_sound)
+	log_admin("[key_name(usr)] spawned a [a.cname] impact at [mob.loc.loc]")
+	message_admins("[key_name(usr)] spawned a [a.cname] impact at [mob.loc.loc]")
 
 /client/proc/create_fleet()
 	set name = "Generate Fleet (Current System)"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -98,6 +98,7 @@ GLOBAL_LIST_INIT(admin_verbs_fun, list(
 	/client/proc/create_wingmen,
 	/client/proc/ftl_force_jump,
 	/client/proc/toggle_ship_combat_log_spam,
+	/client/proc/ftl_stray_shot,
 	/client/proc/smite
 	))
 
@@ -777,6 +778,21 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, list(
 		SSship.ship_combat_log_spam = TRUE
 		log_admin("[key_name(usr)] has turned combat log spam on.")
 		message_admins("[key_name_admin(usr)] has turned combat log spam on.")
+
+/client/proc/ftl_stray_shot()
+	set name = "Create ship weapon impact"
+	set category = "FTL"
+	set desc = "Spawn a weapon hit marker at your current location"
+	var/list/weapons = list()
+	for(var/datum/ship_component/weapon/W in SSship.ship_components)
+		weapons += W
+
+	var/datum/ship_component/weapon/tofire = input("Which weapon do you want to fire at the ship?") in (list("CANCEL") + weapons)
+	if(tofire != "CANCEL")
+		tofire.attack_effect(mob.loc)
+		SSship.broadcast_message("<span class=warning>A stray round from a [tofire.name] has pierced the shield and hit! Hit location: [mob.loc.loc].</span>",SSship.error_sound)
+		log_admin("[key_name(usr)] spawned a [tofire.name] hit at [mob.loc.loc]")
+		message_admins("[key_name(usr)] spawned a [tofire.name] hit at [mob.loc.loc]")
 
 /client/proc/create_fleet()
 	set name = "Generate Fleet (Current System)"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -784,15 +784,21 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, list(
 	set category = "FTL"
 	set desc = "Spawn a weapon hit marker at your current location"
 	var/list/weapons = list()
-	for(var/datum/ship_component/weapon/W in SSship.ship_components)
+	for(var/datum/ship_component/weapon/W in SSship.ship_components) //TODO: improve when floyd finishes the weapon revamp by moving the attack_effect proc into ship_attack
 		weapons += W
+	for(var/datum/ship_component/weapon/random/memegun/W in SSship.ship_components) //fuck random weapons
+		for(var/datum/ship_attack/A in W.possible_weapons)
+			var/datum/ship_component/weapon/temp = new /datum/ship_component/weapon
+			temp.attack_data = new A
+			temp.name = temp.attack_data.cname
+			weapons += temp
 
 	var/datum/ship_component/weapon/tofire = input("Which weapon do you want to fire at the ship?") in (list("CANCEL") + weapons)
 	if(tofire != "CANCEL")
 		tofire.attack_effect(mob.loc)
 		SSship.broadcast_message("<span class=warning>A stray round from a [tofire.name] has pierced the shield and hit! Hit location: [mob.loc.loc].</span>",SSship.error_sound)
-		log_admin("[key_name(usr)] spawned a [tofire.name] hit at [mob.loc.loc]")
-		message_admins("[key_name(usr)] spawned a [tofire.name] hit at [mob.loc.loc]")
+		log_admin("[key_name(usr)] spawned a [tofire.name] impact at [mob.loc.loc]")
+		message_admins("[key_name(usr)] spawned a [tofire.name] impact at [mob.loc.loc]")
 
 /client/proc/create_fleet()
 	set name = "Generate Fleet (Current System)"

--- a/code/modules/ftl/weaponry/ship_attacks.dm
+++ b/code/modules/ftl/weaponry/ship_attacks.dm
@@ -21,6 +21,9 @@
 /datum/ship_attack/proc/damage_effects(var/turf/epicenter)
 	return
 
+/datum/ship_attack/proc/attack_effect(var/turf/T)
+	new /obj/effect/temp_visual/ship_target(T, src)
+
 /datum/ship_attack/laser
 	cname = "phase cannon"
 	projectile_effect = "heavylaser"
@@ -195,6 +198,15 @@
 
 /datum/ship_attack/prototype_laser_barrage/damage_effects(turf/epicenter)
 	explosion(epicenter,1,3,6,9,SSship.ship_combat_log_spam)
+
+
+	/datum/ship_attack/prototype_laser_barrage/attack_effect(var/turf/T) //10 shots, 7 spread
+	var/turf/target_sub
+	new /obj/effect/temp_visual/ship_target(T, src) //Initial hit
+	for(var/I = 1 to 10) //Loop for each fragment
+		spawn(warning_time+I)//Saves spamming many audio queues at once
+			target_sub = locate(T.x + rand(-7,7),T.y + rand(-7,7), T.z)
+			new /obj/effect/temp_visual/ship_target(target_sub, src)
 
 //Below is the hell of adminbus weaponry, keep these at the bottom like they should be :^). Don't use these on serious ships.
 

--- a/code/modules/ftl/weaponry/ship_attacks.dm
+++ b/code/modules/ftl/weaponry/ship_attacks.dm
@@ -200,7 +200,7 @@
 	explosion(epicenter,1,3,6,9,SSship.ship_combat_log_spam)
 
 
-	/datum/ship_attack/prototype_laser_barrage/attack_effect(var/turf/T) //10 shots, 7 spread
+/datum/ship_attack/prototype_laser_barrage/attack_effect(var/turf/T) //10 shots, 7 spread
 	var/turf/target_sub
 	new /obj/effect/temp_visual/ship_target(T, src) //Initial hit
 	for(var/I = 1 to 10) //Loop for each fragment

--- a/code/modules/ftl/weaponry/ship_attacks.dm
+++ b/code/modules/ftl/weaponry/ship_attacks.dm
@@ -199,14 +199,15 @@
 /datum/ship_attack/prototype_laser_barrage/damage_effects(turf/epicenter)
 	explosion(epicenter,1,3,6,9,SSship.ship_combat_log_spam)
 
+/datum/ship_attack/prototype_laser_barrage/proc/subimpact(var/turf/T)
+	new /obj/effect/temp_visual/ship_target(T, src)
 
 /datum/ship_attack/prototype_laser_barrage/attack_effect(var/turf/T) //10 shots, 7 spread
 	var/turf/target_sub
 	new /obj/effect/temp_visual/ship_target(T, src) //Initial hit
 	for(var/I = 1 to 10) //Loop for each fragment
-		spawn(warning_time+I)//Saves spamming many audio queues at once
-			target_sub = locate(T.x + rand(-7,7),T.y + rand(-7,7), T.z)
-			new /obj/effect/temp_visual/ship_target(target_sub, src)
+		target_sub = locate(T.x + rand(-7,7),T.y + rand(-7,7), T.z)
+		addtimer(CALLBACK(src, .proc/subimpact, target_sub), warning_time+(2*I)) //Saves spamming many audio queues at once
 
 //Below is the hell of adminbus weaponry, keep these at the bottom like they should be :^). Don't use these on serious ships.
 

--- a/code/modules/ftl/weaponry/ship_attacks.dm
+++ b/code/modules/ftl/weaponry/ship_attacks.dm
@@ -172,7 +172,8 @@
 	for(var/I = 1 to amount)
 		var/path = pick(boarding_mobs)
 		var/mob/to_spawn = new path(epicenter)
-		to_spawn.faction = list(our_ship_component.ship.faction)
+		if(our_ship_component.ship) //Means that attacks spawned from verbs deafult to Syndicate and don't runtime
+			to_spawn.faction = list(our_ship_component.ship.faction)
 
 /datum/ship_attack/carrier_weapon/oneTime
 	var/fired = FALSE


### PR DESCRIPTION
dumb verb only for adminbus


:cl: TMTIME
add: Admins can now spawn weapon hit markers
fix: Incorrect slow stunbomber name
/:cl:


pray oh honkmother please drown the bridge in vapebombs please

Will rework some parts once floub does his weapon revamp by moving attack_effect to ship_attack datums