### PR TITLE
Stops war from being declared if they are in transit/out of range

### DIFF
--- a/code/controllers/subsystem/ships.dm
+++ b/code/controllers/subsystem/ships.dm
@@ -202,6 +202,13 @@ SUBSYSTEM_DEF(ship)
 
 /datum/controller/subsystem/ship/proc/damage_ship(var/datum/ship_component/C,var/datum/ship_attack/attack_data,var/datum/starship/attacking_ship = null,var/shooter)
 	var/datum/starship/S = C.ship
+	if(attacking_ship)
+		broadcast_message("<span class=notice>[faction2prefix(attacking_ship)] ship ([attacking_ship.name]) firing on [faction2prefix(S)] ship ([S.name]).",null,S)
+	if((!attacking_ship && S.planet != SSstarmap.current_planet) || (attacking_ship && attacking_ship.planet != S.planet))
+		spawn(10) //a bit of a delay wouldn't hurt, especially since we now have a cool af laser sound
+			if(istype(S)) // fix for runtime (ship might have ceased to exist during the spawn)
+				broadcast_message("<span class=notice>Shot missed! [faction2prefix(S)] ship ([S.name]) out of range!</span>",error_sound,S)
+		return
 	if(!attacking_ship) //No attacker means its the player
 		if(check_hostilities(S.faction,"ship") != 0) //We only care if they ain't at war
 			make_hostile(S.faction,"ship")
@@ -210,13 +217,6 @@ SUBSYSTEM_DEF(ship)
 			if(S.faction != "nanotrasen") //start dat intergalactic war
 				make_hostile(S.faction,"nanotrasen")
 				make_hostile("nanotrasen",S.faction)
-	if(attacking_ship)
-		broadcast_message("<span class=notice>[faction2prefix(attacking_ship)] ship ([attacking_ship.name]) firing on [faction2prefix(S)] ship ([S.name]).",null,S)
-	if((!attacking_ship && S.planet != SSstarmap.current_planet) || (attacking_ship && attacking_ship.planet != S.planet))
-		spawn(10) //a bit of a delay wouldn't hurt, especially since we now have a cool af laser sound
-			if(istype(S)) // fix for runtime (ship might have ceased to exist during the spawn)
-				broadcast_message("<span class=notice>Shot missed! [faction2prefix(S)] ship ([S.name]) out of range!</span>",error_sound,S)
-		return
 	if(prob(S.evasion_chance * attack_data.evasion_mod))
 		spawn(10)
 			if(istype(S)) // fix for runtime (ship might have ceased to exist during the spawn)


### PR DESCRIPTION
s p e e d r e s o l v e

:cl: TMTIME
fix: Stops factions from declaring war if the shot was never going to hit
/:cl:

fixes #3553 