### PR TITLE
Better fix for broken shuttle dock dirs

### DIFF
--- a/code/modules/shuttle/dock_landmarks.dm
+++ b/code/modules/shuttle/dock_landmarks.dm
@@ -1,6 +1,7 @@
 //Eventualy these should create the docking port in initialize but for now that requires too much work
 
 /obj/effect/landmark/dock_spawn
+	dir = WEST
 	var/turf_type = /turf/open/space
 	var/baseturf_type = /turf/open/space
 	var/area_type = /area/space


### PR DESCRIPTION

:cl: TMTIME
fix: fixes FOB landing sideways on ice and habitable planets and cargo shuttle on station docks
/:cl:

[why]: # kill me why was that not there
