### PR TITLE
Fixes an error when deconstructing Luminosity Eyes

### DIFF
--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -146,7 +146,7 @@
 /obj/item/organ/eyes/robotic/glow
 	name = "High Luminosity Eyes"
 	desc = "Special glowing eyes, used by snowflakes who want to be special."
-	origin_tech = "material=3;biotech=3;engineering=3;magnets=4"
+	origin_tech = "materials=3;biotech=3;engineering=3;magnets=4"
 	eye_color = "000"
 	actions_types = list(/datum/action/item_action/organ_action/use, /datum/action/item_action/organ_action/toggle)
 	var/current_color_string = "#ffffff"


### PR DESCRIPTION
[Changelogs]: When deconstructing luminosity eyes players would get the error, "ERROR: Report This 3." This was caused by a typo in the items tech origin.

:cl: optional name here
fix: Corrected the High Luminosity Eyes' tech origin
/:cl:

[why]: Errors are bad mkay