### PR TITLE
Changes random name generation to use the ship name generation

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -60,7 +60,7 @@ GLOBAL_VAR(command_name)
 		if(config && config.station_name)
 			newname = config.station_name
 		else
-			newname = new_station_name()
+			newname = "NSV [generate_ship_name()]"
 
 		set_station_name(newname)
 


### PR DESCRIPTION
As the title says

:cl: Vivalas
tweak: Station name is now picked using the same method NPC ship names are picked.
/:cl:

[why]: Because NSV Buttmasher is better than Hooligan Waypoint Seven
