### PR TITLE
Makes cells removable

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1242,7 +1242,6 @@
 
 /obj/machinery/power/apc/ship
 	cell_type = 500
-	removable_cell = 0
 
 /*Power module, used for APC construction*/
 /obj/item/weapon/electronics/apc


### PR DESCRIPTION
[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)
[]: # (See here for how to easily make a changelog: https://github.com/tgstation/tgstation/wiki/Changelogs. An example changelog has been provided below. Please edit or remove)


:cl: Altangy
tweak: APCs on all ships can have their power cells removed.
fix: Because the power cells on ship APCs can be changed, APCs can be deconstructed.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) Okay, ever since we removed the ability for players to remove cells they couldn't deconstruct APCs. This is an issue for repairs as you have to bash the things off the walls do replace the APC if the cover is damaged or the terminal if that gets burned up. Considering we don't really have an issue with players removing and upgrading cells there is no point in removing the ability to remove cells.