### PR TITLE
Somehow fixes map templates

### DIFF
--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -33,6 +33,27 @@
 
 	log_game("Z-level [name] loaded at at [x],[y],[world.maxz]")
 
+/datum/map_template/proc/initTemplateBounds(var/list/bounds)
+	var/list/obj/machinery/atmospherics/atmos_machines = list()
+	var/list/obj/structure/cable/cables = list()
+	var/list/atom/atoms = list()
+
+	for(var/L in block(locate(bounds[MAP_MINX], bounds[MAP_MINY], bounds[MAP_MINZ]),
+	                   locate(bounds[MAP_MAXX], bounds[MAP_MAXY], bounds[MAP_MAXZ])))
+		var/turf/B = L
+		for(var/A in B)
+			atoms += A
+			if(istype(A,/obj/structure/cable))
+				cables += A
+				continue
+			if(istype(A,/obj/machinery/atmospherics))
+				atmos_machines += A
+				continue
+
+	SSatoms.InitializeAtoms(atoms)
+	SSmachines.setup_template_powernets(cables)
+	SSair.setup_template_machinery(atmos_machines)
+
 /datum/map_template/proc/load(turf/T, centered = FALSE)
 	if(centered)
 		T = locate(T.x - round(width/2) , T.y - round(height/2) , T.z)
@@ -49,7 +70,9 @@
 
 	if(!SSmapping.loading_ruins) //Will be done manually during mapping ss init
 		repopulate_sorted_areas()
-	
+
+	//initialize things that are normally initialized after map load
+	initTemplateBounds(bounds)
 
 	log_game("[name] loaded at at [T.x],[T.y],[T.z]")
 	return TRUE


### PR DESCRIPTION
im back

:cl: TMTIME
fix: Survival pods and the admin map template command spawn initialised areas again
/:cl:

fixes #3470
fixes #2627

an eh fix and will be replaced by actual neater fixes with a rebase

This fix means salvage maps can now be toggled back on.

Oh god they can now be toggled back on