### PR TITLE
Station/ship destroyed, mission failed.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -150,7 +150,7 @@ GLOBAL_VAR(bot_ip)
 	var/mutant_races = 0				//players can choose their mutant race before joining the game
 	var/list/roundstart_races = list()	//races you can play as from the get go. If left undefined the game's roundstart var for species is used
 	var/mutant_humans = 0				//players can pick mutant bodyparts for humans before joining the game
-
+	var/check_station_integrity = FALSE //Whether critical station integrity should force a round restart
 	var/no_summon_guns		//No
 	var/no_summon_magic		//Fun
 	var/no_summon_events	//Allowed
@@ -748,6 +748,8 @@ GLOBAL_VAR(bot_ip)
 							GLOB.roundstart_species[species_id] = GLOB.species_list[species_id]
 				if("join_with_mutant_humans")
 					mutant_humans			= 1
+				if("check_station_integrity")
+					check_station_integrity = TRUE
 				if("assistant_cap")
 					assistant_cap			= text2num(value)
 				if("starlight")

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -186,6 +186,14 @@
 		return TRUE
 	if(station_was_nuked)
 		return TRUE
+
+	if(config.check_station_integrity)
+		var/static/datum/station_state/end_state = new /datum/station_state() //Static so it doesn't have to keep being remade.
+		end_state.count()
+		var/station_integrity = min(PERCENT(GLOB.start_state.score(end_state)), 100)
+		if(station_integrity <= 20) //Below 20% integrity
+			message_admins("The station/ship has suffered critical damage, with the config set so that it ends the round with critical damage. Doing so..")
+			return TRUE
 	if(!round_converted && (!config.continuous[config_tag] || (config.continuous[config_tag] && config.midround_antag[config_tag]))) //Non-continuous or continous with replacement antags
 		if(!continuous_sanity_checked) //make sure we have antags to be checking in the first place
 			for(var/mob/Player in GLOB.mob_list)


### PR DESCRIPTION
Should the ship receive critical damage, the round ends.

:cl: 
add: Should the ship receive critical damage. The round ends.
/:cl:

[why]: # Right now, should the ship get turboclucked into the 8th ring of hell with nobody alive to call it off, it resolves to admin intervention to end the round. This is somewhat unfortunate should an admin not be present to press the explode-everything button.
