### PR TITLE
Makes gas mouse transparent

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -97,19 +97,20 @@
 
 /turf/open/proc/update_visuals()
 	var/list/new_overlay_types = tile_graphic()
+	var/list/atmos_overlay_types = src.atmos_overlay_types // Cache for free performance
 
 	if (atmos_overlay_types)
 		for(var/overlay in atmos_overlay_types-new_overlay_types) //doesn't remove overlays that would only be added
-			cut_overlay(overlay)
+			vis_contents -= overlay
 
-	if (new_overlay_types.len)
+	if (length(new_overlay_types))
 		if (atmos_overlay_types)
-			add_overlay(new_overlay_types - atmos_overlay_types) //don't add overlays that already exist
+			vis_contents += new_overlay_types - atmos_overlay_types //don't add overlays that already exist
 		else
-			add_overlay(new_overlay_types)
+			vis_contents += new_overlay_types
 
 	UNSETEMPTY(new_overlay_types)
-	atmos_overlay_types = new_overlay_types
+	src.atmos_overlay_types = new_overlay_types
 
 /turf/open/proc/tile_graphic()
 	. = new /list


### PR DESCRIPTION
:cl: ninjanomnom
tweak: Gas overlays no longer block clicks when a stray pixel goes in front of your mouse
/:cl:

An easy to port tg thing you guys apparently don't have. This does require 512.

Port of https://github.com/tgstation/tgstation/pull/32569 and other changes to the same feature