### PR TITLE
Enables the weather subsystem

### DIFF
--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -3,7 +3,7 @@ SUBSYSTEM_DEF(weather)
 	name = "Weather"
 	flags = SS_BACKGROUND
 	wait = 10
-	can_fire = 0 //bandaid to stop the random ash storms on planets, at least until it's revamped to planetary weather
+	can_fire = 1 //bandaid to stop the random ash storms on planets, at least until it's revamped to planetary weather
 	runlevels = RUNLEVEL_GAME
 	var/list/processing = list()
 	var/list/existing_weather = list()

--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -3,7 +3,7 @@ SUBSYSTEM_DEF(weather)
 	name = "Weather"
 	flags = SS_BACKGROUND
 	wait = 10
-	can_fire = 1 //bandaid to stop the random ash storms on planets, at least until it's revamped to planetary weather
+	can_fire = 1 
 	runlevels = RUNLEVEL_GAME
 	var/list/processing = list()
 	var/list/existing_weather = list()


### PR DESCRIPTION
:cl: Crossedfall
tweak: Allows the weather subsystem to fire again
/:cl:

[why]: # Because storms are fun and for the most part are working again. No reason not to enable this.