### PR TITLE
Stops alien larva from spamming runtimes

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -405,9 +405,9 @@
 			liver_failure()
 		else
 			liver.failing = FALSE
-
-	if(((!(NOLIVER in dna.species.species_traits)) && (!liver)))
-		liver_failure()
+	if(dna)
+		if(((!(NOLIVER in dna.species.species_traits)) && (!liver)))
+			liver_failure()
 
 /mob/living/carbon/proc/undergoing_liver_failure()
 	var/obj/item/organ/liver/liver = getorganslot("liver")

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -405,9 +405,8 @@
 			liver_failure()
 		else
 			liver.failing = FALSE
-	if(dna)
-		if(((!(NOLIVER in dna.species.species_traits)) && (!liver)))
-			liver_failure()
+	if((dna && (!(NOLIVER in dna.species.species_traits)) && (!liver)))
+		liver_failure()
 
 /mob/living/carbon/proc/undergoing_liver_failure()
 	var/obj/item/organ/liver/liver = getorganslot("liver")


### PR DESCRIPTION
~~shit fix sue me~~


:cl: TMTIME
tweak: Alien larva no longer spam runtimes
/:cl:

[why]: # [19:54:03] Runtime in life.dm, line 409: Cannot read null.species
[19:54:05] Runtime in life.dm, line 409: Cannot read null.species
[19:54:07] Runtime in life.dm, line 409: Cannot read null.species
[19:54:09] Runtime in life.dm, line 409: Cannot read null.species
[19:54:11] Runtime in life.dm, line 409: Cannot read null.species
[19:54:13] Runtime in life.dm, line 409: Cannot read null.species
[19:54:15] Runtime in life.dm, line 409: Cannot read null.species
[19:54:17] Runtime in life.dm, line 409: Cannot read null.species
[19:54:19] Runtime in life.dm, line 409: Cannot read null.species
[19:54:21] Runtime in life.dm, line 409: Cannot read null.species
[19:54:23] Runtime in life.dm, line 409: Cannot read null.species
[19:54:25] Runtime in life.dm, line 409: Cannot read null.species
[19:54:27] Runtime in life.dm, line 409: Cannot read null.species
[19:54:29] Runtime in life.dm, line 409: Cannot read null.species
[19:54:31] Runtime in life.dm, line 409: Cannot read null.species
