### PR TITLE
Updates to the latest 512 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 env:
     global:
     - BYOND_MAJOR="512"
-    - BYOND_MINOR="1441"
+    - BYOND_MINOR="1454"
     - NODE_VERSION="4"
     - BUILD_TOOLS=false
     - BUILD_TESTING=false


### PR DESCRIPTION
:cl: Crossedfall
tweak: Updated travis to use the latest 512 version to reduce compile times.
/:cl:

[why]: Even if we're only submitting major bug fixes and some new map stuff to this repo, updating Travis can help make the testing process go faster