### PR TITLE
Modern ore box

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -482,3 +482,9 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	valid_territory = FALSE
 	blob_allowed = FALSE
 	addSorted()
+
+/area/AllowDrop()
+	CRASH("Bad op: area/AllowDrop() called")
+
+/area/drop_location()
+	CRASH("Bad op: area/drop_location() called")

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -211,8 +211,8 @@
 		return TRUE
 	return container_type & DRAWABLE
 
-/atom/proc/allow_drop()
-	return 1
+/atom/proc/AllowDrop()
+	return FALSE
 
 /atom/proc/CheckExit()
 	return 1
@@ -614,3 +614,9 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 	.["Add reagent"] = "?_src_=vars;addreagent=\ref[src]"
 	.["Trigger EM pulse"] = "?_src_=vars;emp=\ref[src]"
 	.["Trigger explosion"] = "?_src_=vars;explode=\ref[src]"
+
+/atom/proc/drop_location()
+	var/atom/L = loc
+	if(!L)
+		return null
+	return L.AllowDrop() ? L : get_turf(L)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -473,9 +473,6 @@ Class Procs:
 /obj/machinery/proc/on_deconstruction()
 	return
 
-/obj/machinery/allow_drop()
-	return 0
-
 // Hook for html_interface module to prevent updates to clients who don't have this as their active machine.
 /obj/machinery/proc/hiIsValidClient(datum/html_interface_client/hclient, datum/html_interface/hi)
 	if (hclient.client.mob && (hclient.client.mob.stat == 0 || IsAdminGhost(hclient.client.mob)))

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -42,9 +42,6 @@
 	var/inject_amount = 10
 	salvageable = 0
 
-/obj/item/mecha_parts/mecha_equipment/medical/sleeper/allow_drop()
-	return 0
-
 /obj/item/mecha_parts/mecha_equipment/medical/sleeper/Destroy()
 	for(var/atom/movable/AM in src)
 		AM.forceMove(get_turf(src))

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1047,9 +1047,6 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 		return 1
 	return 0
 
-/obj/mecha/allow_drop()
-	return 0
-
 /obj/mecha/update_remote_sight(mob/living/user)
 	if(occupant_sight_flags)
 		if(user == occupant)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -412,6 +412,8 @@
 
 	handle_item_insertion(W, 0 , user)
 
+/obj/item/weapon/storage/AllowDrop()
+	return TRUE
 
 /obj/item/weapon/storage/attack_hand(mob/user)
 	if(user.s_active == src && loc == user) //if you're already looking inside the storage item

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -110,7 +110,12 @@
 	return 1
 
 /obj/structure/closet/proc/dump_contents()
-	var/turf/T = get_turf(src)
+	var/atom/L = loc
+	if(!L)
+		for(var/I in src)
+			qdel(I)
+		return
+	var/turf/T = L.drop_location()
 	for(var/atom/movable/AM in src)
 		AM.forceMove(T)
 		if(throwing) // you keep some momentum when getting out of a thrown closet
@@ -119,7 +124,10 @@
 		throwing.finalize(FALSE)
 
 /obj/structure/closet/proc/take_contents()
-	var/turf/T = get_turf(src)
+	var/atom/L = loc
+	if(!L)
+		return
+	var/turf/T = L.drop_location()
 	for(var/atom/movable/AM in T)
 		if(AM != src && insert(AM) == -1) // limit reached
 			break
@@ -448,3 +456,6 @@
 /obj/structure/closet/singularity_act()
 	dump_contents()
 	..()
+
+/obj/structure/closet/AllowDrop()
+	return TRUE

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -110,25 +110,17 @@
 	return 1
 
 /obj/structure/closet/proc/dump_contents()
-	var/atom/L = loc
-	if(!L)
-		for(var/I in src)
-			qdel(I)
-		return
-	var/turf/T = L.drop_location()
+	var/atom/L = drop_location()
 	for(var/atom/movable/AM in src)
-		AM.forceMove(T)
+		AM.forceMove(L)
 		if(throwing) // you keep some momentum when getting out of a thrown closet
 			step(AM, dir)
 	if(throwing)
 		throwing.finalize(FALSE)
 
 /obj/structure/closet/proc/take_contents()
-	var/atom/L = loc
-	if(!L)
-		return
-	var/turf/T = L.drop_location()
-	for(var/atom/movable/AM in T)
+	var/atom/L = drop_location()
+	for(var/atom/movable/AM in L)
 		if(AM != src && insert(AM) == -1) // limit reached
 			break
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -553,3 +553,6 @@
 		else
 			return I
 	return I
+
+/turf/AllowDrop()
+	return TRUE

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -48,6 +48,7 @@
 	user << browse(dat, "window=orebox")
 
 /obj/structure/ore_box/proc/dump_box_contents()
+	var/drop = drop_location()
 	for(var/obj/item/weapon/ore/O in src)
 		if(QDELETED(O))
 			continue

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -48,8 +48,15 @@
 	user << browse(dat, "window=orebox")
 
 /obj/structure/ore_box/proc/dump_box_contents()
-	for(var/obj/item/weapon/ore/O in contents)
-		O.forceMove(loc)
+	for(var/obj/item/weapon/ore/O in src)
+		if(QDELETED(O))
+			continue
+		if(QDELETED(src))
+			break
+		O.forceMove(drop)
+		if(TICK_CHECK)
+			stoplag()
+			drop = drop_location()
 
 /obj/structure/ore_box/Topic(href, href_list)
 	if(..())

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -234,15 +234,11 @@
 
 
 /mob/proc/drop_all_held_items()
-	if(!loc || !loc.allow_drop())
-		return
 	for(var/obj/item/I in held_items)
 		dropItemToGround(I)
 
 //Drops the item in our active hand.
 /mob/proc/drop_item()
-	if(!loc || !loc.allow_drop())
-		return
 	var/obj/item/held = get_active_held_item()
 	return dropItemToGround(held)
 
@@ -272,7 +268,7 @@
 //for when you want the item to end up on the ground
 //will force move the item to the ground and call the turf's Entered
 /mob/proc/dropItemToGround(obj/item/I, force = FALSE)
-	return doUnEquip(I, force, loc, FALSE)
+	return doUnEquip(I, force, drop_location(), FALSE)
 
 //for when the item will be immediately placed in a loc other than the ground
 /mob/proc/transferItemToLoc(obj/item/I, newloc = null, force = FALSE)

--- a/code/modules/modular_computers/hardware/printer.dm
+++ b/code/modules/modular_computers/hardware/printer.dm
@@ -24,7 +24,7 @@
 	if(!check_functionality())
 		return FALSE
 
-	var/obj/item/weapon/paper/P = new/obj/item/weapon/paper(get_turf(holder))
+	var/obj/item/weapon/paper/P = new/obj/item/weapon/paper(holder.drop_location())
 
 	// Damaged printer causes the resulting paper to be somewhat harder to read.
 	if(damage > damage_malfunction)

--- a/code/modules/recycling/disposal-structures.dm
+++ b/code/modules/recycling/disposal-structures.dm
@@ -121,8 +121,8 @@
 	T.assume_air(gas)
 	T.air_update_turf()
 
-/obj/structure/disposalholder/allow_drop()
-	return 1
+/obj/structure/disposalholder/AllowDrop()
+	return TRUE
 
 /obj/structure/disposalholder/ex_act(severity, target)
 	return


### PR DESCRIPTION
This simply migrates some modern TG code over to help reduce crashes and lag

:cl: crossedfall
add: drop_location()
add: tick check for ore boxes
/:cl:

[why]: # Prevents the huge lag spikes and possible crashes whenever miners dump an ore box full of ore.

Migrates: 
https://github.com/tgstation/tgstation/commit/728aefbd70e6370f23454e05fb9e2b50cb4370ae
https://github.com/tgstation/tgstation/commit/79ce9a6a690ae554ed7331cd96c82a29ec064728
https://github.com/tgstation/tgstation/commit/6f6bdcd7d39908790412fde316bcead4cd043258