### PR TITLE
[Bugfix] Removes the duplicate priority alert notice for the "Create Command Report" verb

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -490,8 +490,6 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(confirm == "Public")
 		priority_announce(crBody, crTitle, 'sound/ai/commandreport.ogg', "Admin", crSender)
 	else
-		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/ai/commandreport.ogg')
-
 		print_command_report(crBody,"[confirm=="Public" ? "" : "Classified "][crSender] Report")
 
 	log_admin("[key_name(src)] has created a command report: [crBody]")


### PR DESCRIPTION
:cl: Crossedfall
fix: Fixed the admin verb for private announcements to prevent duplicate player notifications from firing off
/:cl:

[why]: # Because it's really annoying to see two huge notifications for the same thing