### PR TITLE
Corrects the z_level choice for minimap generation

### DIFF
--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -9,7 +9,7 @@ SUBSYSTEM_DEF(minimap)
 	var/const/MINIMAP_SIZE = 2048
 	var/const/TILE_SIZE = 8
 
-	var/list/z_levels = list(1)
+	var/list/z_levels = list(3)
 
 /datum/controller/subsystem/minimap/Initialize(timeofday)
 	var/hash = md5(SSmapping.config.GetFullMapPath())


### PR DESCRIPTION
:cl: Crossedfall
fix: Updated the z_level choice for minimap generation from 1 to 3.
/:cl:

[why]: # It was trying to use the centcom z_level prior, when it should be using the ship level.

![image](https://user-images.githubusercontent.com/26130695/50047543-e89c1a80-007c-11e9-951e-e5d3f47c21f5.png)

