### PR TITLE
Curators should spawn in correctly at round start

### DIFF
--- a/_maps/map_files/Aetherwhisp/Aetherwhisp.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp.dmm
@@ -13538,6 +13538,17 @@
 	dir = 8
 	},
 /area/shuttle/ftl/hallway/primary/port)
+"dzR" = (
+/obj/structure/chair/office/light{
+	dir = 2
+	},
+/obj/effect/landmark/start{
+	name = "Curator"
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Library"
+	})
 "dAn" = (
 /obj/structure/table/reinforced,
 /obj/item/device/aicard,
@@ -87057,7 +87068,7 @@ aCk
 tsf
 aWu
 aXz
-hzr
+dzR
 aXz
 aXz
 gyO

--- a/_maps/map_files/Aetherwhisp/Aetherwhisp.dmm
+++ b/_maps/map_files/Aetherwhisp/Aetherwhisp.dmm
@@ -9467,17 +9467,6 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/plasteel/bar,
 /area/shuttle/ftl/crew_quarters/bar)
-"aYG" = (
-/obj/structure/chair/office/light{
-	dir = 2
-	},
-/obj/effect/landmark/start{
-	name = "Librarian"
-	},
-/turf/open/floor/wood,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Library"
-	})
 "aYK" = (
 /obj/machinery/door/poddoor{
 	id = "armory_blast";
@@ -19579,6 +19568,17 @@
 	dir = 4
 	},
 /area/shuttle/ftl/hallway/primary/starboard)
+"hzr" = (
+/obj/structure/chair/office/light{
+	dir = 2
+	},
+/obj/effect/landmark/start{
+	name = "Curator"
+	},
+/turf/open/floor/wood,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Library"
+	})
 "hzK" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/neutral/side{
@@ -87057,7 +87057,7 @@ aCk
 tsf
 aWu
 aXz
-aYG
+hzr
 aXz
 aXz
 gyO

--- a/_maps/map_files/Feliciana/Feliciana.dmm
+++ b/_maps/map_files/Feliciana/Feliciana.dmm
@@ -44793,6 +44793,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
+"xPF" = (
+/obj/structure/chair/comfy/brown,
+/obj/effect/landmark/start{
+	name = "Curator"
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Library"
+	})
 
 (1,1,1) = {"
 aaa
@@ -66300,7 +66309,7 @@ bAL
 bBu
 bBV
 bCo
-kKi
+xPF
 bDp
 bDv
 bDy

--- a/_maps/map_files/Feliciana/Feliciana.dmm
+++ b/_maps/map_files/Feliciana/Feliciana.dmm
@@ -44249,15 +44249,6 @@
 /area/shuttle/ftl/crew_quarters/theatre{
 	name = "Library"
 	})
-"bCO" = (
-/obj/structure/chair/comfy/brown,
-/obj/effect/landmark/start{
-	name = "Librarian"
-	},
-/turf/open/floor/carpet/black,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Library"
-	})
 "bCP" = (
 /obj/machinery/libraryscanner,
 /turf/open/floor/carpet/black,
@@ -44631,6 +44622,15 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/crew_quarters/sleep)
+"kKi" = (
+/obj/structure/chair/comfy/brown,
+/obj/effect/landmark/start{
+	name = "Curator"
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Library"
+	})
 "mna" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/station{
 	dir = 1
@@ -66300,7 +66300,7 @@ bAL
 bBu
 bBV
 bCo
-bCO
+kKi
 bDp
 bDv
 bDy

--- a/_maps/map_files/Ineese/Ineese.dmm
+++ b/_maps/map_files/Ineese/Ineese.dmm
@@ -5059,6 +5059,15 @@
 /obj/item/device/toner,
 /turf/open/floor/plating,
 /area/shuttle/ftl/janitor)
+"dQY" = (
+/obj/effect/landmark/start{
+	name = "Curator"
+	},
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/engineering)
 "dSn" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -21794,15 +21803,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/research/lab)
-"rwb" = (
-/obj/effect/landmark/start{
-	name = "Librarian"
-	},
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/ftl/maintenance/engineering)
 "rwn" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 2
@@ -57594,7 +57594,7 @@ tjH
 yan
 bDi
 nru
-rwb
+dQY
 aSB
 uuA
 wFI

--- a/_maps/map_files/Ineese/Ineese.dmm
+++ b/_maps/map_files/Ineese/Ineese.dmm
@@ -6867,6 +6867,15 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/cargo/shuttle)
+"fgW" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Curator"
+	},
+/turf/open/floor/plating,
+/area/shuttle/ftl/maintenance/engineering)
 "fhg" = (
 /obj/structure/chair/bridge{
 	dir = 4
@@ -57594,7 +57603,7 @@ tjH
 yan
 bDi
 nru
-dQY
+fgW
 aSB
 uuA
 wFI

--- a/_maps/map_files/Scarab/Scarab.dmm
+++ b/_maps/map_files/Scarab/Scarab.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaa" = (
 /turf/open/space,
 /area/space)
@@ -42239,6 +42239,10 @@
 	dir = 1
 	},
 /area/shuttle/ftl/medical/virology)
+"jGi" = (
+/obj/effect/ftl_shield,
+/turf/open/space,
+/area/shuttle/ftl/space)
 "jHp" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -42712,6 +42716,13 @@
 /area/shuttle/ftl/munitions{
 	name = "Port Weapons Mount"
 	})
+"mYl" = (
+/obj/effect/landmark{
+	name = "carpspawn"
+	},
+/obj/effect/ftl_shield,
+/turf/open/space,
+/area/shuttle/ftl/space)
 "nad" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -42803,20 +42814,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/ftl/cargo/mining)
-"nPt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/obj/effect/landmark/start{
-	name = "Librarian"
-	},
-/turf/open/floor/carpet,
-/area/shuttle/ftl/crew_quarters/theatre{
-	name = "Lounge"
-	})
 "nVw" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -43178,6 +43175,20 @@
 	dir = 5
 	},
 /area/shuttle/ftl/subshuttle/pod_main)
+"pvi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Curator"
+	},
+/turf/open/floor/carpet,
+/area/shuttle/ftl/crew_quarters/theatre{
+	name = "Lounge"
+	})
 "pzt" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen{
@@ -43373,6 +43384,10 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/hallway/primary/port)
+"rmI" = (
+/obj/effect/ftl_shield,
+/turf/open/space/basic,
+/area/space)
 "rqQ" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -43840,6 +43855,10 @@
 	dir = 8
 	},
 /area/shuttle/ftl/hallway/primary/port)
+"trQ" = (
+/obj/effect/ftl_shield,
+/turf/open/space/basic,
+/area/shuttle/ftl/space)
 "tAM" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless/warnplate,
@@ -44451,25 +44470,6 @@
 	dir = 5
 	},
 /area/shuttle/ftl/research/xenobiology)
-"FId" = (
-/obj/effect/ftl_shield,
-/turf/open/space/basic,
-/area/space)
-"Lqk" = (
-/obj/effect/ftl_shield,
-/turf/open/space/basic,
-/area/shuttle/ftl/space)
-"Uqk" = (
-/obj/effect/ftl_shield,
-/turf/open/space,
-/area/shuttle/ftl/space)
-"VtO" = (
-/obj/effect/landmark{
-	name = "carpspawn"
-	},
-/obj/effect/ftl_shield,
-/turf/open/space,
-/area/shuttle/ftl/space)
 
 (1,1,1) = {"
 aaa
@@ -59871,27 +59871,27 @@ aab
 aac
 aac
 aac
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Lqk
-Lqk
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+trQ
+trQ
 aad
 aad
 aad
@@ -59918,26 +59918,26 @@ aad
 aad
 aad
 aad
-Lqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
-Uqk
+trQ
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
+jGi
 aad
 aad
 aad
@@ -60121,8 +60121,8 @@ aab
 aab
 aac
 aac
-Uqk
-Uqk
+jGi
+jGi
 aac
 aac
 acl
@@ -60142,8 +60142,8 @@ aac
 aac
 aac
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -60168,8 +60168,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aac
 aac
 aac
@@ -60188,8 +60188,8 @@ aac
 aac
 aac
 aac
-Uqk
-Lqk
+jGi
+trQ
 aad
 aad
 aab
@@ -60371,8 +60371,8 @@ aab
 aab
 aab
 aac
-Uqk
-Uqk
+jGi
+jGi
 aac
 aac
 aac
@@ -60394,8 +60394,8 @@ aac
 aac
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -60418,8 +60418,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aae
 aac
 aac
@@ -60440,8 +60440,8 @@ aac
 aac
 aac
 aac
-Lqk
-Lqk
+trQ
+trQ
 aad
 aab
 aab
@@ -60621,8 +60621,8 @@ aab
 aab
 aab
 aab
-Uqk
-Uqk
+jGi
+jGi
 aac
 aac
 aac
@@ -60646,8 +60646,8 @@ aac
 aad
 aae
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -60668,8 +60668,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aac
@@ -60692,8 +60692,8 @@ aac
 aac
 aac
 aae
-Lqk
-Lqk
+trQ
+trQ
 aab
 aab
 aab
@@ -60872,7 +60872,7 @@ aab
 aab
 aab
 aab
-Uqk
+jGi
 aac
 aac
 aac
@@ -60898,8 +60898,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -60918,8 +60918,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -60944,7 +60944,7 @@ aac
 aac
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -61123,7 +61123,7 @@ aab
 aab
 aab
 aab
-Uqk
+jGi
 aac
 aac
 aac
@@ -61150,8 +61150,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -61168,8 +61168,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -61195,7 +61195,7 @@ ova
 aac
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -61374,7 +61374,7 @@ aab
 aab
 aab
 aab
-Uqk
+jGi
 aac
 aac
 aac
@@ -61402,8 +61402,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -61418,8 +61418,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -61446,7 +61446,7 @@ btc
 aac
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -61625,7 +61625,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aac
 aac
 aac
@@ -61654,22 +61654,22 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
 aad
 aad
 aad
@@ -61697,7 +61697,7 @@ btc
 aac
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -61876,7 +61876,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aac
 aac
 aac
@@ -61948,7 +61948,7 @@ btc
 aac
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -62127,7 +62127,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aac
 aac
 aac
@@ -62199,7 +62199,7 @@ btc
 aac
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -62378,7 +62378,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aac
 aac
 aac
@@ -62450,7 +62450,7 @@ btc
 aac
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -62629,7 +62629,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aac
 aac
 aac
@@ -62701,7 +62701,7 @@ buO
 aac
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -62880,7 +62880,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aac
 aac
 aac
@@ -62952,7 +62952,7 @@ buP
 aac
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -63131,7 +63131,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aac
 aac
 aak
@@ -63203,7 +63203,7 @@ buQ
 aac
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -63382,7 +63382,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aac
 aac
 aag
@@ -63454,7 +63454,7 @@ buR
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -63633,7 +63633,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aac
 aac
 aah
@@ -63705,7 +63705,7 @@ buS
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -63884,7 +63884,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aac
 aac
 aah
@@ -63956,7 +63956,7 @@ buT
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -64135,7 +64135,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aac
 aac
 aag
@@ -64207,7 +64207,7 @@ buT
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -64386,7 +64386,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aac
 aac
 aac
@@ -64458,7 +64458,7 @@ buT
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -64637,7 +64637,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aac
 aac
 aac
@@ -64709,7 +64709,7 @@ buU
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -64888,7 +64888,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aac
 aac
 aac
@@ -64960,7 +64960,7 @@ buU
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -65139,7 +65139,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aac
 aac
 aac
@@ -65211,7 +65211,7 @@ buU
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -65390,7 +65390,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aac
 aac
 aac
@@ -65462,7 +65462,7 @@ bnO
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -65641,7 +65641,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aac
 aac
 aac
@@ -65713,7 +65713,7 @@ aai
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -65892,7 +65892,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aac
 aac
 aac
@@ -65964,7 +65964,7 @@ buV
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -66143,7 +66143,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aac
 aac
 aac
@@ -66215,7 +66215,7 @@ aai
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -66394,7 +66394,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aac
 aac
 aac
@@ -66466,7 +66466,7 @@ aZo
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -66645,7 +66645,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aae
 aac
 aac
@@ -66717,7 +66717,7 @@ btf
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -66896,7 +66896,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aac
@@ -66968,7 +66968,7 @@ buW
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -67147,7 +67147,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aac
@@ -67219,7 +67219,7 @@ btf
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -67398,7 +67398,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aac
@@ -67470,7 +67470,7 @@ aac
 aad
 aae
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -67649,7 +67649,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aad
@@ -67721,7 +67721,7 @@ aac
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -67900,7 +67900,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aad
@@ -67972,7 +67972,7 @@ aad
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -68151,7 +68151,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aad
@@ -68223,7 +68223,7 @@ aad
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -68402,7 +68402,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aad
@@ -68474,7 +68474,7 @@ aad
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -68653,7 +68653,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aad
@@ -68725,7 +68725,7 @@ aad
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -68904,7 +68904,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aad
@@ -68976,7 +68976,7 @@ aad
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -69155,7 +69155,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aad
@@ -69227,7 +69227,7 @@ aad
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -69406,7 +69406,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aad
@@ -69478,7 +69478,7 @@ aac
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -69657,7 +69657,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aad
@@ -69729,7 +69729,7 @@ bnX
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -69908,7 +69908,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aad
@@ -69980,7 +69980,7 @@ bnX
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -70159,7 +70159,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aad
@@ -70231,7 +70231,7 @@ bnX
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -70410,7 +70410,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aad
@@ -70482,7 +70482,7 @@ bnX
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -70661,7 +70661,7 @@ aab
 aab
 aab
 aab
-FId
+rmI
 aab
 aab
 aab
@@ -70733,7 +70733,7 @@ bkc
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -70912,7 +70912,7 @@ aab
 aab
 aab
 aab
-FId
+rmI
 aab
 aab
 aab
@@ -70984,7 +70984,7 @@ blw
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -71163,7 +71163,7 @@ aab
 aab
 aab
 aab
-FId
+rmI
 aab
 aab
 aab
@@ -71235,7 +71235,7 @@ blw
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -71414,7 +71414,7 @@ aab
 aab
 aab
 aab
-FId
+rmI
 aab
 aab
 aab
@@ -71486,7 +71486,7 @@ blw
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -71665,7 +71665,7 @@ aab
 aab
 aab
 aab
-FId
+rmI
 aab
 aab
 aab
@@ -71737,7 +71737,7 @@ blw
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -71916,7 +71916,7 @@ aab
 aab
 aab
 aab
-FId
+rmI
 aab
 aab
 aab
@@ -71988,7 +71988,7 @@ bkc
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -72167,7 +72167,7 @@ aab
 aab
 aab
 aab
-FId
+rmI
 aab
 aab
 aab
@@ -72239,7 +72239,7 @@ bpx
 aad
 aae
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -72418,7 +72418,7 @@ aab
 aab
 aab
 aab
-FId
+rmI
 aab
 aab
 aab
@@ -72490,7 +72490,7 @@ bkc
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -72669,7 +72669,7 @@ aab
 aab
 aab
 aab
-FId
+rmI
 aab
 aab
 aab
@@ -72741,7 +72741,7 @@ aac
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -72920,7 +72920,7 @@ aab
 aab
 aab
 aab
-FId
+rmI
 aab
 aab
 aab
@@ -72992,7 +72992,7 @@ aac
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -73171,7 +73171,7 @@ aab
 aab
 aab
 aab
-FId
+rmI
 aab
 aab
 aab
@@ -73243,7 +73243,7 @@ aad
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -73422,7 +73422,7 @@ aab
 aab
 aab
 aab
-FId
+rmI
 aab
 aab
 aab
@@ -73494,7 +73494,7 @@ aad
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -73673,7 +73673,7 @@ aab
 aab
 aab
 aab
-FId
+rmI
 aab
 aab
 aab
@@ -73745,7 +73745,7 @@ aad
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -73924,7 +73924,7 @@ aab
 aab
 aab
 aab
-FId
+rmI
 aab
 aab
 aab
@@ -73996,7 +73996,7 @@ aad
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -74175,7 +74175,7 @@ aab
 aab
 aab
 aab
-FId
+rmI
 aab
 aab
 aab
@@ -74247,7 +74247,7 @@ aad
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -74426,7 +74426,7 @@ aab
 aab
 aab
 aaa
-Lqk
+trQ
 aad
 aad
 aad
@@ -74498,7 +74498,7 @@ aad
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -74677,7 +74677,7 @@ aab
 aab
 aab
 aaa
-Lqk
+trQ
 aad
 aad
 aad
@@ -74749,7 +74749,7 @@ aad
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -74928,7 +74928,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aac
@@ -75000,7 +75000,7 @@ oPU
 toR
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -75179,7 +75179,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aad
@@ -75251,7 +75251,7 @@ oPU
 oPU
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -75430,7 +75430,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aal
@@ -75502,7 +75502,7 @@ kzI
 kzI
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -75681,7 +75681,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 hre
@@ -75753,7 +75753,7 @@ xzB
 xzB
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -75932,7 +75932,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 hre
@@ -76004,7 +76004,7 @@ fGc
 xzB
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -76183,7 +76183,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 hre
@@ -76255,7 +76255,7 @@ rdF
 xzB
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -76434,7 +76434,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 hre
@@ -76506,7 +76506,7 @@ wan
 xzB
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -76685,7 +76685,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 hre
@@ -76757,7 +76757,7 @@ xzB
 xzB
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -76936,7 +76936,7 @@ aaa
 aaa
 aaa
 aab
-Lqk
+trQ
 aad
 aad
 aan
@@ -77008,7 +77008,7 @@ bva
 aZL
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -77187,7 +77187,7 @@ aaa
 aaa
 aaa
 aab
-Lqk
+trQ
 aad
 aad
 aao
@@ -77259,7 +77259,7 @@ bvb
 bhy
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -77438,7 +77438,7 @@ aaa
 aaa
 aaa
 aab
-Lqk
+trQ
 aad
 aad
 aao
@@ -77510,7 +77510,7 @@ bso
 bhy
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -77689,7 +77689,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aao
@@ -77761,7 +77761,7 @@ bso
 bhy
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -77940,7 +77940,7 @@ aaa
 aaa
 aaa
 aab
-Lqk
+trQ
 aad
 aad
 aan
@@ -78012,7 +78012,7 @@ bvc
 aZL
 aad
 aae
-Lqk
+trQ
 aab
 aab
 aab
@@ -78263,7 +78263,7 @@ bso
 aZL
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -78442,7 +78442,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aao
@@ -78514,7 +78514,7 @@ bso
 bhy
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -78693,7 +78693,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aao
@@ -78765,7 +78765,7 @@ bso
 bhy
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -78944,7 +78944,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aao
@@ -79016,7 +79016,7 @@ bvd
 aZL
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -79195,7 +79195,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aao
@@ -79267,7 +79267,7 @@ bso
 bhy
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -79446,7 +79446,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aao
@@ -79518,7 +79518,7 @@ bso
 bhy
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -79697,7 +79697,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aan
@@ -79769,7 +79769,7 @@ bve
 aZL
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -79948,7 +79948,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aan
@@ -80020,7 +80020,7 @@ bso
 aZL
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -80199,7 +80199,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aao
@@ -80271,7 +80271,7 @@ bvf
 bhy
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -80450,7 +80450,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aao
@@ -80522,7 +80522,7 @@ bso
 bhy
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -80701,7 +80701,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aao
@@ -80773,7 +80773,7 @@ bso
 bhy
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -80952,7 +80952,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 aan
@@ -81024,7 +81024,7 @@ bvg
 aZL
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -81203,7 +81203,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aaf
 aan
@@ -81275,7 +81275,7 @@ bhy
 aZL
 bvp
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -81454,7 +81454,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aag
 aao
@@ -81526,7 +81526,7 @@ bvh
 btJ
 aag
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -81705,7 +81705,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aah
 aao
@@ -81777,7 +81777,7 @@ bvi
 bvn
 aah
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -81956,7 +81956,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aag
 aao
@@ -82028,7 +82028,7 @@ buI
 bhy
 aag
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -82207,7 +82207,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aac
 aan
@@ -82279,7 +82279,7 @@ bhy
 aZL
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -82458,7 +82458,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aac
 aad
@@ -82530,7 +82530,7 @@ aad
 aad
 aac
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -82709,7 +82709,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 wND
@@ -82781,7 +82781,7 @@ aad
 aad
 aac
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -82960,7 +82960,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 wND
 tQT
@@ -83032,7 +83032,7 @@ nNV
 aac
 aac
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -83211,7 +83211,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 qcQ
 cca
@@ -83283,7 +83283,7 @@ qyO
 bgu
 aac
 aae
-Lqk
+trQ
 aab
 aab
 aab
@@ -83462,7 +83462,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 qcQ
 rEk
@@ -83534,7 +83534,7 @@ bhz
 bgv
 aac
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -83713,7 +83713,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 qcQ
 ptu
@@ -83785,7 +83785,7 @@ bvj
 bgv
 aac
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -83964,7 +83964,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 wND
 wND
@@ -84036,7 +84036,7 @@ bvk
 bgv
 aac
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -84215,7 +84215,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 qcQ
 ekG
@@ -84287,7 +84287,7 @@ bvl
 bgv
 aac
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -84466,7 +84466,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 qcQ
 maT
@@ -84538,7 +84538,7 @@ kYy
 bgv
 aac
 aac
-Lqk
+trQ
 aab
 aab
 aab
@@ -84717,7 +84717,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 qcQ
 uDi
@@ -84789,7 +84789,7 @@ bgu
 bgu
 aac
 aac
-Lqk
+trQ
 aab
 aab
 aab
@@ -84968,7 +84968,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 wND
 tQT
@@ -85040,7 +85040,7 @@ bgu
 aad
 aac
 aac
-Lqk
+trQ
 aab
 aab
 aab
@@ -85219,7 +85219,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aad
 wND
@@ -85291,7 +85291,7 @@ aad
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -85470,7 +85470,7 @@ aab
 aab
 aab
 aab
-Lqk
+trQ
 aad
 aac
 aay
@@ -85542,7 +85542,7 @@ aad
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -85721,7 +85721,7 @@ aaa
 aaa
 aaa
 aaa
-Lqk
+trQ
 aad
 aac
 aay
@@ -85793,7 +85793,7 @@ aad
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -85972,7 +85972,7 @@ aaa
 aaa
 aaa
 aaa
-Uqk
+jGi
 aac
 aac
 aaz
@@ -86044,7 +86044,7 @@ aad
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -86223,7 +86223,7 @@ aaa
 aaa
 aaa
 aaa
-Uqk
+jGi
 aac
 aac
 aaA
@@ -86295,7 +86295,7 @@ aad
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -86474,7 +86474,7 @@ aaa
 aaa
 aaa
 aaa
-Uqk
+jGi
 aac
 aac
 aaB
@@ -86546,7 +86546,7 @@ aad
 aad
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -86725,7 +86725,7 @@ aaa
 aaa
 aaa
 aaa
-Uqk
+jGi
 aac
 aac
 aay
@@ -86797,7 +86797,7 @@ qyO
 foA
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -86976,7 +86976,7 @@ aaa
 aaa
 aaa
 aaa
-Uqk
+jGi
 aac
 aac
 aay
@@ -87048,7 +87048,7 @@ qyO
 qyO
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -87227,7 +87227,7 @@ aaa
 aaa
 aaa
 aaa
-Uqk
+jGi
 aac
 aac
 aac
@@ -87299,7 +87299,7 @@ bgv
 bgv
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -87478,7 +87478,7 @@ aaa
 aaa
 aaa
 aaa
-Uqk
+jGi
 aac
 aac
 aac
@@ -87550,7 +87550,7 @@ bgv
 bgu
 aad
 aad
-Lqk
+trQ
 aab
 aab
 aab
@@ -87729,8 +87729,8 @@ aaa
 aaa
 aaa
 aaa
-Uqk
-Uqk
+jGi
+jGi
 aac
 aac
 aac
@@ -87751,7 +87751,7 @@ atu
 oYS
 nMw
 nVO
-nPt
+pvi
 umV
 ats
 aAs
@@ -87800,8 +87800,8 @@ bgu
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aab
 aab
 aab
@@ -87981,8 +87981,8 @@ aaa
 aaa
 aaa
 aac
-Uqk
-Lqk
+jGi
+trQ
 aac
 aac
 aac
@@ -88050,8 +88050,8 @@ bgv
 bgu
 aad
 aad
-Uqk
-Uqk
+jGi
+jGi
 aad
 aaa
 aaa
@@ -88233,8 +88233,8 @@ aaa
 aaa
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -88300,8 +88300,8 @@ bgv
 bgu
 aad
 aad
-Lqk
-Uqk
+trQ
+jGi
 aac
 aad
 aaa
@@ -88485,8 +88485,8 @@ aaa
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aac
@@ -88550,8 +88550,8 @@ brI
 bgv
 aad
 aad
-Uqk
-Uqk
+jGi
+jGi
 aac
 aac
 aad
@@ -88737,8 +88737,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aac
 aac
@@ -88800,8 +88800,8 @@ bnv
 bgv
 bgu
 aad
-Lqk
-Uqk
+trQ
+jGi
 aac
 aac
 aac
@@ -88990,7 +88990,7 @@ aad
 aad
 aad
 qfQ
-Lqk
+trQ
 aac
 aac
 aac
@@ -89051,8 +89051,8 @@ aad
 aac
 aac
 aac
-Uqk
-Uqk
+jGi
+jGi
 aac
 aac
 aac
@@ -89241,8 +89241,8 @@ aad
 aad
 aad
 aad
-Lqk
-Uqk
+trQ
+jGi
 aac
 aac
 aac
@@ -89301,8 +89301,8 @@ aad
 aad
 aac
 aac
-Uqk
-Uqk
+jGi
+jGi
 aac
 aac
 aac
@@ -89493,8 +89493,8 @@ aad
 aad
 aad
 aad
-Uqk
-Uqk
+jGi
+jGi
 aac
 aac
 aad
@@ -89550,9 +89550,9 @@ aad
 aad
 aad
 aad
-Uqk
-Uqk
-Uqk
+jGi
+jGi
+jGi
 aac
 aac
 aac
@@ -89745,8 +89745,8 @@ aad
 aad
 aad
 aac
-Uqk
-Uqk
+jGi
+jGi
 aac
 aac
 aac
@@ -89800,9 +89800,9 @@ aaN
 aad
 aad
 aad
-Lqk
-VtO
-Uqk
+trQ
+mYl
+jGi
 aac
 aac
 aac
@@ -89997,8 +89997,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aac
@@ -90050,8 +90050,8 @@ aad
 aaN
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aac
 aac
 aac
@@ -90249,8 +90249,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aac
@@ -90300,8 +90300,8 @@ aac
 aac
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -90501,8 +90501,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aac
 aac
@@ -90550,8 +90550,8 @@ aad
 aac
 aac
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -90753,8 +90753,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aac
 aac
 aac
@@ -90800,8 +90800,8 @@ aaN
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -91005,8 +91005,8 @@ aad
 aad
 aad
 aad
-Lqk
-Uqk
+trQ
+jGi
 aac
 aac
 aac
@@ -91050,8 +91050,8 @@ aac
 aac
 aac
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -91257,8 +91257,8 @@ aad
 aad
 aad
 aad
-Uqk
-Uqk
+jGi
+jGi
 aac
 aac
 aac
@@ -91300,8 +91300,8 @@ aad
 aac
 aac
 aac
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -91509,8 +91509,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aac
@@ -91550,8 +91550,8 @@ aac
 aac
 aac
 aac
-Uqk
-Lqk
+jGi
+trQ
 aad
 aad
 aad
@@ -91761,8 +91761,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aac
 aac
@@ -91800,8 +91800,8 @@ aac
 aac
 aac
 aac
-Uqk
-Uqk
+jGi
+jGi
 aad
 aad
 aad
@@ -92013,8 +92013,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aac
 aac
 aac
@@ -92050,8 +92050,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -92265,8 +92265,8 @@ aad
 aad
 aad
 aad
-Lqk
-Uqk
+trQ
+jGi
 aac
 aac
 aac
@@ -92300,8 +92300,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -92517,8 +92517,8 @@ aad
 aad
 aad
 aad
-Uqk
-Uqk
+jGi
+jGi
 aac
 aac
 aac
@@ -92550,8 +92550,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -92769,8 +92769,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -92800,8 +92800,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -93021,8 +93021,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -93050,8 +93050,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -93273,8 +93273,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -93300,8 +93300,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -93525,8 +93525,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -93550,8 +93550,8 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
+trQ
+trQ
 aad
 aad
 aad
@@ -93777,31 +93777,31 @@ aad
 aad
 aad
 aad
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Uqk
-Uqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
-Lqk
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+jGi
+jGi
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
+trQ
 aad
 aad
 aad

--- a/_maps/map_files/SpaceSHIP/SpaceSHIP.dmm
+++ b/_maps/map_files/SpaceSHIP/SpaceSHIP.dmm
@@ -14207,28 +14207,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/crew_quarters/heads)
-"nGW" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Librarian"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/ftl/hallway/primary/central)
 "nHm" = (
 /turf/open/floor/plasteel,
 /area/shuttle/ftl/atmos)
@@ -21814,6 +21792,28 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/shuttle/ftl/security/main)
+"uRD" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Curator"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
 "uRY" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
@@ -50173,7 +50173,7 @@ kII
 mDx
 diq
 rsq
-nGW
+uRD
 sBF
 diq
 rsq

--- a/_maps/map_files/SpaceSHIP/SpaceSHIP.dmm
+++ b/_maps/map_files/SpaceSHIP/SpaceSHIP.dmm
@@ -16532,6 +16532,28 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/ftl/storage/tech)
+"pHz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Curator"
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/ftl/hallway/primary/central)
 "pHK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -50173,7 +50195,7 @@ kII
 mDx
 diq
 rsq
-uRD
+pHz
 sBF
 diq
 rsq

--- a/_maps/map_files/Yacht/Yacht.dmm
+++ b/_maps/map_files/Yacht/Yacht.dmm
@@ -7742,6 +7742,22 @@
 /obj/machinery/telecomms/receiver/preset_left/birdstation,
 /turf/open/floor/engine/airless,
 /area/shuttle/ftl/engine/engine_smes)
+"tuS" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/effect/landmark/start{
+	name = "Curator"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 
 (1,1,1) = {"
 aaa
@@ -43756,7 +43772,7 @@ aga
 agY
 abw
 acX
-jIT
+tuS
 aiV
 aio
 akJ

--- a/_maps/map_files/Yacht/Yacht.dmm
+++ b/_maps/map_files/Yacht/Yacht.dmm
@@ -3959,22 +3959,6 @@
 	dir = 1
 	},
 /area/shuttle/ftl/engine/engineering)
-"ahC" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/effect/landmark/start{
-	name = "Librarian"
-	},
-/turf/open/floor/plasteel/black,
-/area/shuttle/ftl/hallway/primary/central)
 "ahD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -7738,6 +7722,22 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/shuttle/ftl/space)
+"jIT" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/effect/landmark/start{
+	name = "Curator"
+	},
+/turf/open/floor/plasteel/black,
+/area/shuttle/ftl/hallway/primary/central)
 "oRc" = (
 /obj/machinery/telecomms/receiver/preset_left/birdstation,
 /turf/open/floor/engine/airless,
@@ -43756,7 +43756,7 @@ aga
 agY
 abw
 acX
-ahC
+jIT
 aiV
 aio
 akJ


### PR DESCRIPTION
**Curators now spawns in correctly.**

tweak: Tweaked the name variable on the "Librarian" spawnpoint to "Curator" on the following maps; Aetherwhisp, Feliciana, Ineese, Scarab, SpaceShip, and Yacht.

fix: Curators should now spawn in correctly at round start.

[why]: It should resolve issue #3669 , the same changes has been commited to the Honkerprise test merge.

Additionaly: I were unable to save the butterfly without the map currupting itself constantly, and I gave up. @NIXC will sadly have to resolve the same issue on the Butterfly on their own. 